### PR TITLE
Enable line-level myData overrides for discountOption

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -469,6 +469,23 @@ public class AADEFactory
         }
     }
 
+    private static void ApplyInvoiceDetailsOverride(InvoiceRowType invoiceRow, MyDataOverride overrideData)
+    {
+        if (overrideData?.InvoiceDetails == null)
+        {
+            return;
+        }
+
+        var detailsOverride = overrideData.InvoiceDetails;
+
+        // Apply discountOption override (VAT deduction right)
+        if (detailsOverride.DiscountOption.HasValue)
+        {
+            invoiceRow.discountOption = detailsOverride.DiscountOption.Value;
+            invoiceRow.discountOptionSpecified = true;
+        }
+    }
+
     private static List<TaxTotalsType> GetDocumentLevelTaxes(ReceiptRequest receiptRequest)
     {
         if (AADEMappings.GetInvoiceType(receiptRequest) == InvoiceType.Item82)
@@ -755,6 +772,10 @@ public class AADEFactory
                 invoiceRow.deductionsAmountSpecified = true;
                 invoiceRow.discountOption = true;
                 invoiceRow.discountOptionSpecified = true;
+            }
+            if (x.TryDeserializeftChargeItemCaseData<ftChargeItemCaseDataPayload>(out var chargeItemOverrideData) && chargeItemOverrideData?.GR?.MyDataOverride != null)
+            {
+                ApplyInvoiceDetailsOverride(invoiceRow, chargeItemOverrideData.GR.MyDataOverride);
             }
             return invoiceRow;
         }).ToList();

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Helpers/ReceiptRequestExtensions.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Helpers/ReceiptRequestExtensions.cs
@@ -62,6 +62,28 @@ public static class ReceiptRequestExtensions
         }
     }
 
