### PR TITLE
FIx lookup of failed receipt resends

### DIFF
--- a/queue/fiskaltrust.Middleware.sln
+++ b/queue/fiskaltrust.Middleware.sln
@@ -123,8 +123,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Stor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Storage.AzureTableStorage.AcceptanceTest", "test\fiskaltrust.Middleware.Storage.AzureTableStorage.AcceptanceTest\fiskaltrust.Middleware.Storage.AzureTableStorage.AcceptanceTest.csproj", "{F39B38CB-B8B7-4537-9130-43131AD51FF2}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Localization.QueueES", "src\fiskaltrust.Middleware.Localization.QueueES\fiskaltrust.Middleware.Localization.QueueES.csproj", "{27C42C72-639D-4B55-A931-6896D7095685}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Localization.QueueIT", "src\fiskaltrust.Middleware.Localization.QueueIT\fiskaltrust.Middleware.Localization.QueueIT.csproj", "{65633C3A-65AA-4E05-8E56-7A348872CCC3}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Localization.QueueIT.UnitTest", "test\fiskaltrust.Middleware.Localization.QueueIT.UnitTest\fiskaltrust.Middleware.Localization.QueueIT.UnitTest.csproj", "{5FAB9D88-4B90-4DF0-B1B7-1F50DF7CFCA4}"
@@ -139,13 +137,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.Stor
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Interface.Tagging", "src\fiskaltrust.Interface.Tagging\fiskaltrust.Interface.Tagging.csproj", "{FD564EEA-CEAD-47E0-BB0A-113C07F57CAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Interface.Tagging.UnitTests", "test\fiskaltrust.Interface.Tagging.UnitTests\fiskaltrust.Interface.Tagging.UnitTests.csproj", "{9E42B570-AEEC-498E-AC81-0AB70264229B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Interface.Tagging.UnitTests", "test\fiskaltrust.Interface.Tagging.UnitTests\fiskaltrust.Interface.Tagging.UnitTests.csproj", "{9E42B570-AEEC-498E-AC81-0AB70264229B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Interface.Tagging.Generator", "src\fiskaltrust.Interface.Tagging.Generator\fiskaltrust.Interface.Tagging.Generator.csproj", "{930A9188-4273-45C5-9506-922CE7B1E712}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Interface.Tagging.Generator", "src\fiskaltrust.Interface.Tagging.Generator\fiskaltrust.Interface.Tagging.Generator.csproj", "{930A9188-4273-45C5-9506-922CE7B1E712}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Interface.Tagging.Generator.UnitTests", "test\fiskaltrust.Interface.Tagging.Generator.UnitTests\fiskaltrust.Interface.Tagging.Generator.UnitTests.csproj", "{855013AC-6255-4A3C-80C7-5140F5BD20B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Interface.Tagging.Generator.UnitTests", "test\fiskaltrust.Interface.Tagging.Generator.UnitTests\fiskaltrust.Interface.Tagging.Generator.UnitTests.csproj", "{855013AC-6255-4A3C-80C7-5140F5BD20B9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Interface.Tagging.Generator.IntegrationTests", "test\fiskaltrust.Interface.Tagging.Generator.IntegrationTests\fiskaltrust.Interface.Tagging.Generator.IntegrationTests.csproj", "{34229319-E3C0-4B57-A2D9-F1812CBF5311}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Interface.Tagging.Generator.IntegrationTests", "test\fiskaltrust.Interface.Tagging.Generator.IntegrationTests\fiskaltrust.Interface.Tagging.Generator.IntegrationTests.csproj", "{34229319-E3C0-4B57-A2D9-F1812CBF5311}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -325,10 +323,6 @@ Global
 		{F39B38CB-B8B7-4537-9130-43131AD51FF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F39B38CB-B8B7-4537-9130-43131AD51FF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F39B38CB-B8B7-4537-9130-43131AD51FF2}.Release|Any CPU.Build.0 = Release|Any CPU
-		{27C42C72-639D-4B55-A931-6896D7095685}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{27C42C72-639D-4B55-A931-6896D7095685}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{27C42C72-639D-4B55-A931-6896D7095685}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{27C42C72-639D-4B55-A931-6896D7095685}.Release|Any CPU.Build.0 = Release|Any CPU
 		{65633C3A-65AA-4E05-8E56-7A348872CCC3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{65633C3A-65AA-4E05-8E56-7A348872CCC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65633C3A-65AA-4E05-8E56-7A348872CCC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -349,6 +343,10 @@ Global
 		{7F52D143-9179-4FCF-9DC7-B5F1681BD22A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F52D143-9179-4FCF-9DC7-B5F1681BD22A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7F52D143-9179-4FCF-9DC7-B5F1681BD22A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FD564EEA-CEAD-47E0-BB0A-113C07F57CAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD564EEA-CEAD-47E0-BB0A-113C07F57CAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD564EEA-CEAD-47E0-BB0A-113C07F57CAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -369,10 +367,6 @@ Global
 		{34229319-E3C0-4B57-A2D9-F1812CBF5311}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34229319-E3C0-4B57-A2D9-F1812CBF5311}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34229319-E3C0-4B57-A2D9-F1812CBF5311}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EEDA285C-82F8-4E6D-AAFA-9E42D3C4F0E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -428,7 +422,6 @@ Global
 		{BD6E6701-2F8E-43D1-B583-F3DC1CA52D67} = {16BF88B4-3302-49F5-A5FA-5DA96DD03F0E}
 		{87E0049F-9DF1-4F6F-8137-7765A2B16ABA} = {5195B05E-EB55-4544-8FE6-B683747B1F9E}
 		{F39B38CB-B8B7-4537-9130-43131AD51FF2} = {31488E86-D7EB-4964-84F1-B7338BB5A7D1}
-		{27C42C72-639D-4B55-A931-6896D7095685} = {C345F1F7-C2A5-472A-A55F-987A53DF3CCE}
 		{65633C3A-65AA-4E05-8E56-7A348872CCC3} = {C345F1F7-C2A5-472A-A55F-987A53DF3CCE}
 		{5FAB9D88-4B90-4DF0-B1B7-1F50DF7CFCA4} = {16BF88B4-3302-49F5-A5FA-5DA96DD03F0E}
 		{3C0310D9-EC55-4115-A2D5-0DC8C1246645} = {C345F1F7-C2A5-472A-A55F-987A53DF3CCE}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueIT/v2/MiddlewareStorageHelpers.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueIT/v2/MiddlewareStorageHelpers.cs
@@ -30,12 +30,19 @@ namespace fiskaltrust.Middleware.Localization.QueueIT.v2
 
 
             await foreach (var existingQueueItem in queueItems)
-            {
+            {  
                 var referencedResponse = JsonConvert.DeserializeObject<ReceiptResponse>(existingQueueItem.response);
+                if ((referencedResponse.ftState & 0xEEEE_EEEE) == 0xEEEE_EEEE)
+                {
+                    continue;
+                }
                 if (referencedResponse.GetSignaturItem(SignatureTypesIT.RTDocumentNumber) == null || referencedResponse.GetSignaturItem(SignatureTypesIT.RTZNumber) == null || referencedResponse.GetSignaturItem(SignatureTypesIT.RTDocumentMoment) == null)
                 {
                     break;
                 }
+
+
+
                 var documentNumber = referencedResponse.GetSignaturItem(SignatureTypesIT.RTDocumentNumber).Data;
                 var zNumber = referencedResponse.GetSignaturItem(SignatureTypesIT.RTZNumber).Data;
                 var documentMoment = referencedResponse.GetSignaturItem(SignatureTypesIT.RTDocumentMoment)?.Data;


### PR DESCRIPTION
This change fixes a problem that occurred when a receipt failed to be sent, was resent and then a Nachdruck was made. In this case we weren't able to reload the data

Fixes #396 
