### PR TITLE
Replace non-allowed characters from rowkeys in Table Storage repositories

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/version.json
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.66-rc1",
+  "version": "1.3.67-rc1",
   "releaseBranches": [
     "^refs/tags/queue/azuretablestorage/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Helpers/ConversionHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Helpers/ConversionHelper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Helpers
+{
+    internal static class ConversionHelper
+    {
+        public static string ToBase64UrlString(byte[] bytes)
+        {
+            var base64 = Convert.ToBase64String(bytes);
+            return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
+        }
+
+        public static byte[] FromBase64UrlString(string base64urlString)
+        {
+            var base64 = base64urlString.Replace('_', '/').Replace('-', '+');
+            switch (base64.Length % 4)
+            {
+                case 2:
+                    base64 += "==";
+                    break;
+                case 3:
+                    base64 += "=";
+                    break;
+            }
+            return Convert.FromBase64String(base64);
+        }
+
+        public static string ReplaceNonAllowedKeyCharacters(string partitionOrRowKey)
+        {
+            const char replacementChar = '_';
+
+            if (string.IsNullOrEmpty(partitionOrRowKey))
+            {
+                return partitionOrRowKey;
+            }
+            return partitionOrRowKey
+                .Replace('/', replacementChar)
+                .Replace('\\', replacementChar)
+                .Replace('#', replacementChar)
+                .Replace('?', replacementChar);
+        }
+    }
+}
+

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageReceiptReferenceIndexRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageReceiptReferenceIndexRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Helpers;
 using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities;
 using fiskaltrust.storage.V0;
 
@@ -19,30 +20,6 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
     {
         public string cbReceiptReference { get; set; }
         public Guid ftQueueItemId { get; set; }
-    }
-
-    internal static class ConversionHelper
-    {
-        public static string ToBase64UrlString(byte[] bytes)
-        {
-            var base64 = Convert.ToBase64String(bytes);
-            return base64.TrimEnd('=').Replace('+', '-').Replace('/', '_');
-        }
-
-        public static byte[] FromBase64UrlString(string base64urlString)
-        {
-            var base64 = base64urlString.Replace('_', '/').Replace('-', '+');
-            switch (base64.Length % 4)
-            {
-                case 2:
-                    base64 += "==";
-                    break;
-                case 3:
-                    base64 += "=";
-                    break;
-            }
-            return Convert.FromBase64String(base64);
-        }
     }
 
     public class AzureTableStorageReceiptReferenceIndexRepository : BaseAzureTableStorageRepository<string, ReceiptReferenceIndexTable, ReceiptReferenceIndex>

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedFinishTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedFinishTransactionRepository.cs
@@ -3,9 +3,8 @@ using System.Threading.Tasks;
 using Azure.Data.Tables;
 using fiskaltrust.Middleware.Contracts.Data;
 using fiskaltrust.Middleware.Contracts.Models.Transactions;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Helpers;
 using fiskaltrust.Middleware.Storage.AzureTableStorage.Mapping;
-using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities;
-using fiskaltrust.storage.V0;
 
 namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 {
@@ -18,11 +17,11 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public async Task InsertOrUpdateTransactionAsync(FailedFinishTransaction transaction) => await InsertOrUpdateAsync(transaction).ConfigureAwait(false);
 
-        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(cbReceiptReference).ConfigureAwait(false) != null;
+        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(cbReceiptReference)).ConfigureAwait(false) != null;
 
         protected override void EntityUpdated(FailedFinishTransaction entity) { }
 
-        protected override string GetIdForEntity(FailedFinishTransaction entity) => entity.cbReceiptReference;
+        protected override string GetIdForEntity(FailedFinishTransaction entity) => ConversionHelper.ReplaceNonAllowedKeyCharacters(entity.cbReceiptReference);
 
         public async Task InsertOrUpdateAsync(FailedFinishTransaction storageEntity)
         {
@@ -38,7 +37,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
                 return null;
             }
 
-            var entity = new TableEntity(Mapper.GetHashString(src.FinishMoment.Ticks), src.cbReceiptReference)
+            var entity = new TableEntity(Mapper.GetHashString(src.FinishMoment.Ticks), GetIdForEntity(src))
             {
                 { nameof(FailedFinishTransaction.cbReceiptReference), src.cbReceiptReference },
                 { nameof(FailedFinishTransaction.CashBoxIdentification), src.CashBoxIdentification },

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedStartTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedStartTransactionRepository.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Azure.Data.Tables;
 using fiskaltrust.Middleware.Contracts.Data;
 using fiskaltrust.Middleware.Contracts.Models.Transactions;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Helpers;
 using fiskaltrust.Middleware.Storage.AzureTableStorage.Mapping;
-using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities;
-using fiskaltrust.storage.V0;
 
 namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 {
@@ -18,11 +16,11 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public async Task InsertOrUpdateTransactionAsync(FailedStartTransaction transaction) => await InsertOrUpdateAsync(transaction).ConfigureAwait(false);
 
-        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(cbReceiptReference).ConfigureAwait(false) != null;
+        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(cbReceiptReference)).ConfigureAwait(false) != null;
 
         protected override void EntityUpdated(FailedStartTransaction entity) { }
 
-        protected override string GetIdForEntity(FailedStartTransaction entity) => entity.cbReceiptReference;
+        protected override string GetIdForEntity(FailedStartTransaction entity) => ConversionHelper.ReplaceNonAllowedKeyCharacters(entity.cbReceiptReference);
 
         public async Task InsertOrUpdateAsync(FailedStartTransaction storageEntity)
         {
@@ -38,7 +36,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
                 return null;
             }
 
-            var entity = new TableEntity(Mapper.GetHashString(src.StartMoment.Ticks), src.cbReceiptReference)
+            var entity = new TableEntity(Mapper.GetHashString(src.StartMoment.Ticks), GetIdForEntity(src))
             {
                 { nameof(FailedStartTransaction.cbReceiptReference), src.cbReceiptReference },
                 { nameof(FailedStartTransaction.CashBoxIdentification), src.CashBoxIdentification },

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageOpenTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageOpenTransactionRepository.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Azure.Data.Tables;
 using fiskaltrust.Middleware.Contracts.Data;
 using fiskaltrust.Middleware.Contracts.Models.Transactions;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Helpers;
 using fiskaltrust.Middleware.Storage.AzureTableStorage.Mapping;
 using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities;
 using fiskaltrust.storage.V0;
@@ -18,11 +19,11 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public async Task InsertOrUpdateTransactionAsync(OpenTransaction transaction) => await InsertOrUpdateAsync(transaction).ConfigureAwait(false);
 
-        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(cbReceiptReference).ConfigureAwait(false) != null;
+        public async Task<bool> ExistsAsync(string cbReceiptReference) => await GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(cbReceiptReference)).ConfigureAwait(false) != null;
 
         protected override void EntityUpdated(OpenTransaction entity) { }
 
-        protected override string GetIdForEntity(OpenTransaction entity) => entity.cbReceiptReference;
+        protected override string GetIdForEntity(OpenTransaction entity) => ConversionHelper.ReplaceNonAllowedKeyCharacters(entity.cbReceiptReference);
 
         public async Task InsertOrUpdateAsync(OpenTransaction storageEntity)
         {
@@ -41,7 +42,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
             return new AzureTableStorageOpenTransaction
             {
                 PartitionKey = Mapper.GetHashString(src.StartMoment.Ticks),
-                RowKey = src.cbReceiptReference,
+                RowKey = GetIdForEntity(src),
                 cbReceiptReference = src.cbReceiptReference,
                 StartMoment = src.StartMoment.ToUniversalTime(),
                 StartTransactionSignatureBase64 = src.StartTransactionSignatureBase64,


### PR DESCRIPTION
# Issue description
This issue was noticed by a customer that uses `#` in their cbReceiptReferences, which results in unsigned receipts (as the MW failes to insert the open transaction during the sign processing).

# Fix
This PR removes special characters from `cbReceiptReferences` before they're used as rowkeys for the tables to store open and failed transactions. Azure Table Storage [disallows 4 printable characters](https://learn.microsoft.com/en-us/rest/api/storageservices/Understanding-the-Table-Service-Data-Model#characters-disallowed-in-key-fields) (`/`, `\`, `#`, `?`), and those are now replaced with `_`.

I unfortunately could not use the same approach that's used in the `AzureTableStorageReceiptReferenceIndexRepository`, as this converts the whole value to base64 and would therefore break existing users. The current approach will only affect cases that were currently not working anyway.