### PR TITLE
Fix 123 - Mapping Units of measurement

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -656,22 +656,9 @@ public class AADEFactory
             if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.HasTransportInformation))
             {
                 invoiceRow.itemDescr = x.Description;
-                if (x.Unit == "Litres")
-                {
-                    invoiceRow.measurementUnit = 3;
-                    invoiceRow.measurementUnitSpecified = true;
-                }
-                else if (x.Unit == "Kg")
-                {
-                    invoiceRow.measurementUnit = 2;
-                    invoiceRow.measurementUnitSpecified = true;
-                }
-                else
-                {
-                    invoiceRow.measurementUnit = 1;
-                    invoiceRow.measurementUnitSpecified = true;
-                }
-
+                
+                invoiceRow.measurementUnit = AADEMappings.GetMeasurementUnit(x);
+                invoiceRow.measurementUnitSpecified = true;
             }
 
             if (x.ftChargeItemCase.NatureOfVat() != ChargeItemCaseNatureOfVatGR.UsualVatApplies)

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -584,4 +584,29 @@ public static class AADEMappings
             _ => throw new NotSupportedException($"The ChargeItemCase 0x{chargeItem.ftChargeItemCase:x} contains a not supported Nature NN.") // Unknown nature, no exemption category
         };
     }
+
+
+    public static int GetMeasurementUnit(ChargeItem? chargeItem)
+    {
+        if (chargeItem == null)
+        {
+            return MyDataMeasurementUnit.Pieces;
+        }
+        if (string.IsNullOrWhiteSpace(chargeItem?.Unit))
+        {
+            return MyDataMeasurementUnit.Pieces;
+        }
+
+        return chargeItem.Unit.ToLowerInvariant() switch
+        {
+            "pieces" => MyDataMeasurementUnit.Pieces,
+            "kg" => MyDataMeasurementUnit.Kg,
+            "litres" => MyDataMeasurementUnit.Litres,
+            "meters" => MyDataMeasurementUnit.Meters,
+            "squaremeters" => MyDataMeasurementUnit.SquareMeters,
+            "cubicmeters" => MyDataMeasurementUnit.CubicMeters,
+            "otherpieces" => MyDataMeasurementUnit.OtherPieces,
+            _ => MyDataMeasurementUnit.Pieces
+        };
+    }
 }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/MyDataMeasurementUnit.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/MyDataMeasurementUnit.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.Models
+{
+    public class MyDataMeasurementUnit
+    {
+        public const int Pieces = 1;
+        public const int Kg = 2;
+        public const int Litres = 3;
+        public const int Meters = 4;
+        public const int SquareMeters = 5;
+        public const int CubicMeters = 6;
+        public const int OtherPieces = 7;
+    }
+}

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using fiskaltrust.ifPOS.v2;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
+{
+    public class AADEMappingsChargeItemTests
+    {
+
+        [Theory]
+        [InlineData("PieCes", 1)]
+        [InlineData("pieces", 1)]
+        [InlineData("PIECES", 1)]
+        [InlineData("Kg", 2)]
+        [InlineData("Litres", 3)]
+        [InlineData("Meters", 4)]
+        [InlineData("SquareMeters", 5)]
+        [InlineData("CubicMeters", 6)]
+        [InlineData("OtherPieces", 7)]
+        // legacy / fallback behavior
+        [InlineData("Unknown", 1)]
+        [InlineData("", 1)]
+        [InlineData(null, 1)]
+        public void GetMeasurementUnit_ShouldReturnExpectedValue(string unit, int expectedValue)
+        {
+            // Arrange
+            var chargeItem = new ChargeItem
+            {
+                Unit = unit
+            };
+
+            // Act
+            var result = AADEMappings.GetMeasurementUnit(chargeItem);
+
+            // Assert
+            result.Should().Be(expectedValue);
+        }
+    }
+}


### PR DESCRIPTION
{Summary of the changes}
Create mapping for the default supported units of measurement

{Detail}
I created the Models->MyDataMeasurementUnit class, which defines the default supported units of measurement for MyData.

I added the mappings (case-insensitive) between the UOM description and the units of measurement nomenclature(MyDataMeasurementUnit) in the AADEMAppings->GetMeasurementUnit() procedure. For any mismatch, the method returns MyDataMeasurementUnit.Pieces = 1, as before.

I modified the AADEFactory->GetInvoiceDetails() method to use the GetMeasurementUnit() procedure.

I added the UnitTest->AADEMappingsChargeItemTests unit test class (where any mapping related to ChargeItem can be added), and within it I added a test scenario for the newly created GetMeasurementUnit() procedure.


Fixes #123
