### PR TITLE
Fixer error handling in Austria

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/InitialOperationReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/InitialOperationReceiptCommand.cs
@@ -45,7 +45,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                 _logger.LogInformation(alreadyActiveActionJournal.Message);
                 var actionJournal = new List<ftActionJournal> { alreadyActiveActionJournal };
 
-                var (receiptIdentification, ftStateData, isBackupScuUsed, signatureItems, journalAt) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+                var (receiptIdentification, ftStateData, isBackupScuUsed, signatureItems, journalAt, _) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
                 response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
                 response.ftReceiptIdentification = receiptIdentification;
                 response.ftStateData = ftStateData;
@@ -125,7 +125,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             actionJournals.Add(aj);
 
 
-            var (receiptIdentification, ftStateData, isBackupScuUsed, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+            var (receiptIdentification, ftStateData, isBackupScuUsed, signatureItems, journalAT, isSigned) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
             response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;
@@ -134,7 +134,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                 response.ftState |= 0x80;
             }
 
-            if (journalAT != null)
+            if (isSigned)
             {
                 // Receipt successfully signed, activate Queue
                 queue.StartMoment = DateTime.UtcNow;

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/MonthlyClosingReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/MonthlyClosingReceiptCommand.cs
@@ -62,7 +62,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
         {
             var actionJournals = new List<ftActionJournal>();
 
-            var (receiptIdentification, ftStateData, _, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+            var (receiptIdentification, ftStateData, _, signatureItems, journalAT, _) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
             response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/OutOfOperationReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/OutOfOperationReceiptCommand.cs
@@ -56,12 +56,12 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
         {
             var actionJournals = new List<ftActionJournal>();
 
-            var (receiptIdentification, ftStateData, _, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+            var (receiptIdentification, ftStateData, _, signatureItems, journalAT, isSigned) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
             response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;
 
-            if (journalAT != null)
+            if (journalAT != null && isSigned)
             {
                 // Receipt successfully signed, deactivate Queue
                 queue.StopMoment = DateTime.UtcNow;

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/PosReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/PosReceiptCommand.cs
@@ -19,7 +19,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
         public override async Task<RequestCommandResponse> ExecuteAsync(ftQueue queue, ftQueueAT queueAT, ReceiptRequest request, ftQueueItem queueItem, ReceiptResponse response)
         {
-            var (receiptIdentification, ftStateData, _, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId);
+            var (receiptIdentification, ftStateData, _, signatureItems, journalAT, _) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId);
             response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/YearlyClosingReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/YearlyClosingReceiptCommand.cs
@@ -57,12 +57,12 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
         {
             var actionJournals = new List<ftActionJournal>();
 
-            var (receiptIdentification, ftStateData, _, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+            var (receiptIdentification, ftStateData, _, signatureItems, journalAT, isSigned) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
             response.ftSignatures = response.ftSignatures.Concat(signatureItems).ToArray();
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;
 
-            if (journalAT != null)
+            if (isSigned)
             {
                 // Receipt successfully signed, process yearly receipt
                 response.ftSignatures = response.ftSignatures.Extend(new SignaturItem

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/ZeroReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/ZeroReceiptCommand.cs
@@ -38,7 +38,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                 CreateActionJournal(queue, queueItem, $"QueueItem {queueItem.ftQueueItemId} requests zero receipt of Queue {queueAT.ftQueueATId}")
             };
 
-            var (receiptIdentification, ftStateData, _, signatureItems, journalAT) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
+            var (receiptIdentification, ftStateData, _, signatureItems, journalAT, isSigned) = await SignReceiptAsync(queueAT, request, response.ftReceiptIdentification, response.ftReceiptMoment, queueItem.ftQueueItemId, isZeroReceipt: true);
             response.ftReceiptIdentification = receiptIdentification;
             response.ftStateData = ftStateData;
 
@@ -62,7 +62,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             }
 
             // Recover from failed mode
-            if (journalAT != null && queueAT.UsedFailedCount > 0)
+            if (isSigned && queueAT.UsedFailedCount > 0)
             {
                 var fromReceipt = await GetReceiptIdentificationFromQueueItem(queueAT.UsedFailedQueueItemId.Value);
                 var toReceipt = response.ftReceiptIdentification;
@@ -88,7 +88,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             }
 
             // Recover from SSCD failed mode
-            if (journalAT != null && queueAT.SSCDFailCount > 0)
+            if (isSigned && queueAT.SSCDFailCount > 0)
             {
                 var fromReceipt = await GetReceiptIdentificationFromQueueItem(queueAT.SSCDFailQueueItemId.Value);
                 var toReceipt = response.ftReceiptIdentification;


### PR DESCRIPTION
This PR fixes the error handling in Austria by not only taking the `journalAT` into account, but also explicitely checking if the receipt was signed. This reproduces the same behavior as used in 1.2.