### PR TITLE
GR: Forward ECommerce receipts to SCU, require invoiceType override

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Processors/ReceiptCommandProcessorGR.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Processors/ReceiptCommandProcessorGR.cs
@@ -45,7 +45,16 @@ public class ReceiptCommandProcessorGR(IGRSSCD sscd, IQueueStorageProvider queue
 
     public Task<ProcessCommandResponse> PointOfSaleReceiptWithoutObligation0x0003Async(ProcessCommandRequest request) => GRFallBackOperations.NotSupported(request, "PointOfSaleReceiptWithoutObligation");
 
-    public Task<ProcessCommandResponse> ECommerce0x0004Async(ProcessCommandRequest request) => GRFallBackOperations.NotSupported(request, "ECommerce");
+    public async Task<ProcessCommandResponse> ECommerce0x0004Async(ProcessCommandRequest request)
+    {
+        var receiptReferences = await _queueStorageProvider.GetReceiptReferencesIfNecessaryAsync(request);
+        var response = await _sscd.ProcessReceiptAsync(new ProcessRequest
+        {
+            ReceiptRequest = request.ReceiptRequest,
+            ReceiptResponse = request.ReceiptResponse,
+        }, receiptReferences);
+        return new ProcessCommandResponse(response.ReceiptResponse, []);
+    }
 
     public async Task<ProcessCommandResponse> DeliveryNote0x0005Async(ProcessCommandRequest request)
     {

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueGR.UnitTest/Processors/ReceiptCommandProcessorGRTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueGR.UnitTest/Processors/ReceiptCommandProcessorGRTests.cs
@@ -20,6 +20,7 @@ public class ReceiptCommandProcessorGRTests
     [Theory]
     [InlineData(ReceiptCase.PointOfSaleReceipt0x0001)]
     [InlineData(ReceiptCase.PaymentTransfer0x0002)]
+    [InlineData(ReceiptCase.ECommerce0x0004)]
     public async Task ProcessReceiptAsync_ShouldReturnEmptyList(ReceiptCase receiptCase)
     {
         var queue = TestHelpers.CreateQueue();
@@ -71,7 +72,6 @@ public class ReceiptCommandProcessorGRTests
 
     [Theory]
     [InlineData(ReceiptCase.PointOfSaleReceiptWithoutObligation0x0003)]
-    [InlineData(ReceiptCase.ECommerce0x0004)]
     public async Task ProcessReceiptAsync_ForNotSupportedOperations_ShouldReturnError(ReceiptCase receiptCase)
     {
         var queue = TestHelpers.CreateQueue();

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -123,6 +123,15 @@ public class AADEFactory
     {
         try
         {
+            if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.ECommerce0x0004))
+            {
+                if (!receiptRequest.TryDeserializeftReceiptCaseData<ftReceiptCaseDataPayload>(out var overrideData)
+                    || string.IsNullOrEmpty(overrideData?.GR?.MyDataOverride?.Invoice?.InvoiceHeader?.InvoiceType))
+                {
+                    throw new Exception("ECommerce receipts require an explicit invoiceType override in ftReceiptCaseData.GR.mydataoverride.invoice.invoiceHeader.invoiceType.");
+                }
+            }
+
             foreach (var chargeItem in receiptRequest.cbChargeItems)
             {
                 chargeItem.Amount = Math.Round(chargeItem.Amount, 2);

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -119,19 +119,16 @@ public class AADEFactory
         return doc;
     }
 
+    public static bool HasInvoiceTypeOverride(ReceiptRequest receiptRequest)
+    {
+        return receiptRequest.TryDeserializeftReceiptCaseData<ftReceiptCaseDataPayload>(out var overrideData)
+            && !string.IsNullOrEmpty(overrideData?.GR?.MyDataOverride?.Invoice?.InvoiceHeader?.InvoiceType);
+    }
+
     public (InvoicesDoc? invoiceDoc, AADEFactoryError? error) MapToInvoicesDoc(ReceiptRequest receiptRequest, ReceiptResponse receiptResponse, List<(ReceiptRequest, ReceiptResponse)>? receiptReferences = null)
     {
         try
         {
-            if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.ECommerce0x0004))
-            {
-                if (!receiptRequest.TryDeserializeftReceiptCaseData<ftReceiptCaseDataPayload>(out var overrideData)
-                    || string.IsNullOrEmpty(overrideData?.GR?.MyDataOverride?.Invoice?.InvoiceHeader?.InvoiceType))
-                {
-                    throw new Exception("ECommerce receipts require an explicit invoiceType override in ftReceiptCaseData.GR.mydataoverride.invoice.invoiceHeader.invoiceType.");
-                }
-            }
-
             foreach (var chargeItem in receiptRequest.cbChargeItems)
             {
                 chargeItem.Amount = Math.Round(chargeItem.Amount, 2);

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/MyDataSCU.cs
@@ -71,6 +71,16 @@ public class MyDataSCU : IGRSSCD
 
     public async Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request, List<(ReceiptRequest, ReceiptResponse)>? receiptReferences = null)
     {
+        if (request.ReceiptRequest.ftReceiptCase.IsCase(ReceiptCase.ECommerce0x0004)
+            && !AADEFactory.HasInvoiceTypeOverride(request.ReceiptRequest))
+        {
+            _logger.LogInformation("Skipping myDATA submission for ECommerce receipt '{ReceiptReference}' (QueueItemId: {QueueItemId}): no invoiceType override provided.", request.ReceiptRequest.cbReceiptReference, request.ReceiptResponse.ftQueueItemID);
+            return new ProcessResponse
+            {
+                ReceiptResponse = request.ReceiptResponse
+            };
+        }
+
         if (string.IsNullOrEmpty(_masterDataConfiguration.Account.VatId))
         {
             SetErrorAndLog(request,"The VATId is not setup correctly for this Queue. Please check the master data configuration in fiskaltrust.Portal.");

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
@@ -2360,26 +2360,17 @@ public class MyDataOverrideTests
     }
 
     [Fact]
-    public void MapToInvoicesDoc_ECommerceWithoutOverride_ShouldReturnError()
+    public void HasInvoiceTypeOverride_WithoutCaseData_ReturnsFalse()
     {
-        var factory = CreateFactory();
         var request = CreateBasicReceiptRequest();
-        request.ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000).WithCase(ReceiptCase.ECommerce0x0004);
-        var response = CreateBasicReceiptResponse(request);
 
-        var (doc, error) = factory.MapToInvoicesDoc(request, response);
-
-        doc.Should().BeNull();
-        error.Should().NotBeNull();
-        error!.Exception.Message.Should().Contain("ECommerce receipts require an explicit invoiceType override");
+        AADEFactory.HasInvoiceTypeOverride(request).Should().BeFalse();
     }
 
     [Fact]
-    public void MapToInvoicesDoc_ECommerceWithOverrideButNoInvoiceType_ShouldReturnError()
+    public void HasInvoiceTypeOverride_WithOverrideButNoInvoiceType_ReturnsFalse()
     {
-        var factory = CreateFactory();
         var request = CreateBasicReceiptRequest();
-        request.ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000).WithCase(ReceiptCase.ECommerce0x0004);
         request.ftReceiptCaseData = new
         {
             GR = new
@@ -2396,13 +2387,32 @@ public class MyDataOverrideTests
                 }
             }
         };
-        var response = CreateBasicReceiptResponse(request);
 
-        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+        AADEFactory.HasInvoiceTypeOverride(request).Should().BeFalse();
+    }
 
-        doc.Should().BeNull();
-        error.Should().NotBeNull();
-        error!.Exception.Message.Should().Contain("ECommerce receipts require an explicit invoiceType override");
+    [Fact]
+    public void HasInvoiceTypeOverride_WithInvoiceType_ReturnsTrue()
+    {
+        var request = CreateBasicReceiptRequest();
+        request.ftReceiptCaseData = new
+        {
+            GR = new
+            {
+                mydataoverride = new
+                {
+                    invoice = new
+                    {
+                        invoiceHeader = new
+                        {
+                            invoiceType = "11.1"
+                        }
+                    }
+                }
+            }
+        };
+
+        AADEFactory.HasInvoiceTypeOverride(request).Should().BeTrue();
     }
 
     [Fact]

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
@@ -2358,4 +2358,81 @@ public class MyDataOverrideTests
         xml.Should().Contain("<postalCode>80331</postalCode>");
         xml.Should().Contain("<city>München</city>");
     }
