### PR TITLE
Fixed removing transactions from storage when special characters are used

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/BaseAzureTableStorageRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/BaseAzureTableStorageRepository.cs
@@ -36,7 +36,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
             var entity = MapToAzureEntity(storageEntity);
             await _tableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
         }
-        public async Task<TStorageEntity> RemoveAsync(TKey key)
+        public virtual async Task<TStorageEntity> RemoveAsync(TKey key)
         {
             var entity = await RetrieveAsync(key).ConfigureAwait(false);
             if (entity != null)
@@ -55,7 +55,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
 
         protected abstract TAzureEntity MapToAzureEntity(TStorageEntity entity);
 
-        private async Task<TAzureEntity> RetrieveAsync(TKey id)
+        protected async Task<TAzureEntity> RetrieveAsync(TKey id)
         {
             var result = _tableClient.QueryAsync<TAzureEntity>(x => x.RowKey == id.ToString());
             return await result.FirstOrDefaultAsync();

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedFinishTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedFinishTransactionRepository.cs
@@ -25,6 +25,17 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public override Task<FailedFinishTransaction> GetAsync(string id) => base.GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(id));
 
+        public override async Task<FailedFinishTransaction> RemoveAsync(string key)
+        {
+            var entity = await RetrieveAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(key)).ConfigureAwait(false);
+            if (entity != null)
+            {
+                await _tableClient.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
+            }
+
+            return MapToStorageEntity(entity);
+        }
+
         public async Task InsertOrUpdateAsync(FailedFinishTransaction storageEntity)
         {
             EntityUpdated(storageEntity);

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedStartTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageFailedStartTransactionRepository.cs
@@ -24,6 +24,17 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public override Task<FailedStartTransaction> GetAsync(string id) => base.GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(id));
 
+        public override async Task<FailedStartTransaction> RemoveAsync(string key)
+        {
+            var entity = await RetrieveAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(key)).ConfigureAwait(false);
+            if (entity != null)
+            {
+                await _tableClient.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
+            }
+
+            return MapToStorageEntity(entity);
+        }
+
         public async Task InsertOrUpdateAsync(FailedStartTransaction storageEntity)
         {
             EntityUpdated(storageEntity);

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageOpenTransactionRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/DE/AzureTableStorageOpenTransactionRepository.cs
@@ -27,6 +27,17 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.DE
 
         public override Task<OpenTransaction> GetAsync(string id) => base.GetAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(id));
 
+        public override async Task<OpenTransaction> RemoveAsync(string key)
+        {
+            var entity = await RetrieveAsync(ConversionHelper.ReplaceNonAllowedKeyCharacters(key)).ConfigureAwait(false);
+            if (entity != null)
+            {
+                await _tableClient.DeleteEntityAsync(entity.PartitionKey, entity.RowKey);
+            }
+
+            return MapToStorageEntity(entity);
+        }
+
         public async Task InsertOrUpdateAsync(OpenTransaction storageEntity)
         {
             EntityUpdated(storageEntity);


### PR DESCRIPTION
This follow-up PR fixes an issue we overlooked when supporting special characters in the `cbReceiptReference`  of the CloudCashbox. Removing transactions from the database failed, which leads to errors when the flag is used that should perform this operation.