### PR TITLE
Use v0 of IATSSCD for now

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/QueueATBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/QueueATBootstrapper.cs
@@ -13,7 +13,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddSingleton(sp => QueueATConfiguration.FromMiddlewareConfiguration(sp.GetRequiredService<MiddlewareConfiguration>()));
-            
+
             services.AddScoped<IATSSCDProvider, ATSSCDProvider>();
             services.AddScoped<IRequestCommandFactory, RequestCommandFactory>();
             services.AddScoped<IExportService, ExportService>();
@@ -29,7 +29,6 @@ namespace fiskaltrust.Middleware.Localization.QueueAT
             services.AddScoped<PosReceiptCommand>();
             services.AddScoped<YearlyClosingReceiptCommand>();
             services.AddScoped<ZeroReceiptCommand>();
-
         }
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/DisabledQueueReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/DisabledQueueReceiptCommand.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 
 namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 {
-    internal class DisabledQueueReceiptCommand : RequestCommand
+    public class DisabledQueueReceiptCommand : RequestCommand
     {
         public override string ReceiptName => "Disabled-queue receipt";
 

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
@@ -32,7 +32,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
         protected readonly QueueATConfiguration _queueATConfiguration;
         protected readonly ILogger<RequestCommand> _logger;
 
-        public RequestCommand(IATSSCDProvider sscdProvider, MiddlewareConfiguration middlewareConfiguration, QueueATConfiguration queueATConfiguration, ILogger<RequestCommand> logger )
+        public RequestCommand(IATSSCDProvider sscdProvider, MiddlewareConfiguration middlewareConfiguration, QueueATConfiguration queueATConfiguration, ILogger<RequestCommand> logger)
         {
             _sscdProvider = sscdProvider;
             _middlewareConfiguration = middlewareConfiguration;
@@ -98,7 +98,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             // Not needed anymore, as the database is now only updated when a request finishes
             // Previously, this mechanism was used to ensure that notifications were always included, even when the signing process failed during execution.
             // Kept here temporary for future reference.
-            
+
             //queueAT.MessageCount++;
             //if (!queueAT.MessageMoment.HasValue)
             //{
@@ -161,7 +161,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         13.0m => 0x2,
                         20.0m => 0x3,
                         0.0m => 0x5,
-                        _ => (long) 0x4,
+                        _ => (long)0x4,
                     };
                 }
             }