+    public static bool TryDeserializeftChargeItemCaseData<T>(this ChargeItem chargeItem, out T? result) where T : class
+    {
+        result = default;
+        try
+        {
+            if (chargeItem.ftChargeItemCaseData is null)
+            {
+                return false;
+            }
+            result = JsonSerializer.Deserialize<T>(JsonSerializer.Serialize(chargeItem.ftChargeItemCaseData), new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            });
+            return result != null;
+        }
+        catch (Exception)
+        {
+            result = default;
+            return false;
+        }
+    }
+
     public static List<(ChargeItem chargeItem, List<ChargeItem> modifiers)> GetGroupedChargeItemsModifyPositionsIfNotSet(this ReceiptRequest receiptRequest)
     {
         var data = new List<(ChargeItem chargeItem, List<ChargeItem> modifiers)>();

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
@@ -47,6 +47,40 @@ public class MyDataOverride
     /// </summary>
     [JsonPropertyName("invoice")]
     public InvoiceOverride? Invoice { get; set; }
+
+    /// <summary>
+    /// Invoice details (line-item) overrides (applied via ftChargeItemCaseData)
+    /// </summary>
+    [JsonPropertyName("invoicedetails")]
+    public InvoiceDetailsOverride? InvoiceDetails { get; set; }
+}
+
+public class InvoiceDetailsOverride
+{
+    /// <summary>
+    /// Right to deduct VAT for this line.
+    /// In Greek VAT context, "δικαίωμα έκπτωσης" = whether the VAT of that specific line is deductible (input VAT deduction) for the buyer/recipient.
+    /// </summary>
+    [JsonPropertyName("discountOption")]
+    public bool? DiscountOption { get; set; }
+}
+
+/// <summary>
+/// Payload wrapper for ftChargeItemCaseData - mirrors ftReceiptCaseDataPayload but for charge items.
+/// </summary>
+public class ftChargeItemCaseDataPayload
+{
+    [JsonPropertyName("GR")]
+    public ftChargeItemCaseDataGreekPayload? GR { get; set; }
+}
+
+public class ftChargeItemCaseDataGreekPayload
+{
+    /// <summary>
+    /// MyData override configuration allowing direct control of invoice detail properties per charge item
+    /// </summary>
+    [JsonPropertyName("mydataoverride")]
+    public MyDataOverride? MyDataOverride { get; set; }
 }
 
 public class InvoiceOverride

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataLineItemOverrideTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataLineItemOverrideTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.GR.MyData;
+using fiskaltrust.storage.V0.MasterData;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest;
+
+/// <summary>
+/// Tests for line-item-level mydataoverride via ftChargeItemCaseData.
+/// The discountOption field (δικαίωμα έκπτωσης) indicates whether the
+/// VAT on a given line is deductible for the buyer/recipient. It is NOT
+/// related to price discounts.
+/// </summary>
+public class MyDataLineItemOverrideTests
+{
+    #region Helpers
+    private static AADEFactory CreateFactory() =>
+        new(new MasterDataConfiguration
+        {
+            Account = new AccountMasterData
+            {
+                VatId = "123456789"
+            },
+            Outlet = new OutletMasterData
+            {
+                LocationId = "0"
+            }
+        }, "https://receipts.example.com");
+
+    private static ChargeItem CreateChargeItem(decimal amount, decimal vatRate, object? caseData = null) =>
+        new()
+        {
+            Amount = amount,
+            Quantity = 1,
+            Description = "Test Item",
+            ftChargeItemCase = ((ChargeItemCase)0x4752_2000_0000_0000).WithVat(ChargeItemCase.NormalVatRate),
+            VATRate = vatRate,
+            ftChargeItemCaseData = caseData
+        };
+
+    private static object BuildDiscountOptionOverride(bool value) =>
+        new
+        {
+            GR = new
+            {
+                mydataoverride = new
+                {
+                    invoicedetails = new
+                    {
+                        discountOption = value
+                    }
+                }
+            }
+        };
+
+    private static ReceiptRequest CreateRequest(params ChargeItem[] chargeItems)
+    {
+        var items = new List<ChargeItem>(chargeItems);
+        var totalAmount = 0m;
+        foreach (var item in items)
+        {
+            totalAmount += item.Amount;
+        }
+
+        return new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            Currency = Currency.EUR,
+            cbReceiptMoment = new DateTime(2025, 6, 18, 10, 44, 19, DateTimeKind.Utc),
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            cbChargeItems = items,
+            cbPayItems = new List<PayItem>
+            {
+                new()
+                {
+                    Amount = totalAmount,
+                    ftPayItemCase = (PayItemCase)0x4752_2000_0000_0000
+                }
+            },
+            cbReceiptAmount = totalAmount,
+            ftReceiptCase = ((ReceiptCase)0x4752_2000_0000_0000).WithCase(ReceiptCase.PointOfSaleReceipt0x0001)
+        };
+    }
+
+    private static ReceiptResponse CreateResponse(ReceiptRequest request) =>
+        new()
+        {
+            cbReceiptReference = request.cbReceiptReference,
+            ftReceiptIdentification = "ft123ABC#",
+            ftCashBoxIdentification = "TEST-001"
+        };
+    #endregion
+
+    #region Tests
+    [Fact]
+    public void MapToInvoicesDoc_WithoutOverride_ShouldNotSetDiscountOption()
+    {
+        var factory = CreateFactory();
+        var request = CreateRequest(CreateChargeItem(100, 24));
+        var response = CreateResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        doc!.invoice[0].invoiceDetails[0].discountOptionSpecified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void MapToInvoicesDoc_WithDiscountOptionTrue_ShouldFlagVatAsDeductible()
+    {
+        var factory = CreateFactory();
+        var request = CreateRequest(
+            CreateChargeItem(100, 24, BuildDiscountOptionOverride(true)));
+        var response = CreateResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var line = doc!.invoice[0].invoiceDetails[0];
+        line.discountOptionSpecified.Should().BeTrue();
+        line.discountOption.Should().BeTrue("VAT on this line should be deductible for the buyer");
+    }
+
+    [Fact]
+    public void MapToInvoicesDoc_WithDiscountOptionFalse_ShouldFlagVatAsNonDeductible()
+    {
+        var factory = CreateFactory();
+        var request = CreateRequest(
+            CreateChargeItem(100, 24, BuildDiscountOptionOverride(false)));
+        var response = CreateResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var line = doc!.invoice[0].invoiceDetails[0];
+        line.discountOptionSpecified.Should().BeTrue();
+        line.discountOption.Should().BeFalse("VAT on this line should not be deductible for the buyer");
+    }
+
+    [Fact]
+    public void MapToInvoicesDoc_MultipleItems_OnlyOverriddenLineShouldHaveDiscountOption()
+    {
+        var factory = CreateFactory();
+        var request = CreateRequest(
+            CreateChargeItem(100, 24),
+            CreateChargeItem(50, 24, BuildDiscountOptionOverride(true)));
+        var response = CreateResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var details = doc!.invoice[0].invoiceDetails;
+        details.Should().HaveCount(2);
+        details[0].discountOptionSpecified.Should().BeFalse("first item has no override");
+        details[1].discountOptionSpecified.Should().BeTrue();
+        details[1].discountOption.Should().BeTrue("second item flags VAT as deductible");
+    }
+    #endregion
+}


### PR DESCRIPTION

### **Summary**
This PR enables the `myDataOverride` option at the line level to grant support for the `discountOption` field in myDATA. While header-level overrides are already handled via `ApplyMyDataOverride`

Currently, the only enabled property is `discountOption`, which is used to flag whether the VAT of a specific line is deductible (input VAT deduction) for the buyer/recipient.

### **Technical Details**
* **New Override Classes:** * Added `InvoiceDetailsOverride` to handle line-item specific overrides (currently housing `DiscountOption`).
    * Updated `MyDataOverride` to include an `InvoiceDetails` property mapped to `invoicedetails`.
* **Payload Wrappers:** Introduced `ftChargeItemCaseDataPayload` and `ftChargeItemCaseDataGreekPayload` to allow direct control of invoice detail properties per charge item via the `GR` node.
* **New Method `ApplyInvoiceDetailsOverride`:** Implemented this method to apply the `discountOption` (if it has a value) to the `InvoiceRowType`.
* **Updated `GetInvoiceDetails`:** Modified the mapping logic to attempt deserialization of `ftChargeItemCaseData` into the new payload wrapper. If a line-level myData override is found, it is now passed to `ApplyInvoiceDetailsOverride` right before the invoice row is returned.

**Fixes:** [#130](https://github.com/fiskaltrust/market-gr/issues/130)
