### PR TITLE
Added AustriaCard identification value to CardService

### DIFF
--- a/scu-at/src/fiskaltrust.Middleware.SCU.AT.ATrustSmartcard/Services/CardServiceFactory.cs
+++ b/scu-at/src/fiskaltrust.Middleware.SCU.AT.ATrustSmartcard/Services/CardServiceFactory.cs
@@ -40,6 +40,7 @@ namespace fiskaltrust.Middleware.SCU.AT.ATrustSmartcard.Services
                     "3BDF97008131FE468031905241026405C903AC73D622C030",
                     "3BDF96FF918131FE468031905241026405C903AC73D622C05F",
                     "3BDF18FF918131FE468031905241026405C903AC73D622C0D1",
+                    "3BDF97008131FE4680319052410464050401AC73D622C0F9",
             }.Any(id => atrHex.Replace("-", "").StartsWith(id, StringComparison.OrdinalIgnoreCase)))
             {
                 _logger.LogDebug("Detected an A-Trust AcosID card");


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

integrate apdu command to use globaltrust / austria card signature card for RKS

## Description

It seems like there are no changes compared to the implementation of the previous generations. The only thing needed was the identification value for the new cards.

Fixes #{issue number}
