### PR TITLE
Fix 115 Plastic bag update to include vat

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -478,7 +478,7 @@ public class AADEFactory
         }
 
         var documentTaxes = new List<TaxTotalsType>();
-        foreach (var item in receiptRequest.cbChargeItems.Where(x => SpecialTaxMappings.IsSpecialTaxItem(x)))
+        foreach (var item in receiptRequest.cbChargeItems.Where(x => SpecialTaxMappings.IsSpecialTaxItem(x) && !SpecialTaxMappings.IsVatableSpecialTaxItem(x)))
         {
             var withholdingMapping = SpecialTaxMappings.GetWithholdingTaxMapping(item.Description);
             if (withholdingMapping != null)
@@ -636,7 +636,11 @@ public class AADEFactory
         }
 
         var chargeItems = receiptRequest.GetGroupedChargeItems()
-            .Where(grouped => !SpecialTaxMappings.IsSpecialTaxItem(grouped.chargeItem))
+            .Where(grouped =>
+                    !SpecialTaxMappings.IsSpecialTaxItem(grouped.chargeItem)
+                    ||
+                    (SpecialTaxMappings.IsVatableSpecialTaxItem(grouped.chargeItem))
+                  )
             .ToList();
 
         var nextPosition = 1;
@@ -747,6 +751,17 @@ public class AADEFactory
                     {
                         invoiceRow.incomeClassification = [AADEMappings.GetIncomeClassificationType(receiptRequest, x)];
                     }
+                }
+            }
+            if (SpecialTaxMappings.IsVatableSpecialTaxItem(x))
+            {
+                var feeMapping = SpecialTaxMappings.GetFeeMapping(x.Description);
+                if (feeMapping != null)
+                {
+                    invoiceRow.feesAmount = Math.Abs(x.Amount - (x.VATAmount ?? 0));
+                    invoiceRow.feesAmountSpecified = true;
+                    invoiceRow.feesPercentCategory = feeMapping.Code;
+                    invoiceRow.feesPercentCategorySpecified = true;
                 }
             }
             if (grouped.modifiers.Count > 0)

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -153,6 +153,11 @@ public static class AADEMappings
                 {
                     return IncomeClassificationValueType.E3_561_002;
                 }
+                
+                if (SpecialTaxMappings.IsVatableSpecialTaxItem(chargeItem))
+                {
+                    return IncomeClassificationValueType.E3_561_001;
+                }
 
                 return chargeItem.ftChargeItemCase.TypeOfService() switch
                 {
@@ -219,6 +224,11 @@ public static class AADEMappings
         if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.InternalUsageMaterialConsumption0x3003))
         {
             return IncomeClassificationCategoryType.category1_6;
+        }
+
+        if (SpecialTaxMappings.IsVatableSpecialTaxItem(chargeItem))
+        {
+            return IncomeClassificationCategoryType.category1_1;
         }
 
         return chargeItem.ftChargeItemCase.TypeOfService() switch

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
@@ -450,4 +450,71 @@ public static class SpecialTaxMappings
     {
         return chargeItem.ftChargeItemCase.IsTypeOfService((ChargeItemCaseTypeOfService) 0xF0);
     }
