### PR TITLE
Enhanced the transaction already open exception text

### DIFF
--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
@@ -620,7 +620,7 @@ namespace fiskaltrust.Middleware.SCU.DE.CryptoVision
                     (var result, var updateTransactionResult) = await _proxy.SeUpdateTransactionAsync(request.ClientId, (UInt32) request.TransactionNumber, Convert.FromBase64String(request.ProcessDataBase64 ?? string.Empty), request.ProcessType);
                     if (result == SeResult.ErrorNoTransaction)
                     {
-                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already.");
+                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already. To fix this issue add the 0x0000000020000000  to the daily-closing.");
                     }
                     result.ThrowIfError();
 

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
@@ -620,7 +620,7 @@ namespace fiskaltrust.Middleware.SCU.DE.CryptoVision
                     (var result, var updateTransactionResult) = await _proxy.SeUpdateTransactionAsync(request.ClientId, (UInt32) request.TransactionNumber, Convert.FromBase64String(request.ProcessDataBase64 ?? string.Empty), request.ProcessType);
                     if (result == SeResult.ErrorNoTransaction)
                     {
-                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already. To fix this issue add the 0x0000000020000000  to the daily-closing.");
+                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already. To fix this issue add the 0x0000000020000000 flag to the daily-closing.");
                     }
                     result.ThrowIfError();
 
@@ -666,7 +666,7 @@ namespace fiskaltrust.Middleware.SCU.DE.CryptoVision
                     (var result, var finishTransactionResult) = await _proxy.SeFinishTransactionAsync(request.ClientId, (UInt32) request.TransactionNumber, Convert.FromBase64String(request.ProcessDataBase64 ?? string.Empty), request.ProcessType);
                     if (result == SeResult.ErrorNoTransaction)
                     {
-                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
+                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000 flag to the daily-closing.");
                     }
                     result.ThrowIfError();
 

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.CryptoVision/CryptoVisionSCU.cs
@@ -666,7 +666,7 @@ namespace fiskaltrust.Middleware.SCU.DE.CryptoVision
                     (var result, var finishTransactionResult) = await _proxy.SeFinishTransactionAsync(request.ClientId, (UInt32) request.TransactionNumber, Convert.FromBase64String(request.ProcessDataBase64 ?? string.Empty), request.ProcessType);
                     if (result == SeResult.ErrorNoTransaction)
                     {
-                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already.");
+                        throw new CryptoVisionException($"The transaction with the number {request.TransactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
                     }
                     result.ThrowIfError();
 

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.Swissbit/Interop/SwissbitProxy.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.Swissbit/Interop/SwissbitProxy.cs
@@ -486,7 +486,7 @@ namespace fiskaltrust.Middleware.SCU.DE.Swissbit.Interop
                     var result = _nativeFunctionPointer.func_worm_transaction_update(context, clientIdPtr, transactionNumber, processDataPtr, (UInt64) processData.Length, processTypePtr, transactionResponsePtr);
                     if (result == WormError.WORM_ERROR_TRANSACTION_NOT_STARTED)
                     {
-                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.");
+                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
                     }
                     else if (result == WormError.WORM_ERROR_CLIENT_NOT_REGISTERED)
                     {
@@ -554,7 +554,7 @@ namespace fiskaltrust.Middleware.SCU.DE.Swissbit.Interop
                     var result = _nativeFunctionPointer.func_worm_transaction_finish(context, clientIdPtr, transactionNumber, processDataPtr, (UInt64) processData.Length, processTypePtr, transactionResponsePtr);
                     if (result == WormError.WORM_ERROR_TRANSACTION_NOT_STARTED)
                     {
-                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.");
+                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
                     }
                     else if (result == WormError.WORM_ERROR_CLIENT_NOT_REGISTERED)
                     {

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.Swissbit/Interop/SwissbitProxy.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.Swissbit/Interop/SwissbitProxy.cs
@@ -486,7 +486,7 @@ namespace fiskaltrust.Middleware.SCU.DE.Swissbit.Interop
                     var result = _nativeFunctionPointer.func_worm_transaction_update(context, clientIdPtr, transactionNumber, processDataPtr, (UInt64) processData.Length, processTypePtr, transactionResponsePtr);
                     if (result == WormError.WORM_ERROR_TRANSACTION_NOT_STARTED)
                     {
-                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
+                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000 flag to the daily-closing.");
                     }
                     else if (result == WormError.WORM_ERROR_CLIENT_NOT_REGISTERED)
                     {
@@ -554,7 +554,7 @@ namespace fiskaltrust.Middleware.SCU.DE.Swissbit.Interop
                     var result = _nativeFunctionPointer.func_worm_transaction_finish(context, clientIdPtr, transactionNumber, processDataPtr, (UInt64) processData.Length, processTypePtr, transactionResponsePtr);
                     if (result == WormError.WORM_ERROR_TRANSACTION_NOT_STARTED)
                     {
-                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000  to the daily-closing.");
+                        throw new SwissbitException($"The transaction with the number {transactionNumber} is either not started or has been finished already.To fix this issue add the 0x0000000020000000 flag to the daily-closing.");
                     }
                     else if (result == WormError.WORM_ERROR_CLIENT_NOT_REGISTERED)
                     {


### PR DESCRIPTION
In the daily business there are cases from time to time where the SCU throws the exception "Transaction already finished...". This exception is caused by the transaction being closed in the TSE but still being open in the middleware openTransaction table. This can easily fixed by adding the flag to the daily-closing. The middleware will then close the open transaction in its database.

I added the fix to the exception text, so that customers and the fiskaltrust support know how to fix the issue immediately. 
