### PR TITLE
RFC: Add Strict Mode to the Middleware

### DIFF
--- a/rfcs/0205-strict-mode.md
+++ b/rfcs/0205-strict-mode.md
@@ -1,6 +1,6 @@
 - Feature Name: `strict_mode`
 - Start Date: 2023-08-29
-- RFC PR: [fiskaltrust/middleware#0000](https://github.com/fiskaltrust/middleware/pull/0000)
+- RFC PR: [fiskaltrust/middleware#205](https://github.com/fiskaltrust/middleware/pull/205)
 <!-- - Tracking Issue: [fiskaltrust/middleware#0000](https://github.com/fiskaltrust/middleware/issues/0000) -->
 
 # Summary

--- a/rfcs/0205-strict-mode.md
+++ b/rfcs/0205-strict-mode.md
@@ -74,7 +74,7 @@ The Strict Mode can be disabled for each warning individually by setting the par
 
 # Drawbacks
 
-> Why should we *not* do this?
+It brings extra complexity to the Middleware.
 
 # Rationale and alternatives
 
@@ -83,24 +83,12 @@ The Strict Mode can be disabled for each warning individually by setting the par
 > - What objections immediately spring to mind? How have you addressed them?
 > - What is the impact of not doing this?
 
-# \[Optional\] Prior art
-
-> Discuss prior art, both the good and the bad, in relation to this proposal.
-> A few examples of what this can include are:
-> 
-> - Does this feature exist in other markets and what experience have their community had?
-> - Does this feature exist in other PosSystems and what experience have their community had?
-> - Papers: Are there any published papers or great posts that discuss this?
->   If you have some relevant papers to refer to, this can serve as a more detailed theoretical background.
->
-> This section is intended to encourage you as an author to think about the lessons from other markets and projects, provide readers of your RFC with a fuller picture.
-> If there is no prior art, that is fine - your ideas are interesting to us whether they are brand new or not.
-> 
-> Note that while precedent set by other projects and markets is some motivation, it does not on its own motivate an RFC.
-
 # Unresolved questions
 
 * Do we need to provide the possibility to set warning levels for each warning individually?
+* How is this related to the Basic Receipt Check in the portal?
+  Should the Basic Receipt Check check also adhere to the `StrictMode` and `StrictModeOverrides`?
+  Can we do this with a common code base?
 
 > - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 > - What parts of the design do you expect to resolve through the implementation of this feature before before the feature PR is merged?

--- a/rfcs/strict-mode.md
+++ b/rfcs/strict-mode.md
@@ -1,25 +1,54 @@
-- Feature Name: (fill me in with a unique ident, `my_feature`)
-- Start Date: (fill me in with today's date, YYYY-MM-DD)
+- Feature Name: `strict_mode`
+- Start Date: 2023-08-29
 - RFC PR: [fiskaltrust/middleware#0000](https://github.com/fiskaltrust/middleware/pull/0000)
-- Tracking Issue: [fiskaltrust/middleware#0000](https://github.com/fiskaltrust/middleware/issues/0000)
+<!-- - Tracking Issue: [fiskaltrust/middleware#0000](https://github.com/fiskaltrust/middleware/issues/0000) -->
 
 # Summary
 
-> One paragraph explanation of the feature.
+There are some situations in the Middleware where warnings are logged, but the Middleware still continues to work.
+In Strict Mode these warnings should be treated as errors and the Middleware should throw an Exception.
 
 # Motivation
 
-> Why are we doing this? What use cases does it support? What is the expected outcome?
+The Middleware should generally sign be as lenient as possible in production so the PosOperator is not prevented from issuing receipts.
+This means we have to allow some incorrect receipts to be signed by the Middleware in production.
+
+On the other hand in sandbox we want to be as strict as possible so the PosCreator can see and fix all issues before going to production.
+
+For example the warning `"Aggregated sum of ChargeItem amounts ({chargeAmount}) does not match the sum of PayItem amount ({payAmount}). This is usually a hint for an implementation issue. Please see https://docs.fiskaltrust.cloud/docs/poscreators/middleware-doc for more details."` is logged when the sum of the ChargeItem amounts does not match the sum of the PayItem amounts.
+This is usually a sign for an implementation issue but in production we don't want to halt operation because of that.
+
+Some of those cases are also only warnings instead of exceptions because there are some edge cases where the warning is not an issue.
+To allow for those edge cases the PosCreators need to be able to decide if they want to treat those warnings as errors or not.
+
+If a PosCreators implementation does not work in Strict Mode they are responsible them selves for possible issues that arise from that.
 
 # Guide-level explanation
 
-> Explain the proposal as if it was already included in the middleware and you were teaching it to a PosCreator. That generally means:
-> 
-> - Introducing new named concepts.
-> - Explaining the feature, ideally through simple examples of solutions to concrete problems.
-> - Explaining how users should *think* about the feature, and how it should impact the way they use the middleware. It should explain the impact as concretely as possible.
-> - If applicable, provide sample error messages, deprecation warnings, or migration guidance.
-> - If applicable, explain how this feature compares to similar existing features, and in what situations the user would use each one.
+To solve this problem we introduce the Strict Mode.
+In Strict Mode warnings that are indicative of implementation issues will be treated as errors and the Middleware will throw an Exception.
+
+Per default Strict Mode is enabled in sandbox and disabled in production.
+
+The default setting can be overridden in the Queue configuration in the portal by setting the parameter `StrictMode` to `true` or `false`.
+
+## Example
+
+If Strict Mode is disabled and the sum of the ChargeItem amounts does not match the sum of the PayItem amounts the Middleware will sign the ReceiptRequest and log the warning
+`"Aggregated sum of ChargeItem amounts ({chargeAmount}) does not match the sum of PayItem amount ({payAmount}). This is usually a hint for an implementation issue. Please see https://docs.fiskaltrust.cloud/docs/poscreators/middleware-doc for more details."`.
+
+If Strict Mode is enabled and the sum of the ChargeItem amounts does not match the sum of the PayItem amounts the Middleware will throw an Exception and log the error
+`"Aggregated sum of ChargeItem amounts ({chargeAmount}) does not match the sum of PayItem amount ({payAmount}). This is usually a hint for an implementation issue. Please see https://docs.fiskaltrust.cloud/docs/poscreators/middleware-doc for more details."`.
+
+## Warning Level Configuration
+
+The Strict Mode can be disabled for each warning individually by setting the parameter `StrictModeOverrides` to a JSON dictionary containing `"<warning-id>": true` or `"<warning-id>": false` for each warning to override in the Queue configuration in the portal.
+
+### Example `StrictModeOverrides`
+
+```json
+{ "MissmatchingAmounts": false }
+```
 
 # Reference-level explanation
 
@@ -70,6 +99,8 @@
 > Note that while precedent set by other projects and markets is some motivation, it does not on its own motivate an RFC.
 
 # Unresolved questions
+
+* Do we need to provide the possibility to set warning levels for each warning individually?
 
 > - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 > - What parts of the design do you expect to resolve through the implementation of this feature before before the feature PR is merged?


### PR DESCRIPTION
There are some situations in the Middleware where warnings are logged, but the Middleware still continues to work.
In Strict Mode these warnings should be treated as errors and the Middleware should throw an Exception.

[Rendered](https://github.com/fiskaltrust/middleware/blob/rfc/strict-mode/rfcs/0205-strict-mode.md)

- [ ] Finish proposal
- [ ] Answer unresolved/open questions