+
+    #region IsVatableSpecialTaxItemTests
+
+    /// <summary>
+    /// The set of fee codes for which VAT must never be applied—these codes represent special fees that are always non-vatable.
+    /// If a ChargeItem's fee mapping has one of these codes, it is explicitly excluded from VAT eligibility.
+    /// </summary>
+    private static readonly HashSet<int> NonVatableFeeCodes = new() { 9, 12, 18, 21 };
+
+    /// <summary>
+    /// Determines if the given ChargeItem represents a special tax item that can have VAT applied (is "vatable").
+    /// </summary>
+    /// <param name="chargeItem">The ChargeItem to evaluate.</param>
+    /// <returns>True if the item is a special tax fee eligible for VAT, otherwise false.</returns>
+    public static bool IsVatableSpecialTaxItem(ChargeItem chargeItem)
+    {
+        // 1. If the item is NOT a special tax item, it cannot be a vatable special tax fee.
+        if (!IsSpecialTaxItem(chargeItem))
+            return false;
+
+        // 2. Check that the VAT code of this special tax item is an accepted, vatable code.
+        // Only proceed for these VAT categories: discounted, normal, super-reduced, or zero rates.
+        var vatCode = chargeItem.ftChargeItemCase.Vat();
+        if (
+            vatCode != ChargeItemCase.DiscountedVatRate1
+            && vatCode != ChargeItemCase.DiscountedVatRate2
+            && vatCode != ChargeItemCase.NormalVatRate
+            && vatCode != ChargeItemCase.SuperReducedVatRate1
+            && vatCode != ChargeItemCase.SuperReducedVatRate2
+            && vatCode != ChargeItemCase.ZeroVatRate)
+        {
+            // VAT code is NOT in the list of allowed types for vatable special taxes.
+            return false;
+        }
+
+        // 3. All conditions met—run extra, fee-specific business logic to make the final determination.
+        return IsVatableSpecialFee(chargeItem);
+    }
+
+    /// <summary>
+    /// Determines at business logic level if a special tax fee described by the ChargeItem can actually accept VAT.
+    /// </summary>
+    /// <param name="chargeItem">The ChargeItem to evaluate.</param>
+    /// <returns>True if the special tax fee is eligible for VAT, otherwise false.</returns>
+    public static bool IsVatableSpecialFee(ChargeItem chargeItem)
+    {
+        // Try to find the business mapping for this fee (typically using its description).
+        var feeMapping = SpecialTaxMappings.GetFeeMapping(chargeItem.Description);
+
+        // If there is no mapping found for this fee, it means the fee type is not eligible for VAT.
+        if (feeMapping == null)
+        {
+            return false;
+        }
+
+        // If the fee code is in the list of non-vatable fee codes, 
+        // this fee is explicitly excluded from VAT eligibility.
+        if (NonVatableFeeCodes.Contains(feeMapping.Code))
+        {
+            return false;
+        }
+
+        // If all checks pass, this fee can accept VAT.
+        return true;
+    }
+
+    #endregion IsVatableSpecialTaxItemTests
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEFactoryTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEFactoryTests.cs
@@ -1659,7 +1659,7 @@ public class AADEFactoryTests
         var aadeFactory = new AADEFactory(new storage.V0.MasterData.MasterDataConfiguration
         {
             Account = new storage.V0.MasterData.AccountMasterData()
-        });
+        }, "https://test.receipts.example.com");
 
         // Act
         (var invoiceDoc, var error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse, []);
@@ -1735,7 +1735,7 @@ public class AADEFactoryTests
         var aadeFactory = new AADEFactory(new storage.V0.MasterData.MasterDataConfiguration
         {
             Account = new storage.V0.MasterData.AccountMasterData()
-        });
+        }, "https://test.receipts.example.com");
 
         // Act
         (var invoiceDoc, var error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse, []);
@@ -1856,7 +1856,7 @@ public class AADEFactoryTests
             {
                 VatId = "999123456"
             }
-        });
+        }, "https://test.receipts.example.com");
 
         // Act
         (var doc, var error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse, []);

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
@@ -1,13 +1,13 @@
-using System;
+﻿using System;
 using System.Linq;
-using FluentAssertions;
-using Xunit;
-using fiskaltrust.Middleware.SCU.GR.MyData;
-using fiskaltrust.Middleware.SCU.GR.MyData;
 using fiskaltrust.ifPOS.v2;
 using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.GR.MyData;
+using fiskaltrust.Middleware.SCU.GR.MyData.Helpers;
 using fiskaltrust.storage.V0;
 using fiskaltrust.storage.V0.MasterData;
+using FluentAssertions;
+using Xunit;
 
 namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest.SCU.MyData
 {
@@ -1385,5 +1385,118 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest.SCU.MyData
         }
 
         #endregion
