### PR TITLE
Support FCC 4.1.1 x86

### DIFF
--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/Services/DeutscheFiskalFccDownloadService.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/Services/DeutscheFiskalFccDownloadService.cs
@@ -227,11 +227,6 @@ namespace fiskaltrust.Middleware.SCU.DE.DeutscheFiskal.Services
 
         protected virtual string GetDownloadUriByCurrentPlatform()
         {
-            if (RuntimeInformation.OSArchitecture == Architecture.X86)
-            {
-                throw new Exception("Starting from version 4.1.1, the FCC does not support x86 Operating Systems anymore. Only x64, arm32 and arm64 are supported.");
-            }
-
             var operatingSystem = RuntimeInformation.OSArchitecture switch
             {
                 Architecture.X64 => "x64",

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.DeutscheFiskal/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.57",
+  "version": "1.3.61",
   "releaseBranches": [
     "^refs/tags/scu-de/deutschefiskal/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.SwissbitCloud/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.57",
+  "version": "1.3.61",
   "releaseBranches": [
     "^refs/tags/scu-de/swissbitcloud/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]


### PR DESCRIPTION
Deutsche Fiskal has now added an 32-bit version of the FCC 4.1.1 - hence, we need to remove our check and support this version as well.