@@ -275,12 +275,12 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox && queueAT.SignAll)
                 {
-                    signatures.Add(new SignaturItem() { Caption = "Sign-All-Mode", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = "Sign-All-Mode", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                 }
 
                 if (_middlewareConfiguration.IsSandbox && isZeroReceipt)
                 {
-                    signatures.Add(new SignaturItem() { Caption = "Zero-Receipt", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = "Zero-Receipt", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                 }
             }
             else
@@ -333,7 +333,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox)
                 {
-                    signatures.Add(new SignaturItem() { Caption = $"Decision {decisionNumerical}", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = $"Decision {decisionNumerical}", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                 }
 
                 decision.Number = decisionNumerical;
@@ -381,7 +381,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                             if (_middlewareConfiguration.IsSandbox)
                             {
-                                signatures.Add(new SignaturItem() { Caption = $"Exception A1", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                                signatures.Add(new SignaturItem() { Caption = $"Exception A1", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                             }
                         }
                     }
@@ -401,7 +401,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A2", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A2", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -420,7 +420,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A3", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A3", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -439,7 +439,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A4", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A4", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -479,7 +479,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox)
                 {
-                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
                 }
             }
 
@@ -509,7 +509,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (isZeroReceipt || queueAT.SSCDFailCount == 0)
                 {
-                    if(!(await _sscdProvider.GetAllInstances()).Any())
+                    if (!(await _sscdProvider.GetAllInstances()).Any())
                     {
                         throw new Exception("No SCU is connected to this Queue.");
                     }
@@ -536,12 +536,12 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                                 continue;
                             }
 
-                            isBackupScuUsed = scu.IsBackup();                                
+                            isBackupScuUsed = scu.IsBackup();
 
                             try
                             {
-                                var zda = (await sscd.ZdaAsync()).ZDA;
-                                var certResponse = await sscd.CertificateAsync();
+                                var zda = sscd.Zda().ZDA;
+                                var certResponse = sscd.Certificate();
                                 var cert = new X509CertificateParser().ReadCertificate(certResponse.Certificate);
                                 var certificateSerialNumber = cert.SerialNumber.ToString(16);
 
@@ -569,7 +569,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                                 var jwsDataToSign = Encoding.UTF8.GetBytes($"{journalAT.JWSHeaderBase64url}.{journalAT.JWSPayloadBase64url}");
 
 
-                                var jwsSignature = await sscd.SignAsync(new SignRequest() {Data = jwsDataToSign });
+                                var jwsSignature = sscd.Sign(jwsDataToSign);
 
                                 journalAT.JWSSignatureBase64url = ConversionHelper.ToBase64UrlString(jwsSignature.SignedData);
                                 journalAT.ftSignaturCreationUnitId = scu.ftSignaturCreationUnitATId;
@@ -580,7 +580,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                                 queueAT.LastSignatureZDA = zda;
                                 queueAT.LastSignatureCertificateSerialNumber = certificateSerialNumber;
 
-                                signatures.Add(new SignaturItem() { Caption = "www.fiskaltrust.at", Data = $"{jwsPayload}_{Convert.ToBase64String(jwsSignature.SignedData)}", ftSignatureFormat = (long) SignaturItem.Formats.QR_Code, ftSignatureType = (long) SignaturItem.Types.AT_RKSV });
+                                signatures.Add(new SignaturItem() { Caption = "www.fiskaltrust.at", Data = $"{jwsPayload}_{Convert.ToBase64String(jwsSignature.SignedData)}", ftSignatureFormat = (long)SignaturItem.Formats.QR_Code, ftSignatureType = (long)SignaturItem.Types.AT_RKSV });
 
                                 return (receiptIdentification, ftStateData, isBackupScuUsed, signatures, journalAT, isSigned: true);
                             }
@@ -634,7 +634,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                 queueAT.ftCashTotalizer += Math.Round(totalizer, 2);
                 queueAT.LastSignatureHash = CreateLastReceiptSignature($"{journalAT.JWSHeaderBase64url}.{journalAT.JWSPayloadBase64url}.{journalAT.JWSSignatureBase64url}");
 
-                signatures.Add(new SignaturItem() { Caption = $"Sicherheitseinrichtung ausgefallen", Data = $"{failedReceiptJwsPayload}_{Convert.ToBase64String(ConversionHelper.FromBase64UrlString(SSCD_JWS_SIGNATURE_FAILED))}", ftSignatureFormat = (long) SignaturItem.Formats.QR_Code, ftSignatureType = (long) SignaturItem.Types.AT_RKSV });
+                signatures.Add(new SignaturItem() { Caption = $"Sicherheitseinrichtung ausgefallen", Data = $"{failedReceiptJwsPayload}_{Convert.ToBase64String(ConversionHelper.FromBase64UrlString(SSCD_JWS_SIGNATURE_FAILED))}", ftSignatureFormat = (long)SignaturItem.Formats.QR_Code, ftSignatureType = (long)SignaturItem.Types.AT_RKSV });
 
                 return (receiptIdentification, ftStateData, isBackupScuUsed, signatures, journalAT, isSigned: false);
             }
@@ -644,7 +644,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             }
         }
 
-        
+
         // TODO: Refactor and put directly into the places where we are generating the action journals.
         // This was taken from the previous service code for simplicity reasons for now.
         protected IEnumerable<SignaturItem> CreateNotificationSignatures(List<ftActionJournal> actionJournals)
@@ -671,8 +671,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonDeactivateQueue))
@@ -692,8 +692,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonActivateSCU))
@@ -713,8 +713,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonDeactivateSCU))
@@ -734,8 +734,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonVerifySignature))
@@ -753,8 +753,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else
@@ -763,8 +763,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = item.DataJson,
-                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long) SignaturItem.Types.AT_Unknown
+                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long)SignaturItem.Types.AT_Unknown
                         };
                     }
                 }
