### PR TITLE
Fix 597 - Change ReceiptMoment to LocalTime

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -193,7 +193,7 @@ public class AADEFactory
             {
                 series = receiptResponse.ftCashBoxIdentification,
                 aa = identification.ToString(),
-                issueDate = receiptRequest.cbReceiptMoment,
+                issueDate = AADEMappings.GetLocalTime(receiptRequest),
                 invoiceType = AADEMappings.GetInvoiceType(receiptRequest),
                 currency = CurrencyType.EUR,
                 currencySpecified = true

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -6,6 +6,7 @@ using fiskaltrust.ifPOS.v2.Cases;
 using fiskaltrust.Middleware.SCU.GR.Abstraction;
 using fiskaltrust.Middleware.SCU.GR.MyData.Helpers;
 using fiskaltrust.Middleware.SCU.GR.MyData.Models;
+using NodaTime;
 
 namespace fiskaltrust.Middleware.SCU.GR.MyData;
 public static class AADEMappings
@@ -228,6 +229,65 @@ public static class AADEMappings
             ChargeItemCaseTypeOfService.NotOwnSales => IncomeClassificationCategoryType.category1_7,
             _ => throw new Exception($"The ChargeItem type {chargeItem.ftChargeItemCase.TypeOfService()} is not supported for IncomeClassificationCategoryType."),
         };
+    }
+
+
+    public static DateTime GetLocalTime(ReceiptRequest receiptRequest)
+    {
+        // Get the UTC DateTime from receiptRequest
+        var iniDateTime = receiptRequest.cbReceiptMoment;
+
+        // Ensure it's marked as UTC
+        if (iniDateTime.Kind != DateTimeKind.Utc)
+        {
+            iniDateTime = DateTime.SpecifyKind(iniDateTime, DateTimeKind.Utc);
+        }
+
+        /*
+        Convert the UTC DateTime to a NodaTime Instant
+            Why we do this:
+              1.Instant represents an exact point in time on the UTC timeline(absolute UTC).
+              2.ZonedDateTime requires an Instant to calculate the local time in any time zone correctly.
+              3.Ensures that DST offsets and historical changes in the time zone are applied correctly.
+              4.Avoids errors that could occur if you tried to interpret the DateTime as "local" directly.
+              5.Provides a cross-platform, unambiguous starting point for time zone conversions.
+        */
+        Instant utcInstant = Instant.FromDateTimeUtc(iniDateTime);
+
+        /*
+         Get Greek timezone (IANA)
+            Why we do this:
+              1. "Europe/Athens" is the IANA time zone identifier for Greece.
+              2. Using IANA ensures correct handling of Daylight Saving Time (DST),
+                  including historical and future changes to offsets (+2/+3).
+              3. NodaTime uses DateTimeZone objects to represent time zones in a
+                  cross-platform and unambiguous way, unlike Windows-only TimeZoneInfo.
+              4. This allows safe conversion from UTC Instants to local Greek time
+                  on any operating system (Windows, Linux, macOS).
+        */
+        DateTimeZone zone = DateTimeZoneProviders.Tzdb["Europe/Athens"];
+
+        /*
+        Convert UTC instant to Greek local time(ZonedDateTime)
+            Why we do this:
+              1.utcInstant represents an absolute point in time in UTC.
+              2.InZone(zone) maps that instant to the local time in the specified time zone("Europe/Athens").
+              3.Automatically applies the correct UTC offset(+02:00 in winter, +03:00 in summer) based on DST rules.
+              4.Ensures that the resulting ZonedDateTime reflects the correct local Greek time regardless of the server's local timezone.
+              5.This is the step where the UTC timestamp becomes "real Greek time" safely and accurately.
+        */
+        ZonedDateTime zoned = utcInstant.InZone(zone);
+
+        /*
+        Convert ZonedDateTime to a .NET DateTime with Kind = Unspecified
+            Why we do this:
+              1. The local Greek time (with correct DST offset) is preserved exactly
+              2. Serialization (System.Text.Json, XML, etc.) will NOT adjust the time based on the server's local time zone or UTC settings
+              3. Prevents accidental hour/date shifts if the code runs on a server in a different time zone
+        */
+        DateTime finalDateTime = zoned.ToDateTimeUnspecified();
+
+        return finalDateTime;
     }
 
     public static InvoiceType GetInvoiceType(ReceiptRequest receiptRequest)

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/fiskaltrust.Middleware.SCU.GR.MyData.csproj
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/fiskaltrust.Middleware.SCU.GR.MyData.csproj
@@ -16,6 +16,8 @@
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 
         <PackageReference Include="Azure.Core" Version="1.35.0" />
+
+        <PackageReference Include="NodaTime" Version="3.3.0" />
         <PackageReference Include="System.Collections" Version="4.3.0" />
     </ItemGroup>
 


### PR DESCRIPTION
{Summary of the changes}
Add NodaTime support and implement GetLocalTime()

{Detail}
Installs the NodaTime package and introduces the GetLocalTime() procedure for local time conversion.

Updates CreateInvoiceDocType() to use GetLocalTime().

Adds test scenarios for both winter (UTC+2) and summer (UTC+3) time zones:
- MapToInvoicesDoc_ForReceiptWithReceiptMomentUtcInWinter_ShouldSetLocalTime()
       - Normal daytime
       - One hour before midnight → next day
- MapToInvoicesDoc_ForReceiptWithReceiptMomentUtcInSummer_ShouldSetLocalTime()
      - Normal daytime
      - One hour before midnight → next day

Updates existing test scenarios to use GetLocalTime():
- MapToInvoicesDoc_ForVATExemptReceiptWithCashPayment_ShouldWork()
- MapToInvoicesDoc_ForVATExemptReceiptWithCashPayment_ShouldWork_AndReturnClassification()
- MapToInvoicesDoc_ForPaymentTransferCashPayment_ShouldWork_AndReturnClassification()

Adds test scenarios for GetLocalTime()

Fixes #597 
