### PR TITLE
Fix #100 - Reverse delivery note

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -229,6 +229,13 @@ public class AADEFactory
         {
             // It looks like Item93 does NOT allow to specify the currency
             inv.invoiceHeader.currencySpecified = false;
+
+            // Reverse delivery note: 9.3 + ReceiptCaseFlags.Refund on the receipt case
+            if (receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund))
+            {
+                inv.invoiceHeader.reverseDeliveryNote = true;
+                inv.invoiceHeader.reverseDeliveryNoteSpecified = true;
+            }
         }
 
         var isVoidFlag = receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Void);
@@ -480,6 +487,22 @@ public class AADEFactory
                 invoice.invoiceHeader.otherDeliveryNoteHeader.completeShippingBranch = headerOverride.OtherDeliveryNoteHeader.CompleteShippingBranch.Value;
                 invoice.invoiceHeader.otherDeliveryNoteHeader.completeShippingBranchSpecified = true;
             }
+        }
+
+        // Apply reverse delivery note purpose only when reverseDeliveryNote is already set (9.3 + Refund flag was set earlier in CreateInvoiceDocType)
+        if (invoice.invoiceHeader.invoiceType == InvoiceType.Item93
+            && invoice.invoiceHeader.reverseDeliveryNote)
+        { 
+            if (!headerOverride.ReverseDeliveryNotePurpose.HasValue)
+            {
+                throw new ArgumentException(
+                    "reverseDeliveryNotePurpose is mandatory for reverse delivery note ",
+                    nameof(headerOverride.ReverseDeliveryNotePurpose));
+            }
+
+            invoice.invoiceHeader.reverseDeliveryNotePurpose =
+               AADEMappings.GetReverseDeliveryNotePurpose(headerOverride.ReverseDeliveryNotePurpose.Value);
+            invoice.invoiceHeader.reverseDeliveryNotePurposeSpecified = true;
         }
     }
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -640,4 +640,21 @@ public static class AADEMappings
             _ => MyDataMeasurementUnit.Pieces
         };
     }
+
+
+    /// <summary>
+    /// Valid values: 1-NOT OBLIGED TO ISSUE, 2-REFUSAL/CLERICAL ERROR,
+    /// 3-INTRA-COMMUNITY ACQUISITION, 4-THIRD COUNTRY ACQUISITION, 5-REVERSAL OF OBLIGATION
+    /// </summary>
+    public static int GetReverseDeliveryNotePurpose(int purpose)
+    {
+        if (purpose < 1 || purpose > 5)
+        {
+            throw new Exception(
+                $"Invalid reverseDeliveryNotePurpose value '{purpose}'. " +
+                "Allowed values: 1-NOT OBLIGED TO ISSUE, 2-REFUSAL/CLERICAL ERROR, " +
+                "3-INTRA-COMMUNITY ACQUISITION, 4-THIRD COUNTRY ACQUISITION, 5-REVERSAL OF OBLIGATION.");
+        }
+        return purpose;
+    }
 }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
@@ -132,6 +132,15 @@ public class InvoiceHeaderOverride
     /// </summary>
     [JsonPropertyName("otherMovePurposeTitle")]
     public string? OtherMovePurposeTitle { get; set; }
