### PR TITLE
Filter InternalMaterialConsumption pay items from myDATA submission

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -1231,7 +1231,9 @@ public class AADEFactory
 
     private static List<PaymentMethodDetailType> GetPayments(ReceiptRequest receiptRequest)
     {
-        return receiptRequest.GetGroupedPayItems().Select(group =>
+        return receiptRequest.GetGroupedPayItems()
+            .Where(group => AADEMappings.ShouldTransmitPayItem(group.payItem))
+            .Select(group =>
         {
             var x = group.payItem;
             var payment = new PaymentMethodDetailType

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -533,6 +533,17 @@ public static class AADEMappings
         PayItemCase c => throw new Exception($"The Payment type {c} of PayItem with the case {payItem.ftPayItemCase} is not supported."),
     };
 
+    /// <summary>
+    /// Determines whether a pay item should be transmitted to the myDATA API as a payment method.
+    /// Internal material consumption has no AADE payment-method counterpart and is filtered out
+    /// so it never appears in <c>inv.paymentMethods</c> nor in a standalone <c>SendPaymentsMethod</c> call.
+    /// </summary>
+    public static bool ShouldTransmitPayItem(PayItem payItem) => payItem.ftPayItemCase.Case() switch
+    {
+        PayItemCase.InternalMaterialConsumption => false,
+        _ => true
+    };
+
     private static int GetSEPATransferPaymentType(string description)
     {
         if (string.IsNullOrEmpty(description))

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsGetPaymentTypeTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsGetPaymentTypeTests.cs
@@ -191,6 +191,49 @@ public class AADEMappingsGetPaymentTypeTests
         exception.Message.Should().Contain("is not supported");
     }
 
+    [Theory]
+    [InlineData(PayItemCase.UnknownPaymentType)]
+    [InlineData(PayItemCase.CashPayment)]
+    [InlineData(PayItemCase.NonCash)]
+    [InlineData(PayItemCase.CrossedCheque)]
+    [InlineData(PayItemCase.DebitCardPayment)]
+    [InlineData(PayItemCase.CreditCardPayment)]
+    [InlineData(PayItemCase.VoucherPaymentCouponVoucherByMoneyValue)]
+    [InlineData(PayItemCase.OnlinePayment)]
+    [InlineData(PayItemCase.LoyaltyProgramCustomerCardPayment)]
+    [InlineData(PayItemCase.AccountsReceivable)]
+    [InlineData(PayItemCase.SEPATransfer)]
+    [InlineData(PayItemCase.OtherBankTransfer)]
+    [InlineData(PayItemCase.TransferToCashbookVaultOwnerEmployee)]
+    [InlineData(PayItemCase.Grant)]
+    [InlineData(PayItemCase.TicketRestaurant)]
+    public void ShouldTransmitPayItem_WithAnyPayItemCaseExceptInternalMaterialConsumption_ReturnsTrue(PayItemCase payItemCase)
+    {
+        var payItem = new PayItem
+        {
+            Position = 1,
+            Amount = 10.0m,
+            Description = "Test Payment",
+            ftPayItemCase = ((PayItemCase) 0x4752_2000_0000_0000).WithCase(payItemCase)
+        };
+
+        AADEMappings.ShouldTransmitPayItem(payItem).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldTransmitPayItem_WithInternalMaterialConsumption_ReturnsFalse()
+    {
+        var payItem = new PayItem
+        {
+            Position = 1,
+            Amount = 10.0m,
+            Description = "Test Payment",
+            ftPayItemCase = ((PayItemCase) 0x4752_2000_0000_0000).WithCase(PayItemCase.InternalMaterialConsumption)
+        };
+
+        AADEMappings.ShouldTransmitPayItem(payItem).Should().BeFalse();
+    }
+
     [Fact]
     public void GetPaymentType_WithComplexPayItemCase_ExtractsCorrectCase()
     {

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/GetPaymentsTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/GetPaymentsTests.cs
@@ -340,6 +340,43 @@ public class GetPaymentsTests
 
     #endregion
 
+    #region Filtering of non-transmittable pay items
+
+    [Fact]
+    public void InternalMaterialConsumption_ShouldBeFilteredOut()
+    {
+        var details = GetPaymentDetails(new List<PayItem>
+        {
+            new PayItem { Position = 1, Amount = 10.0m, Description = "Cash",
+                ftPayItemCase = WithLocalFlag(GR(PayItemCase.CashPayment)) },
+            new PayItem { Position = 2, Amount = 5.0m, Description = "Material consumption",
+                ftPayItemCase = WithLocalFlag(GR(PayItemCase.InternalMaterialConsumption)) }
+        });
+
+        details.Should().HaveCount(1, "InternalMaterialConsumption must be filtered before mapping");
+        details[0].type.Should().Be(MyDataPaymentMethods.Cash);
+        details[0].amount.Should().Be(10.0m);
+    }
+
+    [Fact]
+    public void OnlyInternalMaterialConsumption_ShouldReturnError()
+    {
+        var factory = CreateFactory();
+        var request = BuildRequest(new List<PayItem>
+        {
+            new PayItem { Position = 1, Amount = 10.0m, Description = "Material consumption",
+                ftPayItemCase = WithLocalFlag(GR(PayItemCase.InternalMaterialConsumption)) }
+        });
+
+        (var doc, var error) = factory.MapToPaymentMethodsDoc(request, 123);
+
+        doc.Should().BeNull();
+        error.Should().NotBeNull();
+        error!.Exception.Message.Should().Contain("At least one payment method detail is required");
+    }
+
+    #endregion
+
     #region Combined Tip + Provider Data
 
     [Fact]


### PR DESCRIPTION
## Summary

- `PayItemCase.InternalMaterialConsumption` has no AADE payment-method counterpart — `AADEMappings.GetPaymentType` returns `-1` for it, and the previous `GetPayments` code still wrapped that in a `PaymentMethodDetailType` and shipped it to AADE.
- Added a rule-based filter `AADEMappings.ShouldTransmitPayItem(PayItem)` that returns `false` only for `InternalMaterialConsumption` (everything else passes through).
- Applied the filter in `AADEFactory.GetPayments` *before* mapping, so filtered items never appear in `inv.paymentMethods` nor in a standalone `SendPaymentsMethod` call.

## Behavioral notes for the reviewer

- Scope is intentionally narrow: only `InternalMaterialConsumption` is filtered. Other pay item cases that `GetPaymentType` still maps to `-1` (`NonCash`, `OnlinePayment`, `LoyaltyProgramCustomerCardPayment`, `TransferToCashbookVaultOwnerEmployee`, `Grant`, `TicketRestaurant`) are unchanged and will continue to be transmitted with `type = -1` — explicitly out of scope per request.
- A `Pay0x3005` receipt that contains *only* `InternalMaterialConsumption` pay items will now produce zero details, which trips the existing guard in `MapToPaymentMethodsDoc` and surfaces as `"At least one payment method detail is required for SendPaymentsMethod."`.

## Test plan

- [x] New unit tests in `AADEMappingsGetPaymentTypeTests` cover `ShouldTransmitPayItem` for every defined `PayItemCase`.
- [x] New tests in `GetPaymentsTests` verify mixed Cash + InternalMaterialConsumption only emits Cash, and that an InternalMaterialConsumption-only payment receipt errors with the existing guard message.
- [x] Full MyData unit test suite green (747 / 747).

🤖 Generated with [Claude Code](https://claude.com/claude-code)