### PR TITLE
#129 - Partially return void a restaurant order 8.6

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -720,6 +720,20 @@ public class AADEFactory
                 netValue = receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund) ? -x.Amount - -vatAmount : x.Amount - vatAmount,
             };
 
+            // Per-item return flag (0x0002) inside an 8.6 order = recType 7
+            var isPartialReturnItem = AADEMappings.GetInvoiceType(receiptRequest) == InvoiceType.Item86
+                                      && x.IsRefund();
+
+            // myDATA spec: for recType=7 lines amounts MUST be positive; myDATA itself treats them as cancellations.
+            if (isPartialReturnItem)
+            {
+                invoiceRow.recType = 7;
+                invoiceRow.recTypeSpecified = true;
+                invoiceRow.quantity = Math.Abs(invoiceRow.quantity);
+                invoiceRow.vatAmount = Math.Abs(invoiceRow.vatAmount);
+                invoiceRow.netValue = Math.Abs(invoiceRow.netValue);
+            }
+
             if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.HasTransportInformation))
             {
                 invoiceRow.quantitySpecified = true;

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -16,6 +16,14 @@ public static class AADEMappings
     {
         var vatAmount = chargeItem.GetVATAmount();
         var netAmount = receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund) ? -chargeItem.Amount - -vatAmount : chargeItem.Amount - vatAmount;
+
+        // Per-item return flag (0x0002) inside an 8.6 order = recType 7
+        // myDATA spec: for recType=7 lines amounts MUST be positive; myDATA itself treats them as cancellations
+        if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) && chargeItem.IsRefund())
+        {
+            netAmount = Math.Abs(netAmount);
+        }
+
         if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) || receiptRequest.ftReceiptCase.IsCase(ReceiptCase.PaymentTransfer0x0002))
         {
             return new IncomeClassificationType

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/CancelInvoiceValidationTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/CancelInvoiceValidationTests.cs
@@ -336,7 +336,7 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             var (doc, error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse);
 
             error.Should().NotBeNull();
-            error.Exception.Message.Should().Contain("MultipleConnectedMarks");
+            error.Exception.Message.Should().Contain("cbPreviousReceiptReference");
             doc.Should().BeNull();
         }
 

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/PartiallyCancelInvoiceValidationTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/PartiallyCancelInvoiceValidationTests.cs
@@ -1,0 +1,258 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
+{   
+    /// <summary>
+    /// Tests for partial return/cancellation of individual lines within a restaurant order (8.6).
+    /// A partial return is signalled per charge item via ChargeItemCaseFlags.Refund (0x0002),
+    /// NOT by a receipt-level Void or Refund flag.
+    /// myDATA spec: recType=7 lines must carry positive amounts; myDATA treats them as cancellations.
+    /// </summary>
+    public class PartiallyCancelInvoiceValidationTests
+    {
+        //
+        // Test 1:
+        // A single returned line in an 8.6 order must produce recType=7 with positive amounts.
+        //
+        [Fact]
+        public void MapToInvoicesDoc_Order86_SingleReturnedLine_SetsRecType7WithPositiveAmounts()
+        {
+            var receiptRequest = new ReceiptRequest
+            {
+                // 8.6 order — NO Void flag on the receipt
+                ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000)
+                    .WithCase(ReceiptCase.Order0x3004),
+                cbTerminalID = "1",
+                Currency = Currency.EUR,
+                cbReceiptMoment = DateTime.UtcNow,
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbArea = "1",
+                cbPreviousReceiptReference = "Previous-Reference",
+                ftPosSystemId = Guid.NewGuid(),
+                cbChargeItems = new List<ChargeItem>
+                {
+                    new ChargeItem
+                    {
+                        Position         = 1,
+                        Quantity         = 1,
+                        Description      = "Bottle of wine",
+                        Amount           = 12.40m,
+                        VATRate          = 24m,
+                        VATAmount        = 2.40m,
+                        // ftChargeItemCase 0x0000_2000_0002_0013 — 0x0002 = return flag
+                        ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0013)
+                            .WithFlag(ChargeItemCaseFlags.Refund)
+                    }
+                },
+                cbPayItems = new List<PayItem>()
+            };
+
+            var receiptResponse = new ReceiptResponse
+            {
+                cbReceiptReference      = receiptRequest.cbReceiptReference,
+                ftCashBoxIdentification = "CB001",
+                ftReceiptIdentification = "ft123#"
+            };
+            var aadeFactory = new AADEFactory(MockMasterData(), "https://test.receipts.example.com");
+
+            var (docInvoice, error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse);
+
+            using (new AssertionScope())
+            {
+                error.Should().BeNull();
+                docInvoice.Should().NotBeNull();
+
+                var invoice = docInvoice!.invoice[0];
+
+                // header must still be a normal 8.6, NOT a full void
+                invoice.invoiceHeader.invoiceType.Should().Be(InvoiceType.Item86);
+                invoice.invoiceHeader.totalCancelDeliveryOrders.Should().BeFalse(
+                    "partial return must not trigger full void behaviour");
+                invoice.invoiceHeader.tableAA.Should().Be("1");
+
+                var line = invoice.invoiceDetails.Single();
+                line.recTypeSpecified.Should().BeTrue();
+                line.recType.Should().Be(7);
+                line.netValue.Should().BePositive("myDATA requires positive amounts for recType=7");
+                line.vatAmount.Should().BePositive();
+                line.quantity.Should().BePositive();
+                line.itemDescr.Should().Be("Bottle of wine");
+                line.incomeClassification.Should().NotBeNull();
+                line.incomeClassification.Should().AllSatisfy(c =>
+                    c.amount.Should().BePositive("myDATA requires positive incomeClassification amount for recType=7"));
+            }
+        }
+
+        //
+        // Test 2:
+        // Mixed order: normal lines must NOT have recType set; only the returned line gets recType=7.
+        //
+        [Fact]
+        public void MapToInvoicesDoc_Order86_MixedLines_OnlyReturnedLineHasRecType7()
+        {
+            var receiptRequest = new ReceiptRequest
+            {
+                ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000)
+                    .WithCase(ReceiptCase.Order0x3004),
+                cbTerminalID = "1",
+                Currency = Currency.EUR,
+                cbReceiptMoment = DateTime.UtcNow,
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbArea = "1",
+                cbPreviousReceiptReference = "Previous-Reference",
+                ftPosSystemId = Guid.NewGuid(),
+                cbChargeItems = new List<ChargeItem>
+                {
+                    // Normal line
+                    new ChargeItem
+                    {
+                        Position         = 1,
+                        Quantity         = 2,
+                        Description      = "Pizza Margherita",
+                        Amount           = 16.00m,
+                        VATRate          = 24m,
+                        VATAmount        = decimal.Round(16m / 124m * 24m, 2),
+                        ftChargeItemCase = (ChargeItemCase) 0x4752_2000_0000_0013
+                    },
+                    // Returned line
+                    new ChargeItem
+                    {
+                        Position         = 2,
+                        Quantity         = 1,
+                        Description      = "Bottle of wine",
+                        Amount           = 12.40m,
+                        VATRate          = 24m,
+                        VATAmount        = 2.40m,
+                        ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0013)
+                            .WithFlag(ChargeItemCaseFlags.Refund)
+                    }
+                },
+                cbPayItems = new List<PayItem>()
+            };
+
+            var receiptResponse = new ReceiptResponse
+            {
+                cbReceiptReference      = receiptRequest.cbReceiptReference,
+                ftCashBoxIdentification = "CB001",
+                ftReceiptIdentification = "ft123#"
+            };
+            var aadeFactory = new AADEFactory(MockMasterData(), "https://test.receipts.example.com");
+
+            var (docInvoice, error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse);
+
+            using (new AssertionScope())
+            {
+                error.Should().BeNull();
+                docInvoice.Should().NotBeNull();
+
+                var invoice = docInvoice!.invoice[0];
+
+                // header must still be a normal 8.6, NOT a full void
+                invoice.invoiceHeader.invoiceType.Should().Be(InvoiceType.Item86);
+                invoice.invoiceHeader.totalCancelDeliveryOrders.Should().BeFalse(
+                    "partial return must not trigger full void behaviour");
+                invoice.invoiceHeader.tableAA.Should().Be("1");
+
+                var details = invoice.invoiceDetails;
+                details.Should().HaveCount(2);
+
+                var normalLine = details.Single(d => d.lineNumber == 1);
+                normalLine.recTypeSpecified.Should().BeFalse("normal lines must not carry recType");
+
+                var returnLine = details.Single(d => d.lineNumber == 2);
+                returnLine.recTypeSpecified.Should().BeTrue();
+                returnLine.recType.Should().Be(7);
+                returnLine.netValue.Should().BePositive();
+                returnLine.vatAmount.Should().BePositive();
+                returnLine.quantity.Should().BePositive();
+                returnLine.incomeClassification.Should().NotBeNull();
+                returnLine.incomeClassification.Should().AllSatisfy(c =>
+                    c.amount.Should().BePositive("myDATA requires positive incomeClassification amount for recType=7"));
+            }
+        }
+
+        //
+        // Test 3:
+        // Amounts sent as negative in the payload (e.g. from VIVA).
+        // Math.Abs() must normalise them to positive as required by myDATA for recType=7.
+        //
+        [Fact]
+        public void MapToInvoicesDoc_Order86_ReturnedLineWithNegativeAmounts_OutputsPositiveAmounts()
+        {
+            var receiptRequest = new ReceiptRequest
+            {
+                ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000)
+                    .WithCase(ReceiptCase.Order0x3004),
+                cbTerminalID = "1",
+                Currency = Currency.EUR,
+                cbReceiptMoment = DateTime.UtcNow,
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbArea = "1",
+                cbPreviousReceiptReference = "Previous-Reference",
+                ftPosSystemId = Guid.NewGuid(),
+                cbChargeItems = new List<ChargeItem>
+                {
+                    new ChargeItem
+                    {
+                        Position         = 1,
+                        Quantity         = -1,      // negative — POS sent it this way
+                        Description      = "Bottle of wine",
+                        Amount           = -12.40m, // negative — POS sent it this way
+                        VATRate          = 24m,
+                        VATAmount        = -2.40m,  // negative — POS sent it this way
+                        ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0013)
+                            .WithFlag(ChargeItemCaseFlags.Refund)
+                    }
+                },
+                cbPayItems = new List<PayItem>()
+            };
+
+            var receiptResponse = new ReceiptResponse
+            {
+                cbReceiptReference      = receiptRequest.cbReceiptReference,
+                ftCashBoxIdentification = "CB001",
+                ftReceiptIdentification = "ft123#"
+            };
+            var aadeFactory = new AADEFactory(MockMasterData(), "https://test.receipts.example.com");
+
+            var (docInvoice, error) = aadeFactory.MapToInvoicesDoc(receiptRequest, receiptResponse);
+
+            using (new AssertionScope())
+            {
+                error.Should().BeNull();
+                docInvoice.Should().NotBeNull();
+
+                var invoice = docInvoice!.invoice[0];
+
+                invoice.invoiceHeader.invoiceType.Should().Be(InvoiceType.Item86);
+                invoice.invoiceHeader.totalCancelDeliveryOrders.Should().BeFalse(
+                    "partial return must not trigger full void behaviour");
+                invoice.invoiceHeader.tableAA.Should().Be("1");
+
+                var line = invoice.invoiceDetails.Single();
+                line.recTypeSpecified.Should().BeTrue();
+                line.recType.Should().Be(7);
+                // Math.Abs() normalises negative payload values to positive for myDATA
+                line.netValue.Should().BePositive("myDATA requires positive amounts for recType=7");
+                line.vatAmount.Should().BePositive();
+                line.quantity.Should().BePositive();
+                line.incomeClassification.Should().NotBeNull();
+                line.incomeClassification.Should().AllSatisfy(c =>
+                    c.amount.Should().BePositive("myDATA requires positive incomeClassification amount for recType=7"));
+            }
+        }
+
+        private static storage.V0.MasterData.MasterDataConfiguration MockMasterData() =>
+            new storage.V0.MasterData.MasterDataConfiguration
+            {
+                Account = new storage.V0.MasterData.AccountMasterData { VatId = "112545020" }
+            };
+    }
+}


