### PR TITLE
Fix journal version

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
@@ -19,9 +19,4 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public Dictionary<string, object> Configuration { get; set; }
         public Dictionary<string, bool> PreviewFeatures { get; set; }
     }
-    public class AssemblyInfo
-    {
-        public String Name { get; set; }
-        public Version Version { get; set; }
-    }
 }

--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace fiskaltrust.Middleware.Contracts.Models
 {
@@ -14,6 +15,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public bool IsSandbox { get; set; }
         public string ServiceFolder { get; set; }
         public Action<string> OnMessage { get; set; }
+        public AssemblyName AssemblyName { get; set; }
         public Dictionary<string, object> Configuration { get; set; }
         public Dictionary<string, bool> PreviewFeatures { get; set; }
     }

--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
@@ -15,7 +15,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public bool IsSandbox { get; set; }
         public string ServiceFolder { get; set; }
         public Action<string> OnMessage { get; set; }
-        public AssemblyInfo AssemblyInfo { get; set; }
+        public Type AssemblyType { get; set; }
         public Dictionary<string, object> Configuration { get; set; }
         public Dictionary<string, bool> PreviewFeatures { get; set; }
     }

--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
@@ -15,8 +15,13 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public bool IsSandbox { get; set; }
         public string ServiceFolder { get; set; }
         public Action<string> OnMessage { get; set; }
-        public AssemblyName AssemblyName { get; set; }
+        public AssemblyInfo AssemblyInfo { get; set; }
         public Dictionary<string, object> Configuration { get; set; }
         public Dictionary<string, bool> PreviewFeatures { get; set; }
+    }
+    public class AssemblyInfo
+    {
+        public String Name { get; set; }
+        public Version Version { get; set; }
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/MiddlewareConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace fiskaltrust.Middleware.Contracts.Models
 {

--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
@@ -25,11 +25,7 @@ namespace fiskaltrust.Middleware.Queue.AzureTableStorage
             var storageBootStrapper = new AzureTableStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
+using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.AzureTableStorage;
 using Microsoft.Extensions.DependencyInjection;
@@ -25,9 +26,10 @@ namespace fiskaltrust.Middleware.Queue.AzureTableStorage
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.AzureTableStorage;
@@ -22,6 +23,11 @@ namespace fiskaltrust.Middleware.Queue.AzureTableStorage
             
             var storageBootStrapper = new AzureTableStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
@@ -26,7 +26,7 @@ namespace fiskaltrust.Middleware.Queue.AzureTableStorage
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.AzureTableStorage/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.AzureTableStorage;
 using Microsoft.Extensions.DependencyInjection;

--- a/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
@@ -27,11 +27,7 @@ namespace fiskaltrust.Middleware.Queue.EF
             var storageBootStrapper = new EfStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.Ef;
 using fiskaltrust.Middleware.Storage.EF;

--- a/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
@@ -28,9 +28,10 @@ namespace fiskaltrust.Middleware.Queue.EF
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
@@ -29,7 +29,7 @@ namespace fiskaltrust.Middleware.Queue.EF
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.EF/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
@@ -25,6 +26,11 @@ namespace fiskaltrust.Middleware.Queue.EF
 
             var storageBootStrapper = new EfStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -23,9 +23,9 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            //var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            //var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            //assemblyName.Version = version;
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
             Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = new Version() });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.InMemory;
@@ -19,6 +20,11 @@ namespace fiskaltrust.Middleware.Queue.InMemory
 
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -23,10 +23,10 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            //var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            //var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             //assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = new Version() });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -20,7 +20,11 @@ namespace fiskaltrust.Middleware.Queue.InMemory
 
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
-                    
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
+using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.InMemory;
 using Microsoft.Extensions.DependencyInjection;
@@ -21,10 +22,11 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = new AssemblyName(typeof(PosBootstrapper).Assembly.GetName().ToString());
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -22,13 +22,7 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) 
-                ? new Version(result.Major, result.Minor, result.Build, 0) 
-                : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -25,7 +25,7 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
             var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