+
+    [Fact]
+    public void MapToInvoicesDoc_ECommerceWithoutOverride_ShouldReturnError()
+    {
+        var factory = CreateFactory();
+        var request = CreateBasicReceiptRequest();
+        request.ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000).WithCase(ReceiptCase.ECommerce0x0004);
+        var response = CreateBasicReceiptResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        doc.Should().BeNull();
+        error.Should().NotBeNull();
+        error!.Exception.Message.Should().Contain("ECommerce receipts require an explicit invoiceType override");
+    }
+
+    [Fact]
+    public void MapToInvoicesDoc_ECommerceWithOverrideButNoInvoiceType_ShouldReturnError()
+    {
+        var factory = CreateFactory();
+        var request = CreateBasicReceiptRequest();
+        request.ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000).WithCase(ReceiptCase.ECommerce0x0004);
+        request.ftReceiptCaseData = new
+        {
+            GR = new
+            {
+                mydataoverride = new
+                {
+                    invoice = new
+                    {
+                        invoiceHeader = new
+                        {
+                            dispatchDate = "2025-06-18"
+                        }
+                    }
+                }
+            }
+        };
+        var response = CreateBasicReceiptResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        doc.Should().BeNull();
+        error.Should().NotBeNull();
+        error!.Exception.Message.Should().Contain("ECommerce receipts require an explicit invoiceType override");
+    }
+
+    [Fact]
+    public void MapToInvoicesDoc_ECommerceWithInvoiceTypeOverride_ShouldUseOverrideType()
+    {
+        var factory = CreateFactory();
+        var request = CreateBasicReceiptRequest();
+        request.ftReceiptCase = ((ReceiptCase) 0x4752_2000_0000_0000).WithCase(ReceiptCase.ECommerce0x0004);
+        request.ftReceiptCaseData = new
+        {
+            GR = new
+            {
+                mydataoverride = new
+                {
+                    invoice = new
+                    {
+                        invoiceHeader = new
+                        {
+                            invoiceType = "11.1"
+                        }
+                    }
+                }
+            }
+        };
+        var response = CreateBasicReceiptResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item111);
+    }
 }