+
+    /// <summary>
+    /// Reason for issuing a reverse delivery note (9.3 only).
+    /// Valid values: 
+    /// 1-NOT OBLIGED TO ISSUE, 2-REFUSAL/CLERICAL ERROR,
+    /// 3-INTRA-COMMUNITY ACQUISITION, 4-THIRD COUNTRY ACQUISITION, 5-REVERSAL OF OBLIGATION
+    /// </summary>
+    [JsonPropertyName("reverseDeliveryNotePurpose")]
+    public int? ReverseDeliveryNotePurpose { get; set; }
 }
 
 public class OtherDeliveryNoteHeaderOverride

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsReverseDeliveryNotePurposeTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsReverseDeliveryNotePurposeTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using fiskaltrust.Middleware.SCU.GR.MyData;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest.SCU.MyData;
+
+public class AADEMappingsReverseDeliveryNotePurposeTests
+{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void GetReverseDeliveryNotePurpose_ValidValues_ShouldReturnSameValue(int purpose)
+    {
+        var result = AADEMappings.GetReverseDeliveryNotePurpose(purpose);
+
+        result.Should().Be(purpose);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(6)]
+    [InlineData(-1)]
+    [InlineData(100)]
+    public void GetReverseDeliveryNotePurpose_InvalidValues_ShouldThrow(int invalidPurpose)
+    {
+        var act = () => AADEMappings.GetReverseDeliveryNotePurpose(invalidPurpose);
+
+        act.Should().Throw<Exception>()
+            .WithMessage($"*{invalidPurpose}*");
+    }
+}

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/ReverseDeliveryNoteValidationTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/ReverseDeliveryNoteValidationTests.cs
@@ -1,0 +1,438 @@
+﻿using System;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.GR.Abstraction;
+using fiskaltrust.Middleware.SCU.GR.MyData;
+using fiskaltrust.Middleware.SCU.GR.MyData.Helpers;
+using fiskaltrust.Middleware.SCU.GR.MyData.Models;
+using fiskaltrust.storage.V0.MasterData;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest;
+
+public class ReverseDeliveryNoteValidationTests
+{
+    private static readonly MasterDataConfiguration _masterData = new()
+    {
+        Account = new AccountMasterData { VatId = "112545020", AccountName = "Test Company" },
+        Outlet = new OutletMasterData { LocationId = "1", Street = "Test Street", City = "Athens", Zip = "12345" }
+    };
+
+    private static readonly AADEFactory _factory = new(_masterData, "https://test.receipts.example.com");
+
+    private static readonly MiddlewareCustomer _greekCustomer = new()
+    {
+        CustomerVATId = "026883248",
+        CustomerName = "Πελάτης A.E.",
+        CustomerStreet = "Κηφισίας 12",
+        CustomerZip = "12345",
+        CustomerCity = "Αθηνών",
+        CustomerCountry = "GR"
+    };
+
+    private static ReceiptResponse CreateResponse() => new()
+    {
+        cbReceiptReference = Guid.NewGuid().ToString(),
+        ftReceiptIdentification = "ft1#",
+        ftCashBoxIdentification = "TEST-001",
+        ftQueueID = Guid.NewGuid(),
+        ftQueueItemID = Guid.NewGuid()
+    };
+
+    /// <summary>
+    /// Builds the ftReceiptCase for a reverse delivery note (9.3).
+    /// 0x0500 = HasTransportInformation (0x0400) + Refund (0x0100) — matches spec ftReceiptCase: 0x0000_2000_0500_0005
+    /// </summary>
+    private static ReceiptCase CreateReverseDeliveryReceiptCase() =>
+        ((ReceiptCase) 0x4752_2000_0000_0000)
+            .WithCase(ReceiptCase.DeliveryNote0x0005)
+            .WithFlag(ReceiptCaseFlagsGR.HasTransportInformation)
+            .WithFlag(ReceiptCaseFlags.Refund);
+
+    /// <summary>
+    /// Builds the ftReceiptCase for a normal (non-reverse) 9.3 delivery note.
+    /// No ReceiptCaseFlags.Refund — reverseDeliveryNote must NOT be set.
+    /// </summary>
+    private static ReceiptCase CreateNormalDeliveryReceiptCase() =>
+        ((ReceiptCase) 0x4752_2000_0000_0000)
+            .WithCase(ReceiptCase.DeliveryNote0x0005)
+            .WithFlag(ReceiptCaseFlagsGR.HasTransportInformation);
+
+    /// <summary>
+    /// ftReceiptCaseData must be assigned as an object (NOT JsonSerializer.Serialize'd string)
+    /// because TryDeserializeftReceiptCaseData calls JsonSerializer.Serialize(ftReceiptCaseData)
+    /// internally — if ftReceiptCaseData is already a string it gets double-encoded.
+    /// </summary>
+    private static object BuildCaseData(int reverseDeliveryNotePurpose) => new
+    {
+        GR = new
+        {
+            mydataoverride = new
+            {
+                invoice = new
+                {
+                    invoiceHeader = new
+                    {
+                        dispatchDate = "2026-02-05T10:47:18Z",
+                        dispatchTime = "2026-02-05T10:47:18Z",
+                        movePurpose = 1,
+                        reverseDeliveryNotePurpose,
+                        otherDeliveryNoteHeader = new
+                        {
+                            loadingAddress = new { street = "Παπαδιαμάντη 24", number = "0", postalCode = "56429", city = "Νέα Ευκαρπία" },
+                            deliveryAddress = new { street = "ΝΕΟΧΩΡΟΥΔΑ", number = "0", postalCode = "54500", city = "ΑΝΘΟΚΗΠΟΙ" },
+                            startShippingBranch = 0,
+                            completeShippingBranch = 0
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    /// <summary>
+    /// fiskaltrust caller sends Quantity negative (e.g. -1).
+    /// Factory applies -x.Quantity via ReceiptCaseFlags.Refund → myDATA receives positive value.
+    /// </summary>
+    private static ReceiptRequest CreateReverseDeliveryNoteReceiptCase(int? reverseDeliveryNotePurpose = null)
+    {
+        return new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            cbReceiptMoment = DateTime.UtcNow,
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCaseData = reverseDeliveryNotePurpose.HasValue
+                ? BuildCaseData(reverseDeliveryNotePurpose.Value)
+                : null,
+            ftReceiptCase = CreateReverseDeliveryReceiptCase(),
+            cbCustomer = _greekCustomer,
+            cbChargeItems =
+            [
+                new ChargeItem
+                {
+                    Position = 1,
+                    Description = "Tablet return",
+                    Amount = 0,
+                    Quantity = -1,  // fiskaltrust caller sends negative — factory negates → myDATA receives +1
+                    VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                        .WithFlag(ChargeItemCaseFlags.Refund)
+                }
+            ],
+            cbPayItems = []
+        };
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_WithRefundFlag_ShouldSetReverseDeliveryNoteTrue()
+    {
+        // ReceiptCaseFlags.Refund on ftReceiptCase (0x0500) drives reverseDeliveryNote = true
+        var request = CreateReverseDeliveryNoteReceiptCase();
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        using var _ = new AssertionScope();
+        error.Should().BeNull();
+        invoiceDoc.Should().NotBeNull();
+        var header = invoiceDoc!.invoice[0].invoiceHeader;
+        header.invoiceType.Should().Be(InvoiceType.Item93);
+        header.reverseDeliveryNote.Should().BeTrue("ReceiptCaseFlags.Refund on ftReceiptCase must set reverseDeliveryNote = true");
+        header.reverseDeliveryNoteSpecified.Should().BeTrue();
+        header.currencySpecified.Should().BeFalse("9.3 does not allow currency");
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_WithoutRefundFlag_ShouldNotSetReverseDeliveryNote()
+    {
+        // Normal 9.3 — NO ReceiptCaseFlags.Refund on ftReceiptCase
+        var request = new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            cbReceiptMoment = DateTime.UtcNow,
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCase = CreateNormalDeliveryReceiptCase(),
+            cbCustomer = _greekCustomer,
+            cbChargeItems =
+            [
+                new ChargeItem
+                {
+                    Position = 1, Description = "Tablet", Amount = 0, Quantity = 1, VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                }
+            ],
+            cbPayItems = []
+        };
+
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        error.Should().BeNull();
+        invoiceDoc!.invoice[0].invoiceHeader.reverseDeliveryNoteSpecified.Should().BeFalse(
+            "reverseDeliveryNote must not be set when ReceiptCaseFlags.Refund is absent from ftReceiptCase");
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_WithPurposeOverride_ShouldSetReverseDeliveryNotePurpose()
+    {
+        var request = CreateReverseDeliveryNoteReceiptCase(reverseDeliveryNotePurpose: 5);
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        using var _ = new AssertionScope();
+        error.Should().BeNull();
+        invoiceDoc.Should().NotBeNull();
+        var header = invoiceDoc!.invoice[0].invoiceHeader;
+        header.reverseDeliveryNote.Should().BeTrue();
+        header.reverseDeliveryNoteSpecified.Should().BeTrue();
+        header.reverseDeliveryNotePurpose.Should().Be(5);
+        header.reverseDeliveryNotePurposeSpecified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_ChargeItemQuantities_ShouldBePositiveInXmlPayload()
+    {
+        // fiskaltrust caller sends Quantity = -1 (negative)
+        // factory applies -x.Quantity via ReceiptCaseFlags.Refund → myDATA receives +1 (positive)
+        var request = CreateReverseDeliveryNoteReceiptCase(reverseDeliveryNotePurpose: 5);
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        error.Should().BeNull();
+        invoiceDoc!.invoice[0].invoiceDetails[0].quantity.Should().BeGreaterThan(0,
+            "factory negates quantity via ReceiptCaseFlags.Refund — myDATA requires positive values");
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_PurposeNotApplied_WhenReverseDeliveryNoteNotSet()
+    {
+        // Purpose override is ignored when reverseDeliveryNote is not set
+        // (i.e. ReceiptCaseFlags.Refund is absent from ftReceiptCase)
+        var request = new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            cbReceiptMoment = DateTime.UtcNow,
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCaseData = new
+            {
+                GR = new { mydataoverride = new { invoice = new { invoiceHeader = new { dispatchDate = "2026-02-05T10:47:18Z", dispatchTime = "2026-02-05T10:47:18Z", movePurpose = 1, reverseDeliveryNotePurpose = 3 } } } }
+            },
+            ftReceiptCase = CreateNormalDeliveryReceiptCase(), // NO Refund flag
+            cbCustomer = _greekCustomer,
+            cbChargeItems =
+            [
+                new ChargeItem
+                {
+                    Position = 1, Description = "Tablet", Amount = 0, Quantity = 1, VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                }
+            ],
+            cbPayItems = []
+        };
+
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        using var _ = new AssertionScope();
+        error.Should().BeNull();
+        var header = invoiceDoc!.invoice[0].invoiceHeader;
+        header.reverseDeliveryNoteSpecified.Should().BeFalse("no Refund flag on ftReceiptCase → reverseDeliveryNote not set");
+        header.reverseDeliveryNotePurposeSpecified.Should().BeFalse("purpose is not applied when reverseDeliveryNote is not set");
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_GeneratedXml_ShouldContainCorrectTags()
+    {
+        var request = CreateReverseDeliveryNoteReceiptCase(reverseDeliveryNotePurpose: 5);
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+        var xml = AADEFactory.GenerateInvoicePayload(invoiceDoc!);
+
+        using var _ = new AssertionScope();
+        error.Should().BeNull();
+        xml.Should().Contain("<reverseDeliveryNote>true</reverseDeliveryNote>");
+        xml.Should().Contain("<reverseDeliveryNotePurpose>5</reverseDeliveryNotePurpose>");
+        xml.Should().Contain("<invoiceType>9.3</invoiceType>");
+        xml.Should().NotContain("<currency>", "9.3 must not have currency");
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_WithRefundFlag_AndMissingPurpose_ShouldReturnError()
+    {
+        // AADE rule: reverseDeliveryNotePurpose is mandatory when reverseDeliveryNote = true
+        // Override present but reverseDeliveryNotePurpose intentionally omitted
+        var request = new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            cbReceiptMoment = DateTime.UtcNow,
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCase = CreateReverseDeliveryReceiptCase(),
+            ftReceiptCaseData = new
+            {
+                GR = new
+                {
+                    mydataoverride = new
+                    {
+                        invoice = new
+                        {
+                            invoiceHeader = new
+                            {
+                                dispatchDate = "2026-02-05T10:47:18Z",
+                                dispatchTime = "2026-02-05T10:47:18Z",
+                                movePurpose = 1
+                                // reverseDeliveryNotePurpose intentionally omitted
+                            }
+                        }
+                    }
+                }
+            },
+            cbCustomer = _greekCustomer,
+            cbChargeItems =
+            [
+                new ChargeItem
+                {
+                    Position = 1, Description = "Tablet return", Amount = 0, Quantity = -1, VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                        .WithFlag(ChargeItemCaseFlags.Refund)
+                }
+            ],
+            cbPayItems = []
+        };
+
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+
+        error.Should().NotBeNull("reverseDeliveryNotePurpose is mandatory when reverseDeliveryNote = true");
+        invoiceDoc.Should().BeNull();
+    }
+
+    [Fact]
+    public void ReverseDeliveryNote_SpecExample_GenerateXmlForManualMyDataValidation()
+    {
+        var request = new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            cbReceiptMoment = DateTime.UtcNow,
+            cbReceiptReference = "1234",
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCase = CreateReverseDeliveryReceiptCase(), // 0x0000_2000_0500_0005
+            cbCustomer = new MiddlewareCustomer
+            {
+                CustomerVATId = "026883248",
+                CustomerName = "Πελάτης A.E.",
+                CustomerStreet = "Κηφισίας 12",
+                CustomerZip = "12345",
+                CustomerCity = "Αθηνών",
+                CustomerCountry = "GR"
+            },
+            ftReceiptCaseData = new
+            {
+                GR = new
+                {
+                    mydataoverride = new
+                    {
+                        invoice = new
+                        {
+                            invoiceHeader = new
+                            {
+                                dispatchDate = "2026-11-27T15:22:07Z",
+                                dispatchTime = "2026-11-27T15:22:07Z",
+                                movePurpose = 1,
+                                vehicleNumber = "ΝΒΧ8311",
+                                reverseDeliveryNotePurpose = 5,
+                                otherDeliveryNoteHeader = new
+                                {
+                                    loadingAddress = new { street = "Παπαδιαμάντη 24", number = "0", postalCode = "56429", city = "Νέα Ευκαρπία - Θεσσαλονίκη" },
+                                    deliveryAddress = new { street = "ΙΚΤΙΝΟΥ 22", number = "0", postalCode = "54622", city = "ΘΕΣΣΑΛΟΝΙΚΗ" },
+                                    startShippingBranch = 0,
+                                    completeShippingBranch = 0
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            cbChargeItems =
+            [
+                new ChargeItem
+                {
+                    Position = 1,
+                    Description = "Tablet",
+                    Amount = 0,
+                    Quantity = -1,  // fiskaltrust caller sends negative — factory negates → myDATA receives +1
+                    VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                        .WithFlag(ChargeItemCaseFlags.Refund)
+                },
+                new ChargeItem
+                {
+                    Position = 2,
+                    Description = "Laptop",
+                    Amount = 0,
+                    Quantity = -7,  // fiskaltrust caller sends negative — factory negates → myDATA receives +7
+                    VATRate = 0,
+                    ftChargeItemCase = ((ChargeItemCase) 0x4752_2000_0000_0000)
+                        .WithVat(ChargeItemCase.NotTaxable)
+                        .WithFlag(ChargeItemCaseFlags.Refund)
+                }
+            ],
+            cbPayItems = []
+        };
+
+        var (invoiceDoc, error) = _factory.MapToInvoicesDoc(request, CreateResponse());
+        var xml = AADEFactory.GenerateInvoicePayload(invoiceDoc!);
+
+        // Validated successfully against myDATA sandbox — XML was accepted by AADE API
+        using var _ = new AssertionScope();
+        error.Should().BeNull("spec example must map without errors");
+        invoiceDoc.Should().NotBeNull();
+
+        var header = invoiceDoc!.invoice[0].invoiceHeader;
+
+        // Invoice type must be 9.3
+        header.invoiceType.Should().Be(InvoiceType.Item93);
+
+        // reverseDeliveryNote must be true — driven by ReceiptCaseFlags.Refund on ftReceiptCase
+        header.reverseDeliveryNote.Should().BeTrue();
+        header.reverseDeliveryNoteSpecified.Should().BeTrue();
+
+        // reverseDeliveryNotePurpose = 5 (REVERSAL OF OBLIGATION) — from override
+        header.reverseDeliveryNotePurpose.Should().Be(5);
+        header.reverseDeliveryNotePurposeSpecified.Should().BeTrue();
+
+        // 9.3 must NOT have currency
+        header.currencySpecified.Should().BeFalse();
+
+        // vehicleNumber from override
+        header.vehicleNumber.Should().Be("ΝΒΧ8311");
+
+        // movePurpose from override
+        header.movePurpose.Should().Be(1);
+        header.movePurposeSpecified.Should().BeTrue();
+
+        // loading address from override
+        header.otherDeliveryNoteHeader.Should().NotBeNull();
+        header.otherDeliveryNoteHeader.loadingAddress.street.Should().Be("Παπαδιαμάντη 24");
+        header.otherDeliveryNoteHeader.loadingAddress.city.Should().Be("Νέα Ευκαρπία - Θεσσαλονίκη");
+
+        // delivery address from override
+        header.otherDeliveryNoteHeader.deliveryAddress.street.Should().Be("ΙΚΤΙΝΟΥ 22");
+        header.otherDeliveryNoteHeader.deliveryAddress.city.Should().Be("ΘΕΣΣΑΛΟΝΙΚΗ");
+
+        // 2 charge items — factory negates Quantity via ReceiptCaseFlags.Refund → myDATA receives positive values
+        invoiceDoc.invoice[0].invoiceDetails.Should().HaveCount(2);
+        invoiceDoc.invoice[0].invoiceDetails[0].quantity.Should().BeGreaterThan(0,
+            "factory negates -1 → myDATA receives +1");
+        invoiceDoc.invoice[0].invoiceDetails[1].quantity.Should().BeGreaterThan(0,
+            "factory negates -7 → myDATA receives +7");
+
+        // XML output — key tags verified (payload accepted by myDATA sandbox)
+        xml.Should().Contain("<invoiceType>9.3</invoiceType>");
+        xml.Should().Contain("<reverseDeliveryNote>true</reverseDeliveryNote>");
+        xml.Should().Contain("<reverseDeliveryNotePurpose>5</reverseDeliveryNotePurpose>");
+        xml.Should().NotContain("<currency>");
+    }
+}


### PR DESCRIPTION
{Summary of the changes}

Support Reverse Delivery Note (9.3) for return of goods in transit via myDATA.

When a delivery note (type `9.3`) is flagged as a reverse shipment (`ReceiptCaseFlags.Refund` / `0x0100` on `ftReceiptCase`), the middleware now correctly sets `reverseDeliveryNote = true` and enforces `reverseDeliveryNotePurpose` (mandatory per AADE rules), as required by myDATA.

The `ReceiptCaseFlags.Refund` flag is set at **receipt level** (not per charge item), meaning the entire delivery note is a reversal — not a partial return. Combined with `HasTransportInformation` (`0x0400`), the result is:

`ftReceiptCase: 0x0000_2000_0500_0005`

This matches the official fiskaltrust specification for reverse delivery notes.

Previously, the `reverseDeliveryNote` field was never set, causing myDATA to reject the payload for reverse delivery notes.

The generated XML payload was validated successfully against the **myDATA sandbox** (AADE API accepted).


{Detail}

I added reverse delivery note detection in **AADEFactory.cs** → `CreateInvoiceDocType()`, where:
- `reverseDeliveryNote = true`
- `reverseDeliveryNoteSpecified = true`

are set when:
- invoice type is `9.3`
- `ReceiptCaseFlags.Refund` is present on `ftReceiptCase`

---

I added `ReverseDeliveryNotePurpose` property to **MyDataSCU.cs** → `InvoiceHeaderOverride` with:

`[JsonPropertyName("reverseDeliveryNotePurpose")]`

This allows the caller to pass the purpose code via:

`ftReceiptCaseData.GR.mydataoverride.invoice.invoiceHeader.reverseDeliveryNotePurpose`

---

I added the override application in **AADEFactory.cs** → `ApplyMyDataOverride()`, where:
- `reverseDeliveryNotePurpose` is applied **only when** `reverseDeliveryNote = true`
- if `reverseDeliveryNote = true` but the purpose is missing → an `ArgumentException` is thrown

AADE requires this field when `reverseDeliveryNote = true`.

---

I added **AADEMappings.cs** → `GetReverseDeliveryNotePurpose(int)` which validates that the value is in the allowed range `1–5`, otherwise throws an exception:

- `1` — NOT OBLIGED TO ISSUE  
- `2` — REFUSAL / CLERICAL ERROR  
- `3` — INTRA-COMMUNITY ACQUISITION  
- `4` — THIRD COUNTRY ACQUISITION  
- `5` — REVERSAL OF OBLIGATION  

---

### Charge item convention for reverse delivery notes

The caller must send each returned charge item with:

- `Quantity` **negative** (e.g. `-1`)  
  → factory applies negation via `ReceiptCaseFlags.Refund` on `ftReceiptCase`  
  → myDATA receives positive value (`+1`)

- `Amount = 0`  
- `VATRate = 0`  

(as required by myDATA for reverse delivery note lines)

---

## Tests

### AADEMappingsGetReverseDeliveryNotePurposeTests (9 tests)

Direct unit tests on `GetReverseDeliveryNotePurpose`:

- Valid values `1–5` return the same value (Theory ×5)  
- Invalid values `0, 6, -1, 100` throw an exception (Theory ×4)  

---

### ReverseDeliveryNoteValidationTests (8 tests)

- **ReverseDeliveryNote_WithRefundFlag_ShouldSetReverseDeliveryNoteTrue**  
  `ReceiptCaseFlags.Refund` on `ftReceiptCase` sets `reverseDeliveryNote = true`, invoice type is `9.3`, no `<currency>` in XML  

- **ReverseDeliveryNote_WithoutRefundFlag_ShouldNotSetReverseDeliveryNote**  
  Normal `9.3` without `Refund` flag does **not** set `reverseDeliveryNote`  

- **ReverseDeliveryNote_WithPurposeOverride_ShouldSetReverseDeliveryNotePurpose**  
  Purpose `5` from override is correctly applied  

- **ReverseDeliveryNote_ChargeItemQuantities_ShouldBePositiveInXmlPayload**  
  Caller sends `Quantity = -1`, factory negates via `ReceiptCaseFlags.Refund` → myDATA receives `+1`  

- **ReverseDeliveryNote_PurposeNotApplied_WhenReverseDeliveryNoteNotSet**  
  Purpose override is ignored when `reverseDeliveryNote` is not set  

- **ReverseDeliveryNote_GeneratedXml_ShouldContainCorrectTags**  
  XML contains:  
  - `<reverseDeliveryNote>true</reverseDeliveryNote>`  
  - `<reverseDeliveryNotePurpose>5</reverseDeliveryNotePurpose>`  
  - `<invoiceType>9.3</invoiceType>`  
  - no `<currency>`  

- **ReverseDeliveryNote_WithRefundFlag_AndMissingPurpose_ShouldReturnError**  
  Missing `reverseDeliveryNotePurpose` → `ArgumentException`  

- **ReverseDeliveryNote_SpecExample_GenerateXmlForManualMyDataValidation**  
  Full spec example using:  
  `ftReceiptCase: 0x0000_2000_0500_0005`  
  Successfully validated against myDATA sandbox  

---

## Files changed

- `src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs`  
- `src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs`  
- `src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs`  
- `test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/ReverseDeliveryNoteValidationTests.cs` *(new)*  
- `test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsGetReverseDeliveryNotePurposeTests.cs` *(new)*  

Fixes fiskaltrust/market-gr#100