+            //assemblyName.Version = version;
             Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -21,7 +21,7 @@ namespace fiskaltrust.Middleware.Queue.InMemory
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var assemblyName = new AssemblyName(typeof(PosBootstrapper).Assembly.GetName().ToString());
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
             assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -24,9 +24,11 @@ namespace fiskaltrust.Middleware.Queue.InMemory
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            var version = Version.TryParse(versionAttribute, out var result) 
+                ? new Version(result.Major, result.Minor, result.Build, 0) 
+                : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = new Version() });
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.InMemory;
 using Microsoft.Extensions.DependencyInjection;

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -20,11 +20,7 @@ namespace fiskaltrust.Middleware.Queue.InMemory
 
             var storageBootStrapper = new InMemoryStorageBootstrapper(Id, Configuration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
-
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+                    
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.InMemory/PosBootstrapper.cs
@@ -23,7 +23,7 @@ namespace fiskaltrust.Middleware.Queue.InMemory
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
@@ -24,6 +25,11 @@ namespace fiskaltrust.Middleware.Queue.MySQL
 
             var storageBootStrapper = new MySQLBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
@@ -27,9 +27,10 @@ namespace fiskaltrust.Middleware.Queue.MySQL
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
@@ -28,7 +28,7 @@ namespace fiskaltrust.Middleware.Queue.MySQL
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
@@ -26,11 +26,7 @@ namespace fiskaltrust.Middleware.Queue.MySQL
             var storageBootStrapper = new MySQLBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.MySQL/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.MySQL;
 using Microsoft.Extensions.DependencyInjection;

--- a/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
@@ -27,9 +27,10 @@ namespace fiskaltrust.Middleware.Queue.PostgreSQL
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
@@ -28,7 +28,7 @@ namespace fiskaltrust.Middleware.Queue.PostgreSQL
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
@@ -26,11 +26,7 @@ namespace fiskaltrust.Middleware.Queue.PostgreSQL
             var storageBootStrapper = new EFCorePostgreSQLStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.EFCore.PostgreSQL;
 using Microsoft.Extensions.DependencyInjection;

--- a/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.PostgreSQL/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
@@ -24,6 +25,11 @@ namespace fiskaltrust.Middleware.Queue.PostgreSQL
 
             var storageBootStrapper = new EFCorePostgreSQLStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -26,12 +26,7 @@ namespace fiskaltrust.Middleware.Queue.SQLite
             var storageBootStrapper = new SQLiteStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
-            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            assemblyName.Version = version;
-            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
-
+            Configuration.Add("assemblytype", typeof(PosBootstrapper));
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -26,7 +26,7 @@ namespace fiskaltrust.Middleware.Queue.SQLite
             var storageBootStrapper = new SQLiteStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var assemblyName = new AssemblyName(typeof(PosBootstrapper).Assembly.GetName().ToString());
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
             assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -29,7 +29,7 @@ namespace fiskaltrust.Middleware.Queue.SQLite
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -8,7 +8,6 @@ using fiskaltrust.Middleware.Storage.SQLite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using System.Linq;
 
 namespace fiskaltrust.Middleware.Queue.SQLite
 {

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
-using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
 using fiskaltrust.Middleware.Storage.SQLite;
 using Microsoft.Extensions.DependencyInjection;

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -26,10 +26,12 @@ namespace fiskaltrust.Middleware.Queue.SQLite
             var storageBootStrapper = new SQLiteStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
 
-            var assemblyName = new AssemblyName(typeof(PosBootstrapper).Assembly.GetName().ToString());
-            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
-            Configuration.Add("assemblyname", assemblyName);
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var versionAttribute = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            var version = Version.TryParse(versionAttribute, out var result) ? new Version(result.Major, result.Minor, result.Build, 0) : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+            assemblyName.Version = version;
+            Configuration.Add("assemblyinfo", new AssemblyInfo { Name = assemblyName.FullName, Version = version });
+
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Queue.Bootstrapper;
@@ -7,6 +8,7 @@ using fiskaltrust.Middleware.Storage.SQLite;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using System.Linq;
 
 namespace fiskaltrust.Middleware.Queue.SQLite
 {
@@ -24,6 +26,11 @@ namespace fiskaltrust.Middleware.Queue.SQLite
 
             var storageBootStrapper = new SQLiteStorageBootstrapper(Id, Configuration, storageConfiguration, logger);
             storageBootStrapper.ConfigureStorageServices(serviceCollection);
+
+            var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
+            var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+            assemblyName.Version = System.Version.TryParse(version, out Version result) ? result : assemblyName.Version;
+            Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);
             queueBootstrapper.ConfigureServices(serviceCollection);

--- a/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue.SQLite/PosBootstrapper.cs
@@ -29,7 +29,7 @@ namespace fiskaltrust.Middleware.Queue.SQLite
 
             var assemblyName = typeof(PosBootstrapper).Assembly.GetName();
             var version = typeof(PosBootstrapper).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
-            assemblyName.Version = System.Version.TryParse(version, out Version result) ? result : assemblyName.Version;
+            assemblyName.Version = System.Version.TryParse(version, out var result) ? result : assemblyName.Version;
             Configuration.Add("assemblyname", assemblyName);
 
             var queueBootstrapper = new QueueBootstrapper(Id, Configuration);

--- a/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;

--- a/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;
@@ -40,6 +41,7 @@ namespace fiskaltrust.Middleware.Queue.Bootstrapper
                 QueueId = _activeQueueId,
                 IsSandbox = _configuration.TryGetValue("sandbox", out var sandbox) && bool.TryParse(sandbox.ToString(), out var sandboxBool) && sandboxBool,
                 ServiceFolder = _configuration.TryGetValue("servicefolder", out var val) ? val.ToString() : GetServiceFolder(),
+                AssemblyName = _configuration.TryGetValue("assemblyname", out var assemblyName) ? (AssemblyName)assemblyName : null,
                 Configuration = _configuration,
                 PreviewFeatures = GetPreviewFeatures(_configuration),
                 AllowUnsafeScuSwitch = _configuration.TryGetValue("AllowUnsafeScuSwitch", out var allowUnsafeScuSwitch) && bool.TryParse(allowUnsafeScuSwitch.ToString(), out var allowUnsafeScuSwitchBool) && allowUnsafeScuSwitchBool,

--- a/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
@@ -41,7 +41,7 @@ namespace fiskaltrust.Middleware.Queue.Bootstrapper
                 QueueId = _activeQueueId,
                 IsSandbox = _configuration.TryGetValue("sandbox", out var sandbox) && bool.TryParse(sandbox.ToString(), out var sandboxBool) && sandboxBool,
                 ServiceFolder = _configuration.TryGetValue("servicefolder", out var val) ? val.ToString() : GetServiceFolder(),
-                AssemblyName = _configuration.TryGetValue("assemblyname", out var assemblyName) ? (AssemblyName)assemblyName : null,
+                AssemblyInfo = _configuration.TryGetValue("assemblyinfo", out var assemblyInfo) ? (AssemblyInfo)assemblyInfo : null,
                 Configuration = _configuration,
                 PreviewFeatures = GetPreviewFeatures(_configuration),
                 AllowUnsafeScuSwitch = _configuration.TryGetValue("AllowUnsafeScuSwitch", out var allowUnsafeScuSwitch) && bool.TryParse(allowUnsafeScuSwitch.ToString(), out var allowUnsafeScuSwitchBool) && allowUnsafeScuSwitchBool,

--- a/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Bootstrapper/QueueBootstrapper.cs
@@ -41,12 +41,12 @@ namespace fiskaltrust.Middleware.Queue.Bootstrapper
                 QueueId = _activeQueueId,
                 IsSandbox = _configuration.TryGetValue("sandbox", out var sandbox) && bool.TryParse(sandbox.ToString(), out var sandboxBool) && sandboxBool,
                 ServiceFolder = _configuration.TryGetValue("servicefolder", out var val) ? val.ToString() : GetServiceFolder(),
-                AssemblyInfo = _configuration.TryGetValue("assemblyinfo", out var assemblyInfo) ? (AssemblyInfo)assemblyInfo : null,
+                AssemblyType = _configuration.TryGetValue("assemblytype", out var assemblyType) ? (Type) assemblyType : null,
                 Configuration = _configuration,
                 PreviewFeatures = GetPreviewFeatures(_configuration),
                 AllowUnsafeScuSwitch = _configuration.TryGetValue("AllowUnsafeScuSwitch", out var allowUnsafeScuSwitch) && bool.TryParse(allowUnsafeScuSwitch.ToString(), out var allowUnsafeScuSwitchBool) && allowUnsafeScuSwitchBool,
             };
-
+            
             services.AddSingleton(sp =>
             {
                 CreateConfigurationActionJournalAsync(middlewareConfiguration, sp.GetRequiredService<IMiddlewareQueueItemRepository>(), sp.GetRequiredService<IMiddlewareActionJournalRepository>()).Wait();

--- a/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
@@ -1,14 +1,18 @@
-﻿namespace fiskaltrust.Middleware.Queue.Helpers;
+﻿using System;
+using System.Reflection;
+
+namespace fiskaltrust.Middleware.Queue.Helpers;
 
 public static class VersionHelper
 {
-    private static readonly string _currentMiddlewareVersion;
-
-    static VersionHelper()
+    public static string GetCurrentMiddlewareVersion(Type assemblyType)
     {
-        var version = typeof(VersionHelper).Assembly.GetName().Version;
-        _currentMiddlewareVersion = version?.ToString();
-    }
-    
-    public static string GetCurrentMiddlewareVersion() => _currentMiddlewareVersion;
+        var assemblyName = assemblyType.Assembly.GetName();
+        var versionAttribute = assemblyType?.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+        var version = Version.TryParse(versionAttribute, out var result)
+            ? new Version(result.Major, result.Minor, result.Build, 0)
+        : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
+        
+        return version?.ToString();
+    } 
 }

--- a/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
@@ -7,13 +7,16 @@ public static class VersionHelper
 {
     public static string GetCurrentMiddlewareVersion(Type assemblyType)
     {
-        assemblyType = assemblyType ?? typeof(VersionHelper);
+        if(assemblyType == null)
+        {
+            return typeof(VersionHelper).Assembly.GetName().Version?.ToString();
+        }
         var assemblyName = assemblyType.Assembly.GetName();
         var versionAttribute = assemblyType.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
         var version = Version.TryParse(versionAttribute, out var result)
             ? new Version(result.Major, result.Minor, result.Build, 0)
         : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);
         
-        return version?.ToString();
+        return version.ToString();
     } 
 }

--- a/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
@@ -7,7 +7,7 @@ public static class VersionHelper
 {
     public static string GetCurrentMiddlewareVersion(Type assemblyType)
     {
-        var assemblyName = assemblyType.Assembly.GetName();
+        var assemblyName = assemblyType?.Assembly.GetName();
         var versionAttribute = assemblyType?.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
         var version = Version.TryParse(versionAttribute, out var result)
             ? new Version(result.Major, result.Minor, result.Build, 0)

--- a/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/Helpers/VersionHelper.cs
@@ -7,8 +7,9 @@ public static class VersionHelper
 {
     public static string GetCurrentMiddlewareVersion(Type assemblyType)
     {
-        var assemblyName = assemblyType?.Assembly.GetName();
-        var versionAttribute = assemblyType?.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
+        assemblyType = assemblyType ?? typeof(VersionHelper);
+        var assemblyName = assemblyType.Assembly.GetName();
+        var versionAttribute = assemblyType.Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion.Split(new char[] { '+', '-' })[0];
         var version = Version.TryParse(versionAttribute, out var result)
             ? new Version(result.Major, result.Minor, result.Build, 0)
         : new Version(assemblyName.Version.Major, assemblyName.Version.Minor, assemblyName.Version.Build, 0);

--- a/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
@@ -127,10 +127,7 @@ namespace fiskaltrust.Middleware.Queue
             {
                 Assembly = assemblyName.FullName,
                 Version = version
-
             };
-
-
         }
         private async Task<object> GetConfiguration()
         {

--- a/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
@@ -95,8 +95,8 @@ namespace fiskaltrust.Middleware.Queue
                         {
                             Chunk = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new
                                 {
-                                    Assembly = _middlewareConfiguration.AssemblyName?.FullName,
-                                    Version = _middlewareConfiguration.AssemblyName?.Version
+                                    Assembly = _middlewareConfiguration.AssemblyInfo?.Name,
+                                    Version = _middlewareConfiguration.AssemblyInfo?.Version
                                 }
                             )).ToList()
                         }

--- a/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
@@ -95,8 +95,8 @@ namespace fiskaltrust.Middleware.Queue
                         {
                             Chunk = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new
                                 {
-                                    Assembly = _middlewareConfiguration.AssemblyName.FullName,
-                                    Version = _middlewareConfiguration.AssemblyName.Version
+                                    Assembly = _middlewareConfiguration.AssemblyName?.FullName,
+                                    Version = _middlewareConfiguration.AssemblyName?.Version
                                 }
                             )).ToList()
                         }

--- a/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/JournalProcessor.cs
@@ -95,8 +95,8 @@ namespace fiskaltrust.Middleware.Queue
                         {
                             Chunk = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(new
                                 {
-                                    Assembly = typeof(JournalProcessor).Assembly.GetName().FullName,
-                                    Version = typeof(JournalProcessor).Assembly.GetName().Version
+                                    Assembly = _middlewareConfiguration.AssemblyName.FullName,
+                                    Version = _middlewareConfiguration.AssemblyName.Version
                                 }
                             )).ToList()
                         }

