### PR TITLE
Added support for FCC 4.1.1

### DIFF
--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCU.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCU.cs
@@ -73,7 +73,7 @@ namespace fiskaltrust.Middleware.SCU.DE.DeutscheFiskal
 
                 if (!_fccDownloadService.IsInstalled(_fccDirectory))
                 {
-                    if (_fccDownloadService.DownloadFccAsync(_fccDirectory).Result)
+                    if (_fccDownloadService.DownloadFccAsync(_fccDirectory, null).Result)
                     {
                         _fccInitializationService.Initialize(_fccDirectory);
                         _version = new Version(_configuration.FccVersion);
@@ -81,7 +81,8 @@ namespace fiskaltrust.Middleware.SCU.DE.DeutscheFiskal
                 }
                 else if (!_fccDownloadService.IsLatestVersion(_fccDirectory, new Version(_configuration.FccVersion)))
                 {
-                    if (_fccDownloadService.DownloadFccAsync(_fccDirectory).Result)
+                    var currentlyInstalledVersion = _fccDownloadService.UsedFCCVersion;
+                    if (_fccDownloadService.DownloadFccAsync(_fccDirectory, currentlyInstalledVersion).Result)
                     {
                         _fccInitializationService.Update(_fccDirectory);
                     }

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCUConfiguration.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/DeutscheFiskalSCUConfiguration.cs
@@ -18,7 +18,7 @@
         public bool DisplayCertificationIdAddition { get; set; } = true;
         public string CertificationIdAddition { get; set; } = "USK ausgesetzt";
         public string ServiceFolder { get; set; }
-        public string FccVersion { get; set; } = "4.0.8";
+        public string FccVersion { get; set; } = "4.1.1";
         public string ProxyServer { get; set; }
         public int? ProxyPort { get; set; }
         public string ProxyUsername { get; set; }

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/Services/Interfaces/IFccDownloadService.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/Services/Interfaces/IFccDownloadService.cs
@@ -6,7 +6,7 @@ namespace fiskaltrust.Middleware.SCU.DE.DeutscheFiskal.Services.Interfaces
     public interface IFccDownloadService
     {
         Version UsedFCCVersion { get; }
-        Task<bool> DownloadFccAsync(string fccDirectory);
+        Task<bool> DownloadFccAsync(string fccDirectory, Version currentlyInstalledVersion);
         bool IsInstalled(string fccDirectory);
         bool IsLatestVersion(string fccDirectory, Version latestVersion);
         bool IsLatestVersionDat(string fccDirectory, Version latestVersion);

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.55",
+  "version": "1.3.56",
   "releaseBranches": [
     "^refs/tags/scu-de/deutschefiskal/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitAndroid/Resources/Resource.designer.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitAndroid/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace fiskaltrust.Middleware.SCU.DE.SwissbitAndroid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.0.99.154")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.2.120")]
 	public partial class Resource
 	{
 		

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.55",
+  "version": "1.3.56",
   "releaseBranches": [
     "^refs/tags/scu-de/swissbitcloud/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloudAndroid/Resources/Resource.designer.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloudAndroid/Resources/Resource.designer.cs
@@ -14,7 +14,7 @@ namespace fiskaltrust.Middleware.SCU.DE.SwissbitCloudAndroid
 {
 	
 	
-	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.1.111")]
+	[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Xamarin.Android.Build.Tasks", "13.2.2.120")]
 	public partial class Resource
 	{
 		

--- a/scu-de/test/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal.IntegrationTest/FccDownloaderTests.cs
+++ b/scu-de/test/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal.IntegrationTest/FccDownloaderTests.cs
@@ -23,7 +23,7 @@ namespace fiskaltrust.Middleware.SCU.DE.DeutscheFiskal.IntegrationTest
             };
             DeleteNotExistingFolder(notExistingPath);
             var sut = new DeutscheFiskalFccDownloadService(config, Mock.Of<ILogger<DeutscheFiskalFccDownloadService>>());
-            await sut.DownloadFccAsync(config.FccDirectory);
+            await sut.DownloadFccAsync(config.FccDirectory, null);
         }
 
         [Fact]

--- a/scu-de/test/fiskaltrust.Middleware.SCU.DE.SwissbitCloud.IntegrationTest/FccDownloaderTests.cs
+++ b/scu-de/test/fiskaltrust.Middleware.SCU.DE.SwissbitCloud.IntegrationTest/FccDownloaderTests.cs
@@ -21,7 +21,7 @@ namespace fiskaltrust.Middleware.SCU.DE.SwissbitCloud.IntegrationTest
         public async Task DownloadAsync_Should_DownloadFileDependingOnPlatform()
         {
             var sut = new DeutscheFiskalFccDownloadService(_fixture.Configuration, Mock.Of<ILogger<IFccDownloadService>>());
-            await sut.DownloadFccAsync(_fixture.Configuration.FccDirectory);
+            await sut.DownloadFccAsync(_fixture.Configuration.FccDirectory, null);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for the new FCC version 4.1.1, which will be mandatory to use starting from July 31st, 2024.

**Please note that x86 (Windows and Linux) is not supported anymore in this version of the FCC, as it wasn't certified by the BSI.**