+
+        #region IsVatableSpecialTaxItemTests
+        [Fact]
+        public void MapToInvoicesDoc_ShouldHandleIsVatableSpecialTaxItem()
+        {
+            // Arrange         
+            var factory = new AADEFactory(new storage.V0.MasterData.MasterDataConfiguration
+            {
+                Account = new storage.V0.MasterData.AccountMasterData
+                {
+                    VatId = "098000979"
+                }
+            }, "https://test.receipts.example.com");
+
+            var receiptRequest = new ReceiptRequest
+            {
+                ftCashBoxID = Guid.NewGuid(),
+                ftPosSystemId = Guid.NewGuid(),
+                cbTerminalID = "T001",
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbCustomer = new MiddlewareCustomer
+                {
+                    CustomerVATId = "112545020",
+                    CustomerCountry = "GR"
+
+                },
+                cbReceiptMoment = DateTime.UtcNow,
+                ftReceiptCase = (ReceiptCase) 0x2000_0000_1001,
+                cbChargeItems =
+                [
+                    new ChargeItem
+            {
+                Position = 1,
+                Quantity = 1,
+                Description = "Παροχή υπηρεσιών", //Prestare de servicii
+                Amount = 124m,
+                VATRate = 24,
+                VATAmount = 24m,
+                ftChargeItemCase = (ChargeItemCase) 0x_2000_0000_0013,
+            },
+            new ChargeItem
+            {
+                Position = 2,
+                Quantity = 1,
+                Description = "Περιβαλλοντικό Τέλος & πλαστικής σακούλας ν. 2339/2001 αρ. 6α 0,07 ευρώ ανά τεμάχιο",
+                Amount = 10m,
+                VATRate = 24,
+                VATAmount = 2.4m,
+                ftChargeItemCase = (ChargeItemCase) 0x_2000_0000_00F3,
+            }
+                ],
+                cbPayItems =
+                [
+                    new PayItem
+            {
+                Description = "Cash",
+                ftPayItemCase = (PayItemCase) 35184372088833 , 
+                Amount = 134m,
+            }
+                ]
+            };
+
+            var receiptResponse = new ReceiptResponse
+            {
+                ftReceiptIdentification = "ft123456789",
+                ftCashBoxIdentification = "CB001",
+                ftState = (State) 0x4752000000000000,
+                ftSignatures = []
+            };
+
+            // Act
+            var (invoiceDoc, error) = factory.MapToInvoicesDoc(receiptRequest, receiptResponse);
+
+            var xml = AADEFactory.GenerateInvoicePayload(invoiceDoc!);
+
+            // Assert
+            error.Should().BeNull();
+            invoiceDoc.Should().NotBeNull();
+
+            var invoice = invoiceDoc?.invoice[0];
+            invoice?.invoiceDetails.Should().HaveCount(2, "fees with VAT must be represented as a separate invoice line");
+
+            var feeLines = invoice?.invoiceDetails?.Where(d => d.feesAmount > 0).ToList();
+            feeLines.Should().NotBeNull();
+            feeLines.Should().HaveCount(1);
+            var feeLine = feeLines.Single();
+            feeLine.incomeClassification.Single().classificationCategory.Should().Be(IncomeClassificationCategoryType.category1_1, "special tax items with VAT must be classified as Delivery");
+            feeLine.incomeClassification.Single().classificationType.Should().Be(IncomeClassificationValueType.E3_561_001, "special tax items that accept VAT must be treated as taxable income");
+            feeLine.feesPercentCategory.Should().Be(8);
+
+            feeLine.netValue.Should().Be(7.6m, "fee line netValue must equal the fee amount");
+            feeLine.vatCategory.Should().Be(1, "fees must use standard VAT category");
+            feeLine.vatAmount.Should().Be(2.4m, "VAT for the fee must be calculated at 24%");
+            feeLine.feesAmount.Should().Be(7.6m, "special tax fee must be sent as a separate line with the exact fee amount");
+
+            invoice.taxesTotals.Should().BeNull("fees with VAT must not be reported in taxesTotals");
+
+            var summary = invoice?.invoiceSummary;
+            summary.Should().NotBeNull();
+            summary.totalNetValue.Should().Be(107.6m, "total net value must include both service and fee lines");
+            summary.totalVatAmount.Should().Be(26.4m, "VAT must include VAT from service and fee lines");
+            summary.totalFeesAmount.Should().Be(7.6m, "fee amount must be aggregated into invoice summary");
+            summary.totalGrossValue.Should().Be(141.6m, "gross value must equal net + VAT + fee");
+
+            var header = invoice.invoiceHeader;
+            header.invoiceType.Should().Be(InvoiceType.Item11, "Invoices with VAT-bearing fees must be sent as Sales Invoice type 1.1");
+
+            var payment = invoice?.paymentMethods?.Single();
+            payment.Should().NotBeNull();
+            payment.amount.Should().Be(134m, "payment amount must equal total net value plus VAT, excluding fees");
+
+        }
+        #endregion IsVatableSpecialTaxItemTests
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
@@ -194,5 +194,87 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
             mapping.Percentage.Should().Be(expectedPercentage, $"percentage for '{description}' should be {expectedPercentage}");
             mapping.IsFixedAmount.Should().Be(expectedIsFixed, $"IsFixedAmount for '{description}' should be {expectedIsFixed}");
         }
