### PR TITLE
Add noOp Logic and unit test

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
@@ -109,11 +109,16 @@ public sealed class CustomRTServerSCU : LegacySCU
                 return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, signatures);
             }
 
-            if (request.ReceiptRequest.IsDailyClosing())
+            if (request.ReceiptRequest.IsDailyClosing() || request.ReceiptRequest.IsMonthlyClosing() || request.ReceiptRequest.IsYearlyClosing())
             {
                 (var signatures, var state) = await PerformDailyCosingAsync(request.ReceiptRequest, request.ReceiptResponse, cashuuid);
                 request.ReceiptResponse.ftState = state;
                 return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, signatures);
+            }
+
+            if (receiptCase == (long) ITReceiptCases.ProtocolUnspecified0x3000)
+            {
+                return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, new List<SignaturItem>());
             }
 
             switch (receiptCase)
@@ -127,7 +132,7 @@ public sealed class CustomRTServerSCU : LegacySCU
                     return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, signatures);
             }
 
-            throw new Exception($"The given receiptcase 0x{receiptCase.ToString("X")} is not supported.");
+            return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, new List<SignaturItem>());
         }
         catch (Exception ex)
         {

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using FluentAssertions;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.ifPOS.v1.it;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.CustomRTServer.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest;
+
+/// <summary>
+/// Unit tests for CustomRTServerSCU.ProcessReceiptAsync — covers only the cases
+/// added as fixes for issues #581 and #584.
+///
+/// Strategy: a JSON state-cache file is written to a temp dir so that
+/// ReloadCashUUID returns without making any HTTP calls, keeping the NoOp tests
+/// fully offline. For Monthly/Yearly closing, a 100 ms timeout lets the HTTP
+/// call to the unreachable fake server fail fast; PerformDailyCosingAsync has
+/// its own try/catch that emits "rt-server-dailyclosing-error" — distinct from
+/// the outer "rt-server-generic-error" — which proves routing reached the
+/// correct handler.
+/// </summary>
+public class CustomRTServerSCUTests : IDisposable
+{
+    private static readonly Guid _scuId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid _queueId = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private const string _cashBoxId = "0001test001";
+    private readonly string _tempDir;
+
+    public CustomRTServerSCUTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_tempDir);
+
+        // Pre-populate the state cache so ReloadCashUUID skips the HTTP call.
+        var cache = new Dictionary<Guid, QueueIdentification>
+        {
+            [_queueId] = new QueueIdentification
+            {
+                CashUuId = _cashBoxId,
+                CashStatus = "1",
+                LastZNumber = 5,
+                LastDocNumber = 10,
+                CurrentGrandTotal = 0,
+                RTServerSerialNumber = "TESTSERIAL",
+                LastSignature = "testsig",
+                CashHmacKey = "testkey"
+            }
+        };
+        File.WriteAllText(
+            Path.Combine(_tempDir, $"{_scuId}_customrtserver_statecache.json"),
+            JsonConvert.SerializeObject(cache)
+        );
+    }
+
+    public void Dispose() => Directory.Delete(_tempDir, recursive: true);
+
+    private CustomRTServerSCU CreateSut(int httpTimeoutMs = 5000)
+    {
+        var config = new CustomRTServerConfiguration
+        {
+            ServerUrl = "http://127.0.0.1:1/",
+            Password = "test",
+            ServiceFolder = _tempDir,
+            RTServerHttpTimeoutInMs = httpTimeoutMs,
+            IgnoreRTServerErrors = false
+        };
+        var client = new CustomRTServerClient(config, NullLogger<CustomRTServerClient>.Instance);
+        var queue = new CustomRTServerCommunicationQueue(_scuId, client, NullLogger<CustomRTServerCommunicationQueue>.Instance, config);
+        return new CustomRTServerSCU(_scuId, NullLogger<CustomRTServerSCU>.Instance, config, client, queue);
+    }
+
+    private ProcessRequest CreateRequest(long ftReceiptCase) => new ProcessRequest
+    {
+        ReceiptRequest = new ReceiptRequest
+        {
+            ftReceiptCase = ftReceiptCase,
+            cbReceiptMoment = DateTime.UtcNow,
+            cbChargeItems = Array.Empty<ChargeItem>(),
+            cbPayItems = Array.Empty<PayItem>()
+        },
+        ReceiptResponse = new ReceiptResponse
+        {
+            ftQueueID = _queueId.ToString(),
+            ftCashBoxIdentification = _cashBoxId,
+            ftState = 0x4954_2000_0000_0000,
+            ftSignatures = Array.Empty<SignaturItem>()
+        }
+    };
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ProtocolUnspecified0x3000_ReturnsNoOp()
+    {
+        var sut = CreateSut();
+        var result = await sut.ProcessReceiptAsync(CreateRequest(0x4954_2000_0000_3000));
+
+        result.ReceiptResponse.ftSignatures.Should().BeEmpty();
+        result.ReceiptResponse.ftState.Should().Be(0x4954_2000_0000_0000);
+    }
+
+    // Fix #581b
+    [Fact]
+    public async Task ProcessReceiptAsync_UnknownReceiptCase_ReturnsNoOp()
+    {
+        var sut = CreateSut();
+        var result = await sut.ProcessReceiptAsync(CreateRequest(0x4954_2000_0000_9999));
+
+        result.ReceiptResponse.ftSignatures.Should().BeEmpty();
+        result.ReceiptResponse.ftState.Should().Be(0x4954_2000_0000_0000);
+    }
+
+    // Fix #581a
+    [Theory]
+    [InlineData(0x4954_2000_0000_2012L)]   // MonthlyClosing0x2012
+    [InlineData(0x4954_2000_0000_2013L)]   // YearlyClosing0x2013
+    public async Task ProcessReceiptAsync_MonthlyAndYearlyClosing_RoutesToDailyClosingHandler(long ftReceiptCase)
+    {
+        var sut = CreateSut(httpTimeoutMs: 100);
+        var result = await sut.ProcessReceiptAsync(CreateRequest(ftReceiptCase));
+
+        result.ReceiptResponse.ftSignatures.Should().Contain(s => s.Caption == "rt-server-dailyclosing-error");
+        result.ReceiptResponse.ftState.Should().Be(0x4954_2001_EEEE_EEEE);
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest.csproj
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest.csproj
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference
-      Include="..\..\src\fiskaltrust.Middleware.SCU.IT.CustomRTServer\fiskaltrust.Middleware.SCU.IT.CustomRTServer.csproj" />
+    <ProjectReference Include="..\..\src\fiskaltrust.Middleware.SCU.IT.Abstraction\fiskaltrust.Middleware.SCU.IT.Abstraction.csproj" />
+    <ProjectReference Include="..\..\src\fiskaltrust.Middleware.SCU.IT.CustomRTServer\fiskaltrust.Middleware.SCU.IT.CustomRTServer.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #581 and #584 in `CustomRTServerSCU`: both issues had the same root cause: unhandled receipt cases were throwing an exception instead of returning gracefully.

- ProtocolUnspecified0x3000 → NoOp 
 - MonthlyClosing / YearlyClosing  routed to `PerformDailyCosingAsync`, same as `DailyClosing`
 - Final throw replaced with NoOp for unknown/future cases

Fixes #584 #581 
