### PR TITLE
Add GitHub Actions workflow for tagging packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,99 @@
+name: tag Package
+on:
+  repository_dispatch:
+    types: [tag-command]
+
+permissions:
+  pull-requests: write
+  checks: write
+  id-token: write
+  contents: read
+
+jobs:
+  meta:
+    needs: []
+    runs-on: windows-latest
+    outputs:
+      project: ${{ steps.meta.outputs.project }}
+      package: ${{ steps.meta.outputs.package }}
+      directory: ${{ steps.meta.outputs.directory }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+
+      - id: meta
+        shell: pwsh
+        run: |
+          $directory = "${{ github.event.client_payload.slash_command.args.unnamed.arg1 }}"
+          $package = "${{ github.event.client_payload.slash_command.args.unnamed.arg2 }}"
+          Write-Output "package=$package"
+          Write-Output "package=$package" >> $env:GITHUB_OUTPUT
+          Write-Output "directory=$directory/src"
+          Write-Output "directory=$directory/src" >> $env:GITHUB_OUTPUT
+          $prefix = ""
+          if($directory -eq "queue") {
+            $prefix = "fiskaltrust.Middleware.Queue"
+          } elseif($directory -match "scu-([a-z]{2})") {
+            $prefix = "fiskaltrust.Middleware.SCU.$($matches[1].ToUpper())"
+          }
+          $project = $(Get-Item "$directory/src/$prefix.$package").Name
+          Write-Output "project=$project"
+          Write-Output "project=$project" >> $env:GITHUB_OUTPUT
+    
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Install nbgv
+        run: dotnet tool update -g nbgv
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create and push tag
+        run: |
+          nbgv tag --project ${{ needs.meta.outputs.directory }}/${{ needs.meta.outputs.project }}
+          git push --tags
+
+  success:
+    needs:
+      - tag
+    runs-on: ubuntu-latest
+    if: success('package') && !failure('deploy')
+    steps:
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: hooray
+          reactions-edit-mode: replace
+          edit-mode: replace
+          body: |
+            /${{ github.event.client_payload.slash_command.command }} ${{ github.event.client_payload.slash_command.args.all }}
+            [![](https://badgen.net/static/${{ github.event.client_payload.slash_command.command }}%20${{ github.run_id }}/success/green)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+    
+  failure:
+    needs:
+      - tag
+    runs-on: ubuntu-latest
+    if: failure()
+    steps:
+      - name: Add reaction
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+          reactions: confused
+          reactions-edit-mode: replace
+          edit-mode: replace
+          body: |
+            /${{ github.event.client_payload.slash_command.command }} ${{ github.event.client_payload.slash_command.args.all }}
+            [![](https://badgen.net/static/${{ github.event.client_payload.slash_command.command }}%20${{ github.run_id }}/failure/red)](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
This workflow triggers on repository dispatch events to handle tagging packages. It includes jobs for metadata extraction, tagging, and success/failure reactions.

<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