+
+        #region IsVatableSpecialTaxItemTests
+        [Theory]
+        [InlineData("Για μηνιαίο λογαριασμό μέχρι και 50 ευρώ 12%", 1, true)]
+        [InlineData("Για μηνιαίο λογαριασμό από 50,01 μέχρι και 100 ευρώ 15%", 2, true)]
+        [InlineData("Για μηνιαίο λογαριασμό από 100,01 μέχρι και 150 ευρώ 18%", 3, true)]
+        [InlineData("Για μηνιαίο λογαριασμό από 150,01 ευρώ και άνω 20%", 4, true)]
+        [InlineData("Τέλος καρτοκινητής επί της αξίας του χρόνου ομιλίας (12%)", 5, true)]
+        [InlineData("Τέλος στη συνδρομητική τηλεόραση 10%", 6, true)]
+        [InlineData("Τέλος συνδρομητών σταθερής τηλεφωνίας 5%", 7, true)]
+        [InlineData("Περιβαλλοντικό Τέλος & πλαστικής σακούλας ν. 2339/2001 αρ. 6α 0,07 ευρώ ανά τεμάχιο", 8, true)]
+        [InlineData("Εισφορά δακοκτονίας 2%", 9, false)]
+        [InlineData("Λοιπά τέλη", 10, true)]
+        [InlineData("Τέλη Λοιπών Φόρων", 11, true)]
+        [InlineData("Εισφορά δακοκτονίας", 12, false)]
+        [InlineData("Για μηνιαίο λογαριασμό κάθε σύνδεσης (10%)", 13, true)]
+        [InlineData("Τέλος καρτοκινητής επί της αξίας του χρόνου ομιλίας (10%)", 14, true)]
+        [InlineData("Τέλος κινητής και καρτοκινητής για φυσικά πρόσωπα ηλικίας 15 έως και 29 ετών (0%)", 15, true)]
+        [InlineData("Τέλος ανακύκλωσης 0,08 λεπτά ανά τεμάχιο [άρθρο 80 ν. 4819/2021]", 17, true)]
+        [InlineData("Τέλος διαμονής παρεπιδημούντων", 18, false)]
+        [InlineData("Τέλος επί των ακαθάριστων εσόδων των εστιατορίων και συναφών καταστημάτων", 19, true)]
+        [InlineData("Τέλος επί των ακαθάριστων εσόδων των κέντρων διασκέδασης", 20, true)]
+        [InlineData("Τέλος επί των ακαθάριστων εσόδων των καζίνο", 21, false)]
+        [InlineData("Λοιπά τέλη επί των ακαθάριστων εσόδων", 22, true)]
+        [InlineData("Invalid description", 23, false)]
+        [InlineData("INVALID FEE DESC", -1, false)] // unmapped
+        [InlineData("", 0, false)] // empty description = no mapping
+        public void GetFeeMapping_ShouldHandleAllDefinedMappingsForIsVatableSpecialFee(string description, int expectedCode, bool expectedAcceptsVAT)
+        {
+            // Arrange
+            var chargeItem = new ChargeItem { Description = description };
+
+            // Act
+            var result = SpecialTaxMappings.IsVatableSpecialFee(chargeItem);
+
+            // Assert
+            result.Should().Be(expectedAcceptsVAT);
+        }
+
+        [Theory]
+        /* Not special tax item: should always return false for any VAT code and description */
+        [InlineData(ChargeItemCaseTypeOfService.OtherService, ChargeItemCase.NormalVatRate, "Λοιπά τέλη", false)]
+        [InlineData(ChargeItemCaseTypeOfService.OtherService, ChargeItemCase.DiscountedVatRate1, "Λοιπά τέλη", false)]
+        [InlineData(ChargeItemCaseTypeOfService.OtherService, ChargeItemCase.SuperReducedVatRate1, "Λοιπά τέλη", false)]
+        [InlineData(ChargeItemCaseTypeOfService.OtherService, ChargeItemCase.ZeroVatRate, "Λοιπά τέλη", false)]
+        /* Special tax item, allowed VAT code + mapped vatable fee */
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NormalVatRate, "Λοιπά τέλη", true)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.DiscountedVatRate1, "Λοιπά τέλη", true)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.SuperReducedVatRate1, "Λοιπά τέλη", true)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.ZeroVatRate, "Λοιπά τέλη", true)]
+        /* Special tax item, allowed VAT code but non-vatable fee */
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NormalVatRate, "Εισφορά δακοκτονίας 2%", false)]
+        /* Special tax item, allowed VAT code but unmapped fee */
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NormalVatRate, "Unknown Fee", false)]
+        /* Special tax item, allowed VAT code, but empty or null description */
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NormalVatRate, "", false)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NormalVatRate, null, false)]
+        /* Special tax item, disallowed VAT code (should return false regardless of description) */
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.ParkingVatRate, "Λοιπά τέλη", false)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.NotTaxable, "Λοιπά τέλη", false)]
+        [InlineData((ChargeItemCaseTypeOfService) 0xF0, ChargeItemCase.UnknownService, "Λοιπά τέλη", false)]
+        public void IsVatableSpecialTaxItem_ShouldReturnExpectedResult(
+            ChargeItemCaseTypeOfService serviceType,
+            ChargeItemCase vatCode,
+            string description,
+            bool expected
+        )
+        {
+            // If you use a WithTypeOfService extension, apply it; else just use the enum value directly.
+            var chargeCase = vatCode.WithTypeOfService(serviceType);
+
+            var chargeItem = new ChargeItem
+            {
+                Description = description,
+                ftChargeItemCase = chargeCase
+            };
+
+            var result = SpecialTaxMappings.IsVatableSpecialTaxItem(chargeItem);
+
+            result.Should().Be(expected, $"serviceType={serviceType}, vatCode={vatCode}, description='{description ?? "null"}'");
+        }
+        #endregion IsVatableSpecialTaxItemTests
     }
 }