@@ -774,8 +774,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                     {
                         Caption = item.Message,
                         Data = item.DataJson,
-                        ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
-                        ftSignatureType = (long) SignaturItem.Types.AT_Unknown
+                        ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
+                        ftSignatureType = (long)SignaturItem.Types.AT_Unknown
                     };
                 }
             }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
@@ -161,7 +161,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         13.0m => 0x2,
                         20.0m => 0x3,
                         0.0m => 0x5,
-                        _ => (long)0x4,
+                        _ => (long) 0x4,
                     };
                 }
             }
@@ -275,12 +275,12 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox && queueAT.SignAll)
                 {
-                    signatures.Add(new SignaturItem() { Caption = "Sign-All-Mode", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = "Sign-All-Mode", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                 }
 
                 if (_middlewareConfiguration.IsSandbox && isZeroReceipt)
                 {
-                    signatures.Add(new SignaturItem() { Caption = "Zero-Receipt", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = "Zero-Receipt", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                 }
             }
             else
@@ -333,7 +333,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox)
                 {
-                    signatures.Add(new SignaturItem() { Caption = $"Decision {decisionNumerical}", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = $"Decision {decisionNumerical}", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                 }
 
                 decision.Number = decisionNumerical;
@@ -381,7 +381,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                             if (_middlewareConfiguration.IsSandbox)
                             {
-                                signatures.Add(new SignaturItem() { Caption = $"Exception A1", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                                signatures.Add(new SignaturItem() { Caption = $"Exception A1", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                             }
                         }
                     }
@@ -401,7 +401,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A2", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A2", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -420,7 +420,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A3", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A3", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -439,7 +439,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                     if (_middlewareConfiguration.IsSandbox)
                     {
-                        signatures.Add(new SignaturItem() { Caption = $"Exception A4", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                        signatures.Add(new SignaturItem() { Caption = $"Exception A4", Data = $"Sign: {requiresSigning} Counter:{requiresCounting}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                     }
                 }
 
@@ -479,7 +479,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox)
                 {
-                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer}", ftSignatureFormat = (long)SignaturItem.Formats.Text, ftSignatureType = (long)SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                 }
             }
 
@@ -540,9 +540,11 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                             try
                             {
-                                var zda = sscd.Zda().ZDA;
+#pragma warning disable CS0618
+                                var zda = sscd.ZDA();
                                 var certResponse = sscd.Certificate();
-                                var cert = new X509CertificateParser().ReadCertificate(certResponse.Certificate);
+#pragma warning restore
+                                var cert = new X509CertificateParser().ReadCertificate(certResponse);
                                 var certificateSerialNumber = cert.SerialNumber.ToString(16);
 
                                 var sb2 = new StringBuilder();
@@ -568,10 +570,10 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                                 journalAT.JWSPayloadBase64url = ConversionHelper.ToBase64UrlString(Encoding.UTF8.GetBytes(jwsPayload));
                                 var jwsDataToSign = Encoding.UTF8.GetBytes($"{journalAT.JWSHeaderBase64url}.{journalAT.JWSPayloadBase64url}");
 
-
+#pragma warning disable CS0618
                                 var jwsSignature = sscd.Sign(jwsDataToSign);
-
-                                journalAT.JWSSignatureBase64url = ConversionHelper.ToBase64UrlString(jwsSignature.SignedData);
+#pragma warning restore
+                                journalAT.JWSSignatureBase64url = ConversionHelper.ToBase64UrlString(jwsSignature);
                                 journalAT.ftSignaturCreationUnitId = scu.ftSignaturCreationUnitATId;
 
                                 queueAT.ftCashNumerator = cashNumerator;
@@ -580,7 +582,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                                 queueAT.LastSignatureZDA = zda;
                                 queueAT.LastSignatureCertificateSerialNumber = certificateSerialNumber;
 
-                                signatures.Add(new SignaturItem() { Caption = "www.fiskaltrust.at", Data = $"{jwsPayload}_{Convert.ToBase64String(jwsSignature.SignedData)}", ftSignatureFormat = (long)SignaturItem.Formats.QR_Code, ftSignatureType = (long)SignaturItem.Types.AT_RKSV });
+                                signatures.Add(new SignaturItem() { Caption = "www.fiskaltrust.at", Data = $"{jwsPayload}_{Convert.ToBase64String(jwsSignature)}", ftSignatureFormat = (long) SignaturItem.Formats.QR_Code, ftSignatureType = (long) SignaturItem.Types.AT_RKSV });
 
                                 return (receiptIdentification, ftStateData, isBackupScuUsed, signatures, journalAT, isSigned: true);
                             }
@@ -634,7 +636,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                 queueAT.ftCashTotalizer += Math.Round(totalizer, 2);
                 queueAT.LastSignatureHash = CreateLastReceiptSignature($"{journalAT.JWSHeaderBase64url}.{journalAT.JWSPayloadBase64url}.{journalAT.JWSSignatureBase64url}");
 
-                signatures.Add(new SignaturItem() { Caption = $"Sicherheitseinrichtung ausgefallen", Data = $"{failedReceiptJwsPayload}_{Convert.ToBase64String(ConversionHelper.FromBase64UrlString(SSCD_JWS_SIGNATURE_FAILED))}", ftSignatureFormat = (long)SignaturItem.Formats.QR_Code, ftSignatureType = (long)SignaturItem.Types.AT_RKSV });
+                signatures.Add(new SignaturItem() { Caption = $"Sicherheitseinrichtung ausgefallen", Data = $"{failedReceiptJwsPayload}_{Convert.ToBase64String(ConversionHelper.FromBase64UrlString(SSCD_JWS_SIGNATURE_FAILED))}", ftSignatureFormat = (long) SignaturItem.Formats.QR_Code, ftSignatureType = (long) SignaturItem.Types.AT_RKSV });
 
                 return (receiptIdentification, ftStateData, isBackupScuUsed, signatures, journalAT, isSigned: false);
             }
@@ -671,8 +673,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonDeactivateQueue))
@@ -692,8 +694,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonActivateSCU))
@@ -713,8 +715,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonDeactivateSCU))
@@ -734,8 +736,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else if (type == nameof(FonVerifySignature))
@@ -753,8 +755,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = JsonConvert.SerializeObject(new { ActionJournalId = item.ftActionJournalId, Type = item.Type, Data = qrData }),
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_FinanzOnline
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_FinanzOnline
                         };
                     }
                     else
