### PR TITLE
#636 Add subtotal Discount / Surcharge

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
@@ -61,9 +61,9 @@ public static class ReceiptCaseHelper
 
     public static bool IsMultiUseVoucher(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0000_00FF) == 0x48;
     
-    public static bool IsSubtotalDiscount(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0001_0000_0000;
+    public static bool IsSubtotalDiscount(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0100_0000_0000;
 
-    public static bool IsSubtotalSurcharge(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0002_0000_0000;
+    public static bool IsSubtotalSurcharge(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0200_0000_0000;
 
     public static bool IsRefund(this PayItem payItem) => (payItem.ftPayItemCase & 0x0000_0000_0002_0000) > 0x0000;
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
@@ -60,6 +60,10 @@ public static class ReceiptCaseHelper
     public static bool IsSingleUseVoucher(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0000_00F0) == 0x40 && !IsMultiUseVoucher(chargeItem);
 
     public static bool IsMultiUseVoucher(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0000_00FF) == 0x48;
+    
+    public static bool IsSubtotalDiscount(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0001_0000_0000;
+
+    public static bool IsSubtotalSurcharge(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0002_0000_0000;
 
     public static bool IsRefund(this PayItem payItem) => (payItem.ftPayItemCase & 0x0000_0000_0002_0000) > 0x0000;
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -307,6 +307,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             var fiscalReceipt = new FiscalReceipt();
             fiscalReceipt.ItemAndMessages = GetItemAndMessages(receiptRequest);
             fiscalReceipt.AdjustmentAndMessages = new List<AdjustmentAndMessage>();
+            fiscalReceipt.PrintRecSubtotalAdjustment = GetSubtotalAdjustments(receiptRequest);
             fiscalReceipt.RecTotalAndMessages = GetTotalAndMessages(receiptRequest);
             var customerData = receiptRequest.GetCustomer();
             if (customerData != null)
@@ -603,6 +604,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 // Todo handle payment adjustments / discounts
                 foreach (var i in receiptRequest.cbChargeItems)
                 {
+                    if (i.IsSubtotalDiscount() || i.IsSubtotalSurcharge())
+                        continue;
                     GenerateItems(itemAndMessages, i);
                 }
             }
@@ -700,6 +703,35 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             }
         }
 
+        public static List<PrintRecSubtotalAdjustment> GetSubtotalAdjustments(ReceiptRequest receiptRequest)
+        {
+            var adjustments = new List<PrintRecSubtotalAdjustment>();
+            foreach (var i in receiptRequest.cbChargeItems)
+            {
+                if (i.IsSubtotalDiscount())
+                {
+                    adjustments.Add(new PrintRecSubtotalAdjustment
+                    {
+                        Description = i.Description,
+                        Amount = Math.Abs(i.Amount),
+                        AdjustmentType = 1,
+                        Justification = 1
+                    });
+                }
+                else if (i.IsSubtotalSurcharge())
+                {
+                    adjustments.Add(new PrintRecSubtotalAdjustment
+                    {
+                        Description = i.Description,
+                        Amount = Math.Abs(i.Amount),
+                        AdjustmentType = 6,
+                        Justification = 1
+                    });
+                }
+            }
+            return adjustments.Count > 0 ? adjustments : null;
+        }
+
         public static List<TotalAndMessage> GetTotalAndMessages(ReceiptRequest request)
         {
             var totalAndMessages = new List<TotalAndMessage>();
@@ -711,7 +743,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                     Description = pay.Description,
                     PaymentType = paymentType.PaymentType,
                     Index = paymentType.Index,
-                    Payment = (request.IsRefund() || request.IsVoid() || pay.IsRefund() || pay.IsVoid()) ? Math.Abs(pay.Amount) : pay.Amount,
+                    Payment = (request.IsRefund() || request.IsVoid() || pay.IsRefund() || pay.IsVoid() || pay.Amount < 0) ? Math.Abs(pay.Amount) : pay.Amount,
                 };
                 PrintRecMessage? printRecMessage = null;
                 totalAndMessages.Add(new()


### PR DESCRIPTION
- Improve for EpsonRT Printer "Sconto a subtotale"
- Fix negative import sent to Printer

- Added support for subtotal-level discounts and surcharges in the Epson RT printer fiscal receipt generation.             
- Fixed GetTotalAndMessages() to use Math.Abs() for negative payment amounts, ensuring correct handling when discounts cause negative pay item values  

#636 #638 