### PR TITLE
#145 - Inversing chargeitems is handled differently in DSFinV-K, DFKA and Middleware (DE)

### DIFF
--- a/queue/test/fiskaltrust.Middleware.Localization.QueueDE.UnitTest/Helpers/CalculationHelperTest.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueDE.UnitTest/Helpers/CalculationHelperTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using fiskaltrust.Middleware.Localization.QueueDE.Helpers;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.Localization.QueueDE.UnitTest.Helpers
+{
+    public class CalculationHelperTest
+    {
+        [Fact]
+        public void ReviseAmountOnNegativeQuantity_Differentsign_ValidResult()
+        {
+            CalculationHelper.ReviseAmountOnNegativeQuantity(1, 10).Should().Be(10);
+            CalculationHelper.ReviseAmountOnNegativeQuantity(1, -10).Should().Be(-10);
+            CalculationHelper.ReviseAmountOnNegativeQuantity(-1, 10).Should().Be(-10);
+            CalculationHelper.ReviseAmountOnNegativeQuantity(-1, -10).Should().Be(-10);
+
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
