### PR TITLE
#50276 - Use FCC 3.2.5

### DIFF
--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCUConfiguration.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCUConfiguration.cs
@@ -17,7 +17,7 @@
         public bool DisplayCertificationIdAddition { get; set; } = true;
         public string CertificationIdAddition { get; set; } = "USK ausgesetzt";
         public string ServiceFolder { get; set; }
-        public string FccVersion { get; set; } = "3.2.4";
+        public string FccVersion { get; set; } = "3.2.5";
         public string ProxyServer { get; set; }
         public int? ProxyPort { get; set; }
         public string ProxyUsername { get; set; }

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.29",
+  "version": "1.3.30",
   "releaseBranches": [
     "^refs/heads/main$",
     "^refs/tags/scu-de/deutschefiskal/v\\d+(?:\\.\\d+)*(?:-.*)?$"

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.29",
+  "version": "1.3.30",
   "releaseBranches": [
     "^refs/heads/main$",
     "^refs/tags/scu-de/swissbitcloud/v\\d+(?:\\.\\d+)*(?:-.*)?$"


### PR DESCRIPTION
We should use the Fiskal Cloud Connector 3.2.5 in the Middleware, as it contains an updated Log4J version that again fixes some security issues.

- [x] Upload files to download storage