### PR DESCRIPTION
{Summary of the changes}
Forward recType=7 to myDATA for partial cancellation of restaurant order lines (8.6).
When a restaurant order (type 8.6) contains individual charge items flagged as returned
(ChargeItemCaseFlags.Refund / 0x0002), the middleware now correctly sets recType=7 on
those lines and guarantees all amounts are positive, as required by myDATA.
Previously the recType field was never set, causing myDATA to treat returned
lines as normal order lines.

{Detail}
I added the per-item return detection in **AADEFactory.cs** -> **GetInvoiceDetails()**,
where **isPartialReturnItem** is evaluated as **InvoiceType.Item86** && **chargeItem.IsRefund()**.
When true, **recType=7** and **recTypeSpecified=true** are set on the **InvoiceRowType**,
and **Math.Abs()** is applied to **quantity**, **vatAmount** and **netValue** to guarantee
positive values regardless of the sign the POS sends
(e.g. VIVA sends negative amounts with the refund flag).

I fixed **AADEMappings.cs** -> **GetIncomeClassificationType()** to also apply **Math.Abs()**
on **netAmount** for partial return lines in 8.6 orders.
Without this, **incomeClassification.amount** in the generated XML was negative,
which caused myDATA to reject the payload.

I added the **PartiallyCancelInvoiceValidationTests** unit test class with three scenarios:

- Scenario 1: **MapToInvoicesDoc_Order86_SingleReturnedLine_SetsRecType7WithPositiveAmounts**
  A single returned item with positive payload. The POS sends the item with
  **ChargeItemCaseFlags.Refund** and positive amounts.
  Asserts **recType=7**, positive **netValue**, **vatAmount**, **quantity**,
  positive **incomeClassification.amount**, and correct invoice header.

- Scenario 2: **MapToInvoicesDoc_Order86_MixedLines_OnlyReturnedLineHasRecType7**
  A mixed order with one normal line and one returned line.
  Asserts that only the flagged line gets **recType=7**,
  the normal line has no **recType**, and all amounts on the returned
  line are positive including **incomeClassification.amount**.

- Scenario 3: **MapToInvoicesDoc_Order86_ReturnedLineWithNegativeAmounts_OutputsPositiveAmounts**
  A returned item where the POS sends negative amounts (e.g. VIVA-style).
  Asserts that **Math.Abs()** normalises all values to positive
  as required by myDATA for **recType=7** lines.

The existing full-void path (**ReceiptCaseFlags.Void** -> **GetInvoiceDetailsForVoid**)
and all tests in **CancelInvoiceValidationTests** are untouched.

Fixes [#129]([Partially return/void a restaturnat order 8.6 · Issue #129 · fiskaltrust/market-gr](https://github.com/fiskaltrust/market-gr/issues/129))