--- a/queue/src/fiskaltrust.Middleware.Queue/SignProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/SignProcessor.cs
@@ -30,6 +30,7 @@ namespace fiskaltrust.Middleware.Queue
         private readonly Guid _cashBoxId = Guid.Empty;
         private readonly bool _isSandbox;
         private readonly int _receiptRequestMode = 0;
+        private readonly Type _assemblyType;
         private readonly SignatureFactory _signatureFactory;
         private readonly ReceiptConverter _receiptConverter;
         //private readonly Action<string> _onMessage;
@@ -56,6 +57,7 @@ namespace fiskaltrust.Middleware.Queue
             _cashBoxId = configuration.CashBoxId;
             _isSandbox = configuration.IsSandbox;
             _receiptRequestMode = configuration.ReceiptRequestMode;
+            _assemblyType = configuration.AssemblyType;
             //_onMessage = configuration.OnMessage;
             _signatureFactory = new SignatureFactory();
             _receiptConverter = receiptConverter;
@@ -137,7 +139,7 @@ namespace fiskaltrust.Middleware.Queue
                 cbTerminalID = data.cbTerminalID,
                 cbReceiptReference = data.cbReceiptReference,
                 ftQueueRow = ++queue.ftQueuedRow,
-                ProcessingVersion = VersionHelper.GetCurrentMiddlewareVersion()
+                ProcessingVersion = VersionHelper.GetCurrentMiddlewareVersion(_assemblyType)
             };
             if (queueItem.ftQueueTimeout == 0)
             {

--- a/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/Program.cs
+++ b/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/Program.cs
@@ -20,8 +20,8 @@ namespace fiskaltrust.Middleware.Queue.Test.Launcher
 {
     public static class Program
     {
-        private static readonly string _cashBoxId = "";
-        private static readonly string _accessToken = "";
+        private static readonly string _cashBoxId = "f17819b7-4975-4f6b-8068-08978bf62d50";
+        private static readonly string _accessToken = "BIdRt2+2vHnvAcNNq6pvOUS30JSm8Kk/PI2R9sPBRcwffZ9INIPktlsSKsx92wXD/5/Me6sgqj4AwHghb8ys9hQ=";
         private static readonly string _localization = "DE";
 
         public static void Main(string configurationFilePath = "", string serviceFolder = @"C:\ProgramData\fiskaltrust\service")

--- a/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/Program.cs
+++ b/queue/test/Manual/fiskaltrust.Middleware.Queue.Test.Launcher/Program.cs
@@ -20,8 +20,8 @@ namespace fiskaltrust.Middleware.Queue.Test.Launcher
 {
     public static class Program
     {
-        private static readonly string _cashBoxId = "f17819b7-4975-4f6b-8068-08978bf62d50";
-        private static readonly string _accessToken = "BIdRt2+2vHnvAcNNq6pvOUS30JSm8Kk/PI2R9sPBRcwffZ9INIPktlsSKsx92wXD/5/Me6sgqj4AwHghb8ys9hQ=";
+        private static readonly string _cashBoxId = "";
+        private static readonly string _accessToken = "";
         private static readonly string _localization = "DE";
 
         public static void Main(string configurationFilePath = "", string serviceFolder = @"C:\ProgramData\fiskaltrust\service")


### PR DESCRIPTION
Fixed the version in journal endpoint: http://localhost:1500/json/v0/Journal?type=0
The result is like:
`{"Assembly":"fiskaltrust.Middleware.Queue.SQLite, Version=1.3.70.0, Culture=neutral, PublicKeyToken=null","Version":{"Major":1,"Minor":3,"Build":70,"Revision":0,"MajorRevision":0,"MinorRevision":0}}
`
<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