### PR DESCRIPTION
## Summary

- Forward `ReceiptCase.ECommerce0x0004` from `ReceiptCommandProcessorGR` to the MyData SCU instead of throwing `NotSupported`.
- In `MyDataSCU.ProcessReceiptAsync`, short-circuit ECommerce receipts that have no `invoiceType` override: return the response unchanged, with no myDATA API call and no signatures added.
- When an override is present, processing continues normally and `ApplyInvoiceHeaderOverride` sets the invoice type — the default `AADEMappings.GetInvoiceType` mapping is never used for ECommerce.
- Exposed `AADEFactory.HasInvoiceTypeOverride(ReceiptRequest)` as the single helper that decides whether processing should happen.

## Why

Previously `ECommerce0x0004` was unconditionally rejected in QueueGR. It should be allowed, but the Greek myDATA invoice type for an e-commerce transaction cannot be inferred from the receipt case alone — the merchant must pick it explicitly.

When the merchant provides an `invoiceType` override the receipt is submitted to myDATA; when they don't, the SCU effectively no-ops (mirrors the pre-change behaviour of "nothing is submitted"), without surfacing an error to the caller.

## Changes

- `queue/src/.../QueueGR/Processors/ReceiptCommandProcessorGR.cs`: `ECommerce0x0004Async` now calls `_sscd.ProcessReceiptAsync` (mirroring `PointOfSaleReceipt0x0001Async`).
- `scu-gr/src/.../MyData/MyDataSCU.cs`: early return at the top of `ProcessReceiptAsync` for `ECommerce0x0004` + missing `invoiceType` override. Logs an informational entry and returns the unchanged `ReceiptResponse`.
- `scu-gr/src/.../MyData/AADEFactory.cs`: new static `HasInvoiceTypeOverride(ReceiptRequest)` helper.
- Unit tests:
  - `ReceiptCommandProcessorGRTests`: ECommerce moved from the "not supported" theory to the "forwards to SCU" theory.
  - `MyDataOverrideTests`: new coverage for `HasInvoiceTypeOverride` (three cases: no case data, override without `invoiceType`, override with `invoiceType`) and for ECommerce with an `invoiceType` override being mapped to the requested `InvoiceType`.

## Test plan

- [x] `dotnet test queue/test/.../QueueGR.UnitTest` — 34/34 passed
- [x] `dotnet test scu-gr/test/.../MyData.UnitTest` — 729/729 passed
- [ ] Manual end-to-end against MyData sandbox: ECommerce receipt **with** `invoiceType=11.1` override is submitted
- [ ] Manual verification that ECommerce **without** override returns success with an unchanged response (no signatures, no myDATA call)
