### PR TITLE
Add SSCD fail ftState when Queue is in failed mode

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/SignProcessorAT.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/SignProcessorAT.cs
@@ -49,6 +49,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT
             AddStateFlagIfNewMonthOrYearStarted(request, response, queueAT);
             var requestCommandResponse = await PerformReceiptRequest(request, queueItem, queue, queueAT, response).ConfigureAwait(false);
 
+            additionalActionJournals.AddRange(ProcessSSCDFailedReceipt(queueItem, response, null, queue, queueAT));
+
             if (requestCommandResponse.JournalAT != null)
             {
                 await _journalATRepository.InsertAsync(requestCommandResponse.JournalAT);


### PR DESCRIPTION
We should call `ProcessSSCDFailedReceipt` after performing the actual signing to also correctly set the ftState for the first receipt where the SSCD isn't reachable.