@@ -763,8 +765,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                         {
                             Caption = item.Message,
                             Data = item.DataJson,
-                            ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                            ftSignatureType = (long)SignaturItem.Types.AT_Unknown
+                            ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                            ftSignatureType = (long) SignaturItem.Types.AT_Unknown
                         };
                     }
                 }
@@ -774,8 +776,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
                     {
                         Caption = item.Message,
                         Data = item.DataJson,
-                        ftSignatureFormat = (long)SignaturItem.Formats.AZTEC,
-                        ftSignatureType = (long)SignaturItem.Types.AT_Unknown
+                        ftSignatureFormat = (long) SignaturItem.Formats.AZTEC,
+                        ftSignatureType = (long) SignaturItem.Types.AT_Unknown
                     };
                 }
             }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/RequestCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -479,7 +480,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 
                 if (_middlewareConfiguration.IsSandbox)
                 {
-                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
+                    signatures.Add(new SignaturItem() { Caption = $"Counter Add", Data = $"{totalizer.ToString(CultureInfo.InvariantCulture)}", ftSignatureFormat = (long) SignaturItem.Formats.Text, ftSignatureType = (long) SignaturItem.Types.AT_Unknown });
                 }
             }
 

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/ZeroReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/RequestCommands/ZeroReceiptCommand.cs
@@ -14,7 +14,7 @@ using Newtonsoft.Json;
 
 namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
 {
-    internal class ZeroReceiptCommand : RequestCommand
+    public class ZeroReceiptCommand : RequestCommand
     {
         private readonly IReadOnlyQueueItemRepository _queueItemRepository;
 
@@ -120,7 +120,7 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.RequestCommands
             }
             var notificationSignatures = CreateNotificationSignatures(actionJournals);
             response.ftSignatures = response.ftSignatures.Extend(signatureItems).Extend(notificationSignatures);
-            
+
             return new RequestCommandResponse
             {
                 ReceiptResponse = response,

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/Services/ATSSCDProvider.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/Services/ATSSCDProvider.cs
@@ -128,12 +128,16 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.Services
         {
             try
             {
+#pragma warning disable CS0618
                 var certResponse = client.Certificate();
-                var certificate = new X509CertificateParser().ReadCertificate(certResponse.Certificate);
+#pragma warning restore
+                var certificate = new X509CertificateParser().ReadCertificate(certResponse);
                 var certificateSerial = certificate?.SerialNumber?.ToString(16);
 
-                var zdaResponse = client.Zda();
-                scu.ZDA = zdaResponse.ZDA;
+#pragma warning disable CS0618
+                var zdaResponse = client.ZDA();
+#pragma warning restore
+                scu.ZDA = zdaResponse;
                 scu.SN = certificateSerial != null ? $"0x{certificateSerial}" : null;
                 scu.CertificateBase64 = Convert.ToBase64String(certificate.GetEncoded());
 

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueAT/Services/ATSSCDProvider.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueAT/Services/ATSSCDProvider.cs
@@ -128,11 +128,11 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.Services
         {
             try
             {
-                var certResponse = await client.CertificateAsync();
+                var certResponse = client.Certificate();
                 var certificate = new X509CertificateParser().ReadCertificate(certResponse.Certificate);
                 var certificateSerial = certificate?.SerialNumber?.ToString(16);
 
-                var zdaResponse = await client.ZdaAsync();
+                var zdaResponse = client.Zda();
                 scu.ZDA = zdaResponse.ZDA;
                 scu.SN = certificateSerial != null ? $"0x{certificateSerial}" : null;
                 scu.CertificateBase64 = Convert.ToBase64String(certificate.GetEncoded());

--- a/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
+++ b/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" />
-    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.69-ci-25087-81499" />
+    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="70" />
     <PackageReference Include="fiskaltrust.service.Ihelper" Version="1.0.16322.1184" />
     <PackageReference Include="fiskaltrust.storage.encryption" Version="1.3.1" />
     <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />

--- a/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
+++ b/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" />
-    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="70" />
+    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.70" />
     <PackageReference Include="fiskaltrust.service.Ihelper" Version="1.0.16322.1184" />
     <PackageReference Include="fiskaltrust.storage.encryption" Version="1.3.1" />
     <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />

--- a/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
+++ b/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/fiskaltrust.Middleware.Queue.Test.Launcher.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" />
-    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.55-rc2" />
+    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.69-ci-25087-81499" />
     <PackageReference Include="fiskaltrust.service.Ihelper" Version="1.0.16322.1184" />
     <PackageReference Include="fiskaltrust.storage.encryption" Version="1.3.1" />
     <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueAT.UnitTest/SignProcessorATFixture.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueAT.UnitTest/SignProcessorATFixture.cs
@@ -29,8 +29,8 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.UnitTest
     public class SignProcessorATFixture
     {
         private const string CERT_PASSWORD = "password";
-        public Guid cashBoxId { get;} = Guid.Parse("6caa852c-4230-4496-83c0-1597eee7084e");
-        public Guid queueId { get;} = Guid.Parse("ef9764af-1102-41e8-b901-eb89d45cde1c");
+        public Guid cashBoxId { get; } = Guid.Parse("6caa852c-4230-4496-83c0-1597eee7084e");
+        public Guid queueId { get; } = Guid.Parse("ef9764af-1102-41e8-b901-eb89d45cde1c");
         public ftQueue queue { get; private set; }
         public ftQueueAT queueAT { get; private set; }
         public ftQueueAT queueATNotSignAll { get; private set; }
@@ -85,8 +85,9 @@ namespace fiskaltrust.Middleware.Localization.QueueAT.UnitTest
         {
             var sscd = new Mock<IATSSCD>();
             sscd.Setup(x => x.ZdaAsync()).ReturnsAsync(new ZdaResponse() { ZDA = zda });
-            sscd.Setup(x => x.SignAsync(It.IsAny<SignRequest>())).ReturnsAsync(new SignResponse() { SignedData = new byte[] { 0x01, 0x02, 0x03 } });
-            sscd.Setup(x => x.CertificateAsync()).ReturnsAsync(new CertificateResponse { Certificate = _certificate });
+            sscd.Setup(x => x.ZDA()).Returns(zda);
+            sscd.Setup(x => x.Sign(It.IsAny<byte[]>())).Returns(new byte[] { 0x01, 0x02, 0x03 });
+            sscd.Setup(x => x.Certificate()).Returns(_certificate);
             var sscdProvider = new Mock<IATSSCDProvider>();
             sscdProvider.Setup(x => x.GetCurrentlyActiveInstanceAsync()).ReturnsAsync((_signaturCreationUnitAT, sscd.Object, 0));
             var scus = new List<ftSignaturCreationUnitAT>

--- a/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
+++ b/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.1" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" Condition="$(TargetFramework) == 'net461'" />
-        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="70" Condition="$(TargetFramework) == 'net461'" />
+        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.70" Condition="$(TargetFramework) == 'net461'" />
         <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />
         <PackageReference Include="Grpc.Core" Version="2.29.0" />
         <PackageReference Include="Grpc.Core.Api" Version="2.49.0" />

--- a/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
+++ b/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.1" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" Condition="$(TargetFramework) == 'net461'" />
-        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.55-rc2" Condition="$(TargetFramework) == 'net461'" />
+        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.69-ci-25087-81499" Condition="$(TargetFramework) == 'net461'" />
         <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />
         <PackageReference Include="Grpc.Core" Version="2.29.0" />
         <PackageReference Include="Grpc.Core.Api" Version="2.49.0" />

--- a/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
+++ b/scu-at/test/Manual/fiskaltrust.Middleware.SCU.AT.Test.Launcher/fiskaltrust.Middleware.SCU.AT.Test.Launcher.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.1" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.55-rc2" />
         <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.55-rc2" Condition="$(TargetFramework) == 'net461'" />
-        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.69-ci-25087-81499" Condition="$(TargetFramework) == 'net461'" />
+        <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="70" Condition="$(TargetFramework) == 'net461'" />
         <PackageReference Include="fiskaltrust.storage.serialization" Version="1.3.1" />
         <PackageReference Include="Grpc.Core" Version="2.29.0" />
         <PackageReference Include="Grpc.Core.Api" Version="2.49.0" />


### PR DESCRIPTION
The onlinescu `signing[-sandbox].fiskaltrust.at` is still running on 1.2 for now so we need to use the v0 methods of the IATSSCD.

The 1.3 SCUs also support this endpoints so this does not cause problems.

- [x] Update soap client
- [x] Test