### PR DESCRIPTION
{Summary of the changes}

- Implements improved handling of MyData “fee” special taxes—now only specific fee types are eligible for VAT.
- Distinguishes between vatable and non-vatable fees: vatable fees are reported as invoice lines with VAT, while non-vatable fees are reported only at the document level.
- Updates mapping and classification logic to match AADE (MyData) compliance requirements.
- Ensures all legacy and new test scenarios produce XML that is validated and accepted by the MyData platform.
- Currently, the enhancements apply only to “fees”; support for other types of special taxes will be added in future updates.


{Detail}

- Refactored the `GetDocumentLevelTaxes` procedure so that only non-vatable special tax items are aggregated and reported at the document (summary) level; special tax items that are vatable are excluded here, as they are included in the invoice details instead.
- For now, only certain “fee” type special taxes are eligible to be treated as vatable; all other special tax items, including non-vatable fees, continue to be handled as before—reported exclusively in the document `taxTotals`, rather than as invoice lines.
- Updated the `GetInvoiceDetails` procedure:
    - Excludes non-vatable special tax items from invoice lines to prevent MyData validation errors.
    - Handles vatable fee items as separate invoice lines, with correctly calculated VAT, fee categorization, and proper income classification.
- Enhanced mapping and logic for special tax items in `AADEMappings` and `SpecialTaxMappings`:
    - Clearly separates logic for identifying vatable versus non-vatable fees.
    - Maintains defensive checks and exceptions for unsupported or unmapped fee descriptions.
- Expanded and improved unit tests in `SpecialTaxHandlingTests` and `SpecialTaxMappingsTests`:
    - Ensures correct behavior and coverage for all supported fee scenarios.
    - Verifies both legacy and new invoice creation logic.
- All test-generated XML files (from both existing and new scenarios) have been manually uploaded and validated with the MyData platform via Postman, confirming full compliance and absence of business-rule errors.
- Current changes apply only to supported “fees,” except those explicitly excluded in the `NonVatableFeeCodes` hash set (`{ 9, 12, 18, 21 }`); extension for withholdings, stamp duty, and other special taxes will be considered for future releases if needed.

_Fixes fiskaltrust/market-gr#115_
