### PR TITLE
GR myDATA: honor ChargeItem Unit/UnitQuantity with fallbacks

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -1343,6 +1343,10 @@ public class AADEFactory
                     // ftChargeItemCaseData may contain data for other purposes, ignore deserialization errors
                 }
             }
+
+            // Guard the spec-mandatory pair for measurementUnit=7 — covers callers who flipped
+            // measurementUnit via override without supplying the accompanying title/count.
+            AADEMappings.EnsureOtherPiecesMandatoryFields(invoiceRow, x);
             return invoiceRow;
         }).ToList();
     }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -1220,25 +1220,6 @@ public class AADEFactory
                 nextPosition = (int) x.Position + 1;
             }
 
-            // Deserialize ftChargeItemCaseData once so the GR-level named properties
-            // (OtherMeasurementUnitQuantity) and the mydataoverride payload share a single
-            // try/catch and can both feed downstream mapping.
-            ftChargeItemCaseDataPayload? chargeItemData = null;
-            if (x.ftChargeItemCaseData != null)
-            {
-                try
-                {
-                    chargeItemData = JsonSerializer.Deserialize<ftChargeItemCaseDataPayload>(
-                        JsonSerializer.Serialize(x.ftChargeItemCaseData),
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                }
-                catch (JsonException)
-                {
-                    // ftChargeItemCaseData may contain data for other purposes, ignore deserialization errors
-                }
-            }
-            var explicitOtherMeasurementUnitQuantity = chargeItemData?.GR?.OtherMeasurementUnitQuantity;
-
             if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.HasTransportInformation))
             {
                 if (!string.IsNullOrEmpty(x.ProductNumber))
@@ -1248,7 +1229,7 @@ public class AADEFactory
 
                 invoiceRow.itemDescr = x.Description;
 
-                AADEMappings.ApplyMeasurementUnit(invoiceRow, x, explicitOtherMeasurementUnitQuantity);
+                AADEMappings.ApplyMeasurementUnit(invoiceRow, x);
             }
 
             if (x.ftChargeItemCase.NatureOfVat() != ChargeItemCaseNatureOfVatGR.UsualVatApplies)
@@ -1345,14 +1326,27 @@ public class AADEFactory
                 invoiceRow.deductionsAmountSpecified = true;
             }
             // Apply line-level mydataoverride from ftChargeItemCaseData
-            if (chargeItemData?.GR?.MyDataOverride?.InvoiceDetails != null)
+            if (x.ftChargeItemCaseData != null)
             {
-                ApplyInvoiceDetailOverride(invoiceRow, chargeItemData.GR.MyDataOverride.InvoiceDetails);
+                try
+                {
+                    var chargeItemData = JsonSerializer.Deserialize<ftChargeItemCaseDataPayload>(
+                        JsonSerializer.Serialize(x.ftChargeItemCaseData),
+                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    if (chargeItemData?.GR?.MyDataOverride?.InvoiceDetails != null)
+                    {
+                        ApplyInvoiceDetailOverride(invoiceRow, chargeItemData.GR.MyDataOverride.InvoiceDetails);
+                    }
+                }
+                catch (JsonException)
+                {
+                    // ftChargeItemCaseData may contain data for other purposes, ignore deserialization errors
+                }
             }
 
             // Guard the spec-mandatory pair for measurementUnit=7 — covers callers who flipped
             // measurementUnit via override without supplying the accompanying title/count.
-            AADEMappings.EnsureOtherPiecesMandatoryFields(invoiceRow, x, explicitOtherMeasurementUnitQuantity);
+            AADEMappings.EnsureOtherPiecesMandatoryFields(invoiceRow, x);
             return invoiceRow;
         }).ToList();
     }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -1229,8 +1229,7 @@ public class AADEFactory
 
                 invoiceRow.itemDescr = x.Description;
 
-                invoiceRow.measurementUnit = AADEMappings.GetMeasurementUnit(x);
-                invoiceRow.measurementUnitSpecified = true;
+                AADEMappings.ApplyMeasurementUnit(invoiceRow, x);
             }
 
             if (x.ftChargeItemCase.NatureOfVat() != ChargeItemCaseNatureOfVatGR.UsualVatApplies)

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -1220,6 +1220,25 @@ public class AADEFactory
                 nextPosition = (int) x.Position + 1;
             }
 
+            // Deserialize ftChargeItemCaseData once so the GR-level named properties
+            // (OtherMeasurementUnitQuantity) and the mydataoverride payload share a single
+            // try/catch and can both feed downstream mapping.
+            ftChargeItemCaseDataPayload? chargeItemData = null;
+            if (x.ftChargeItemCaseData != null)
+            {
+                try
+                {
+                    chargeItemData = JsonSerializer.Deserialize<ftChargeItemCaseDataPayload>(
+                        JsonSerializer.Serialize(x.ftChargeItemCaseData),
+                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                }
+                catch (JsonException)
+                {
+                    // ftChargeItemCaseData may contain data for other purposes, ignore deserialization errors
+                }
+            }
+            var explicitOtherMeasurementUnitQuantity = chargeItemData?.GR?.OtherMeasurementUnitQuantity;
+
             if (receiptRequest.ftReceiptCase.IsCase(ReceiptCase.Order0x3004) || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.HasTransportInformation))
             {
                 if (!string.IsNullOrEmpty(x.ProductNumber))
@@ -1229,7 +1248,7 @@ public class AADEFactory
 
                 invoiceRow.itemDescr = x.Description;
 
-                AADEMappings.ApplyMeasurementUnit(invoiceRow, x);
+                AADEMappings.ApplyMeasurementUnit(invoiceRow, x, explicitOtherMeasurementUnitQuantity);
             }
 
             if (x.ftChargeItemCase.NatureOfVat() != ChargeItemCaseNatureOfVatGR.UsualVatApplies)
@@ -1326,27 +1345,14 @@ public class AADEFactory
                 invoiceRow.deductionsAmountSpecified = true;
             }
             // Apply line-level mydataoverride from ftChargeItemCaseData
-            if (x.ftChargeItemCaseData != null)
+            if (chargeItemData?.GR?.MyDataOverride?.InvoiceDetails != null)
             {
-                try
-                {
-                    var chargeItemData = JsonSerializer.Deserialize<ftChargeItemCaseDataPayload>(
-                        JsonSerializer.Serialize(x.ftChargeItemCaseData),
-                        new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    if (chargeItemData?.GR?.MyDataOverride?.InvoiceDetails != null)
-                    {
-                        ApplyInvoiceDetailOverride(invoiceRow, chargeItemData.GR.MyDataOverride.InvoiceDetails);
-                    }
-                }
-                catch (JsonException)
-                {
-                    // ftChargeItemCaseData may contain data for other purposes, ignore deserialization errors
-                }
+                ApplyInvoiceDetailOverride(invoiceRow, chargeItemData.GR.MyDataOverride.InvoiceDetails);
             }
 
             // Guard the spec-mandatory pair for measurementUnit=7 — covers callers who flipped
             // measurementUnit via override without supplying the accompanying title/count.
-            AADEMappings.EnsureOtherPiecesMandatoryFields(invoiceRow, x);
+            AADEMappings.EnsureOtherPiecesMandatoryFields(invoiceRow, x, explicitOtherMeasurementUnitQuantity);
             return invoiceRow;
         }).ToList();
     }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -700,10 +700,8 @@ public static class AADEMappings
     /// and <c>otherMeasurementUnitTitle</c> preserves the original string.
     /// </summary>
     /// <remarks>
-    /// The caller is expected to have populated <c>row.quantity</c> with <c>ChargeItem.Quantity</c>
-    /// (with any refund/abs sign adjustments already applied). When this method overrides the value
-    /// with <c>UnitQuantity</c>, it preserves the sign of the value that was already on the row so
-    /// existing refund / partial-return semantics are not broken.
+    /// AADE schema requires <c>quantity &gt; 0</c> (minExclusive="0"), so the value is always emitted
+    /// as the absolute value when this method overrides the row.
     /// </remarks>
     public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
     {
@@ -730,8 +728,7 @@ public static class AADEMappings
         // implements the "Quantity is used as UnitQuantity" fallback.)
         if (chargeItem.UnitQuantity.HasValue)
         {
-            var sign = row.quantity < 0 ? -1m : 1m;
-            row.quantity = sign * Math.Abs(chargeItem.UnitQuantity.Value);
+            row.quantity = Math.Abs(chargeItem.UnitQuantity.Value);
             row.quantitySpecified = true;
         }
     }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -737,6 +737,34 @@ public static class AADEMappings
         }
     }
 
+    /// <summary>
+    /// Enforces myDATA spec v2.0.1 §5.4 rule #9: whenever the row ends up with
+    /// <c>measurementUnit = 7</c> (OtherPieces / Τεμάχια_Λοιπές Περιπτώσεις),
+    /// <c>otherMeasurementUnitTitle</c> and <c>otherMeasurementUnitQuantity</c> must both be set.
+    ///
+    /// This guard runs AFTER any line-level override has been applied — it covers the case
+    /// where a caller flips <c>measurementUnit</c> to 7 via override without supplying the
+    /// accompanying title/quantity, falling back to the values on the original ChargeItem.
+    /// </summary>
+    public static void EnsureOtherPiecesMandatoryFields(InvoiceRowType row, ChargeItem chargeItem)
+    {
+        if (!row.measurementUnitSpecified || row.measurementUnit != MyDataMeasurementUnit.OtherPieces)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(row.otherMeasurementUnitTitle) && !string.IsNullOrWhiteSpace(chargeItem.Unit))
+        {
+            row.otherMeasurementUnitTitle = chargeItem.Unit;
+        }
+
+        if (!row.otherMeasurementUnitQuantitySpecified)
+        {
+            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(chargeItem.Quantity), MidpointRounding.AwayFromZero);
+            row.otherMeasurementUnitQuantitySpecified = true;
+        }
+    }
+
 
     /// <summary>
     /// Valid values: 1-NOT OBLIGED TO ISSUE, 2-REFUSAL/CLERICAL ERROR,

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -697,21 +697,15 @@ public static class AADEMappings
     ///
     /// Mapping applied here:
     /// <list type="bullet">
-    ///   <item><description><c>row.quantity</c> ← <see cref="ChargeItem.UnitQuantity"/> when set, otherwise <see cref="ChargeItem.Quantity"/> (item count)</description></item>
-    ///   <item><description><c>row.otherMeasurementUnitQuantity</c> ← <see cref="ChargeItem.Quantity"/> (packaging count, only when measurementUnit=7)</description></item>
-    ///   <item><description><c>row.otherMeasurementUnitTitle</c> ← <see cref="ChargeItem.Unit"/> (packaging description, only when measurementUnit=7)</description></item>
+    ///   <item><description><c>row.quantity</c> ← <see cref="ChargeItem.UnitQuantity"/> when set, otherwise <see cref="ChargeItem.Quantity"/></description></item>
+    ///   <item><description><c>row.otherMeasurementUnitQuantity</c> ← <see cref="ChargeItem.UnitQuantity"/> when set, otherwise <see cref="ChargeItem.Quantity"/> (only when measurementUnit=7; whole-number validated)</description></item>
+    ///   <item><description><c>row.otherMeasurementUnitTitle</c> ← <see cref="ChargeItem.Unit"/> (only when measurementUnit=7)</description></item>
     /// </list>
     ///
     /// AADE schema requires <c>quantity &gt; 0</c> (<c>minExclusive="0"</c>), so the absolute value
     /// is always emitted.
-    ///
-    /// <paramref name="explicitOtherMeasurementUnitQuantity"/> takes precedence over the
-    /// <see cref="ChargeItem.Quantity"/> fallback for <c>otherMeasurementUnitQuantity</c>
-    /// (sourced from <c>ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity</c>). When the
-    /// caller provides this, the whole-number validation against <c>ChargeItem.Quantity</c>
-    /// is skipped because the explicit value is already an <c>int</c>.
     /// </remarks>
-    public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem, int? explicitOtherMeasurementUnitQuantity = null)
+    public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
     {
         row.measurementUnit = GetMeasurementUnit(chargeItem);
         row.measurementUnitSpecified = true;
@@ -723,8 +717,7 @@ public static class AADEMappings
             if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces)
             {
                 row.otherMeasurementUnitTitle = chargeItem.Unit;
-                row.otherMeasurementUnitQuantity = explicitOtherMeasurementUnitQuantity
-                    ?? ToOtherMeasurementUnitQuantity(chargeItem.Quantity);
+                row.otherMeasurementUnitQuantity = ToOtherMeasurementUnitQuantity(chargeItem.UnitQuantity ?? chargeItem.Quantity);
                 row.otherMeasurementUnitQuantitySpecified = true;
             }
 
@@ -751,7 +744,7 @@ public static class AADEMappings
     /// where a caller flips <c>measurementUnit</c> to 7 via override without supplying the
     /// accompanying title/quantity, falling back to the values on the original ChargeItem.
     /// </summary>
-    public static void EnsureOtherPiecesMandatoryFields(InvoiceRowType row, ChargeItem chargeItem, int? explicitOtherMeasurementUnitQuantity = null)
+    public static void EnsureOtherPiecesMandatoryFields(InvoiceRowType row, ChargeItem chargeItem)
     {
         if (!row.measurementUnitSpecified || row.measurementUnit != MyDataMeasurementUnit.OtherPieces)
         {
@@ -765,27 +758,25 @@ public static class AADEMappings
 
         if (!row.otherMeasurementUnitQuantitySpecified)
         {
-            row.otherMeasurementUnitQuantity = explicitOtherMeasurementUnitQuantity
-                ?? ToOtherMeasurementUnitQuantity(chargeItem.Quantity);
+            row.otherMeasurementUnitQuantity = ToOtherMeasurementUnitQuantity(chargeItem.UnitQuantity ?? chargeItem.Quantity);
             row.otherMeasurementUnitQuantitySpecified = true;
         }
     }
 
     /// <summary>
-    /// Converts a <see cref="ChargeItem.Quantity"/> (decimal) to the AADE
-    /// <c>otherMeasurementUnitQuantity</c> (int). Throws if the value would lose precision —
-    /// callers that need a fractional source-quantity must supply the value explicitly via
-    /// <c>ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity</c>.
+    /// Converts a source quantity (<see cref="ChargeItem.UnitQuantity"/> or
+    /// <see cref="ChargeItem.Quantity"/>) to the AADE <c>otherMeasurementUnitQuantity</c> (int).
+    /// Throws if the value would lose precision — fractional inputs are rejected since the
+    /// AADE field is an integer.
     /// </summary>
-    private static int ToOtherMeasurementUnitQuantity(decimal chargeItemQuantity)
+    private static int ToOtherMeasurementUnitQuantity(decimal sourceQuantity)
     {
-        var abs = Math.Abs(chargeItemQuantity);
+        var abs = Math.Abs(sourceQuantity);
         if (abs != Math.Truncate(abs))
         {
             throw new Exception(
-                $"ChargeItem.Quantity ({chargeItemQuantity}) must be a whole number to populate "
-                + "otherMeasurementUnitQuantity for AADE measurementUnit=7 (OtherPieces). "
-                + "Set ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity explicitly to override.");
+                $"ChargeItem.UnitQuantity/Quantity ({sourceQuantity}) must be a whole number to populate "
+                + "otherMeasurementUnitQuantity for AADE measurementUnit=7 (OtherPieces).");
         }
         return (int) abs;
     }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -689,32 +689,50 @@ public static class AADEMappings
     /// honoring the ChargeItem.Unit / ChargeItem.UnitQuantity named properties with fallbacks
     /// per market-gr issue #182:
     ///
-    /// - If <see cref="ChargeItem.Unit"/> is not set or empty: <c>measurementUnit = Pieces (1)</c>
-    ///   and the row's <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/>.
-    /// - If <see cref="ChargeItem.Unit"/> matches an AADE-defined unit (kg, litres, meters, ...):
-    ///   <c>measurementUnit</c> is set to that code.
-    /// - If <see cref="ChargeItem.Unit"/> is a free-form string: <c>measurementUnit = OtherPieces (7)</c>
-    ///   and <c>otherMeasurementUnitTitle</c> carries the original string. The row's
-    ///   <c>otherMeasurementUnitQuantity</c> is filled from <see cref="ChargeItem.UnitQuantity"/> when set,
-    ///   otherwise from <see cref="ChargeItem.Quantity"/> (Quantity is used as UnitQuantity when missing).
+    /// - If <see cref="ChargeItem.Unit"/> is empty: <c>measurementUnit = Pieces (1)</c>; the row's
+    ///   <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/>.
+    /// - If <see cref="ChargeItem.Unit"/> is set and <see cref="ChargeItem.UnitQuantity"/> is missing:
+    ///   the row's <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/> (Quantity is used as UnitQuantity).
+    /// - If <see cref="ChargeItem.Unit"/> is set and <see cref="ChargeItem.UnitQuantity"/> is set:
+    ///   the row's <c>quantity</c> becomes <see cref="ChargeItem.UnitQuantity"/>.
+    ///
+    /// For free-form unit strings (no AADE-defined code), <c>measurementUnit = OtherPieces (7)</c>
+    /// and <c>otherMeasurementUnitTitle</c> preserves the original string.
     /// </summary>
+    /// <remarks>
+    /// The caller is expected to have populated <c>row.quantity</c> with <c>ChargeItem.Quantity</c>
+    /// (with any refund/abs sign adjustments already applied). When this method overrides the value
+    /// with <c>UnitQuantity</c>, it preserves the sign of the value that was already on the row so
+    /// existing refund / partial-return semantics are not broken.
+    /// </remarks>
     public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
     {
         row.measurementUnit = GetMeasurementUnit(chargeItem);
         row.measurementUnitSpecified = true;
 
-        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces && !string.IsNullOrWhiteSpace(chargeItem.Unit))
+        if (string.IsNullOrWhiteSpace(chargeItem.Unit))
         {
-            // Only carry the title for free-form units. If the caller explicitly used "OtherPieces"
-            // (the AADE-defined code), no title is needed.
-            if (!string.Equals(chargeItem.Unit, "OtherPieces", StringComparison.OrdinalIgnoreCase))
-            {
-                row.otherMeasurementUnitTitle = chargeItem.Unit;
-            }
+            // No Unit set: keep the row's quantity as ChargeItem.Quantity (already set by the caller),
+            // and use the default measurementUnit (Pieces).
+            return;
+        }
 
-            var otherQuantity = chargeItem.UnitQuantity ?? chargeItem.Quantity;
-            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(otherQuantity), MidpointRounding.AwayFromZero);
-            row.otherMeasurementUnitQuantitySpecified = true;
+        // Free-form Unit string: preserve the original via otherMeasurementUnitTitle. When the caller
+        // explicitly used the AADE-defined code "OtherPieces", no title is needed.
+        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces &&
+            !string.Equals(chargeItem.Unit, "OtherPieces", StringComparison.OrdinalIgnoreCase))
+        {
+            row.otherMeasurementUnitTitle = chargeItem.Unit;
+        }
+
+        // Unit is set and UnitQuantity is provided: the AADE row's quantity becomes UnitQuantity.
+        // (When UnitQuantity is missing, the existing row.quantity already carries Quantity, which
+        // implements the "Quantity is used as UnitQuantity" fallback.)
+        if (chargeItem.UnitQuantity.HasValue)
+        {
+            var sign = row.quantity < 0 ? -1m : 1m;
+            row.quantity = sign * Math.Abs(chargeItem.UnitQuantity.Value);
+            row.quantitySpecified = true;
         }
     }
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -663,11 +663,7 @@ public static class AADEMappings
 
     public static int GetMeasurementUnit(ChargeItem? chargeItem)
     {
-        if (chargeItem == null)
-        {
-            return MyDataMeasurementUnit.Pieces;
-        }
-        if (string.IsNullOrWhiteSpace(chargeItem?.Unit))
+        if (chargeItem == null || string.IsNullOrWhiteSpace(chargeItem.Unit))
         {
             return MyDataMeasurementUnit.Pieces;
         }
@@ -681,8 +677,45 @@ public static class AADEMappings
             "squaremeters" => MyDataMeasurementUnit.SquareMeters,
             "cubicmeters" => MyDataMeasurementUnit.CubicMeters,
             "otherpieces" => MyDataMeasurementUnit.OtherPieces,
-            _ => MyDataMeasurementUnit.Pieces
+            // A non-empty Unit that does not match any AADE-defined measurement unit
+            // is mapped to OtherPieces; the original string is carried over via
+            // otherMeasurementUnitTitle (see AADEFactory.ApplyMeasurementUnit).
+            _ => MyDataMeasurementUnit.OtherPieces
         };
+    }
+
+    /// <summary>
+    /// Applies the AADE measurement-unit-related fields on an invoice row from a charge item,
+    /// honoring the ChargeItem.Unit / ChargeItem.UnitQuantity named properties with fallbacks
+    /// per market-gr issue #182:
+    ///
+    /// - If <see cref="ChargeItem.Unit"/> is not set or empty: <c>measurementUnit = Pieces (1)</c>
+    ///   and the row's <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/>.
+    /// - If <see cref="ChargeItem.Unit"/> matches an AADE-defined unit (kg, litres, meters, ...):
+    ///   <c>measurementUnit</c> is set to that code.
+    /// - If <see cref="ChargeItem.Unit"/> is a free-form string: <c>measurementUnit = OtherPieces (7)</c>
+    ///   and <c>otherMeasurementUnitTitle</c> carries the original string. The row's
+    ///   <c>otherMeasurementUnitQuantity</c> is filled from <see cref="ChargeItem.UnitQuantity"/> when set,
+    ///   otherwise from <see cref="ChargeItem.Quantity"/> (Quantity is used as UnitQuantity when missing).
+    /// </summary>
+    public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
+    {
+        row.measurementUnit = GetMeasurementUnit(chargeItem);
+        row.measurementUnitSpecified = true;
+
+        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces && !string.IsNullOrWhiteSpace(chargeItem.Unit))
+        {
+            // Only carry the title for free-form units. If the caller explicitly used "OtherPieces"
+            // (the AADE-defined code), no title is needed.
+            if (!string.Equals(chargeItem.Unit, "OtherPieces", StringComparison.OrdinalIgnoreCase))
+            {
+                row.otherMeasurementUnitTitle = chargeItem.Unit;
+            }
+
+            var otherQuantity = chargeItem.UnitQuantity ?? chargeItem.Quantity;
+            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(otherQuantity), MidpointRounding.AwayFromZero);
+            row.otherMeasurementUnitQuantitySpecified = true;
+        }
     }
 
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -687,21 +687,23 @@ public static class AADEMappings
     /// <summary>
     /// Applies the AADE measurement-unit-related fields on an invoice row from a charge item,
     /// honoring the ChargeItem.Unit / ChargeItem.UnitQuantity named properties with fallbacks
-    /// per market-gr issue #182:
-    ///
-    /// - If <see cref="ChargeItem.Unit"/> is empty: <c>measurementUnit = Pieces (1)</c>; the row's
-    ///   <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/>.
-    /// - If <see cref="ChargeItem.Unit"/> is set and <see cref="ChargeItem.UnitQuantity"/> is missing:
-    ///   the row's <c>quantity</c> stays as <see cref="ChargeItem.Quantity"/> (Quantity is used as UnitQuantity).
-    /// - If <see cref="ChargeItem.Unit"/> is set and <see cref="ChargeItem.UnitQuantity"/> is set:
-    ///   the row's <c>quantity</c> becomes <see cref="ChargeItem.UnitQuantity"/>.
-    ///
-    /// For free-form unit strings (no AADE-defined code), <c>measurementUnit = OtherPieces (7)</c>
-    /// and <c>otherMeasurementUnitTitle</c> preserves the original string.
+    /// per market-gr issue #182.
     /// </summary>
     /// <remarks>
-    /// AADE schema requires <c>quantity &gt; 0</c> (minExclusive="0"), so the value is always emitted
-    /// as the absolute value when this method overrides the row.
+    /// Per myDATA REST API spec v2.0.1 §5.4 rule #9: when <c>measurementUnit = 7</c>
+    /// (Τεμάχια_Λοιπές Περιπτώσεις / Other Pieces), <c>otherMeasurementUnitQuantity</c> and
+    /// <c>otherMeasurementUnitTitle</c> are MANDATORY. The spec also clarifies that
+    /// <c>quantity</c> always represents the count of items being moved, NOT the count of packaging.
+    ///
+    /// Mapping applied here:
+    /// <list type="bullet">
+    ///   <item><description><c>row.quantity</c> ← <see cref="ChargeItem.UnitQuantity"/> when set, otherwise <see cref="ChargeItem.Quantity"/> (item count)</description></item>
+    ///   <item><description><c>row.otherMeasurementUnitQuantity</c> ← <see cref="ChargeItem.Quantity"/> (packaging count, only when measurementUnit=7)</description></item>
+    ///   <item><description><c>row.otherMeasurementUnitTitle</c> ← <see cref="ChargeItem.Unit"/> (packaging description, only when measurementUnit=7)</description></item>
+    /// </list>
+    ///
+    /// AADE schema requires <c>quantity &gt; 0</c> (<c>minExclusive="0"</c>), so the absolute value
+    /// is always emitted.
     /// </remarks>
     public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
     {
@@ -715,17 +717,19 @@ public static class AADEMappings
             return;
         }
 
-        // Free-form Unit string: preserve the original via otherMeasurementUnitTitle. When the caller
-        // explicitly used the AADE-defined code "OtherPieces", no title is needed.
-        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces &&
-            !string.Equals(chargeItem.Unit, "OtherPieces", StringComparison.OrdinalIgnoreCase))
+        // measurementUnit = 7 → both otherMeasurementUnitTitle and otherMeasurementUnitQuantity
+        // are mandatory per spec §5.4 rule #9.
+        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces)
         {
             row.otherMeasurementUnitTitle = chargeItem.Unit;
+            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(chargeItem.Quantity), MidpointRounding.AwayFromZero);
+            row.otherMeasurementUnitQuantitySpecified = true;
         }
 
-        // Unit is set and UnitQuantity is provided: the AADE row's quantity becomes UnitQuantity.
-        // (When UnitQuantity is missing, the existing row.quantity already carries Quantity, which
-        // implements the "Quantity is used as UnitQuantity" fallback.)
+        // Unit is set and UnitQuantity is provided: the AADE row's quantity becomes UnitQuantity
+        // (the count of items being moved). When UnitQuantity is missing, row.quantity already
+        // carries ChargeItem.Quantity from the caller — implementing the fallback rule
+        // "Quantity is used as UnitQuantity".
         if (chargeItem.UnitQuantity.HasValue)
         {
             row.quantity = Math.Abs(chargeItem.UnitQuantity.Value);

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -732,6 +732,8 @@ public static class AADEMappings
             }
         }
 
+        // Normalize: AADE requires quantity > 0 (minExclusive="0"). At this point row.quantity
+        // is whichever source already won above (UnitQuantity or caller-supplied Quantity).
         row.quantity = Math.Abs(row.quantity);
     }
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -704,37 +704,42 @@ public static class AADEMappings
     ///
     /// AADE schema requires <c>quantity &gt; 0</c> (<c>minExclusive="0"</c>), so the absolute value
     /// is always emitted.
+    ///
+    /// <paramref name="explicitOtherMeasurementUnitQuantity"/> takes precedence over the
+    /// <see cref="ChargeItem.Quantity"/> fallback for <c>otherMeasurementUnitQuantity</c>
+    /// (sourced from <c>ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity</c>). When the
+    /// caller provides this, the whole-number validation against <c>ChargeItem.Quantity</c>
+    /// is skipped because the explicit value is already an <c>int</c>.
     /// </remarks>
-    public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem)
+    public static void ApplyMeasurementUnit(InvoiceRowType row, ChargeItem chargeItem, int? explicitOtherMeasurementUnitQuantity = null)
     {
         row.measurementUnit = GetMeasurementUnit(chargeItem);
         row.measurementUnitSpecified = true;
 
-        if (string.IsNullOrWhiteSpace(chargeItem.Unit))
+        if (!string.IsNullOrWhiteSpace(chargeItem.Unit))
         {
-            // No Unit set: keep the row's quantity as ChargeItem.Quantity (already set by the caller),
-            // and use the default measurementUnit (Pieces).
-            return;
+            // measurementUnit = 7 → both otherMeasurementUnitTitle and otherMeasurementUnitQuantity
+            // are mandatory per spec §5.4 rule #9.
+            if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces)
+            {
+                row.otherMeasurementUnitTitle = chargeItem.Unit;
+                row.otherMeasurementUnitQuantity = explicitOtherMeasurementUnitQuantity
+                    ?? ToOtherMeasurementUnitQuantity(chargeItem.Quantity);
+                row.otherMeasurementUnitQuantitySpecified = true;
+            }
+
+            // Unit is set and UnitQuantity is provided: the AADE row's quantity becomes UnitQuantity
+            // (the count of items being moved). When UnitQuantity is missing, row.quantity already
+            // carries ChargeItem.Quantity from the caller — implementing the fallback rule
+            // "Quantity is used as UnitQuantity".
+            if (chargeItem.UnitQuantity.HasValue)
+            {
+                row.quantity = chargeItem.UnitQuantity.Value;
+                row.quantitySpecified = true;
+            }
         }
 
-        // measurementUnit = 7 → both otherMeasurementUnitTitle and otherMeasurementUnitQuantity
-        // are mandatory per spec §5.4 rule #9.
-        if (row.measurementUnit == MyDataMeasurementUnit.OtherPieces)
-        {
-            row.otherMeasurementUnitTitle = chargeItem.Unit;
-            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(chargeItem.Quantity), MidpointRounding.AwayFromZero);
-            row.otherMeasurementUnitQuantitySpecified = true;
-        }
-
-        // Unit is set and UnitQuantity is provided: the AADE row's quantity becomes UnitQuantity
-        // (the count of items being moved). When UnitQuantity is missing, row.quantity already
-        // carries ChargeItem.Quantity from the caller — implementing the fallback rule
-        // "Quantity is used as UnitQuantity".
-        if (chargeItem.UnitQuantity.HasValue)
-        {
-            row.quantity = Math.Abs(chargeItem.UnitQuantity.Value);
-            row.quantitySpecified = true;
-        }
+        row.quantity = Math.Abs(row.quantity);
     }
 
     /// <summary>
@@ -746,7 +751,7 @@ public static class AADEMappings
     /// where a caller flips <c>measurementUnit</c> to 7 via override without supplying the
     /// accompanying title/quantity, falling back to the values on the original ChargeItem.
     /// </summary>
-    public static void EnsureOtherPiecesMandatoryFields(InvoiceRowType row, ChargeItem chargeItem)
+    public static void EnsureOtherPiecesMandatoryFields(InvoiceRowType row, ChargeItem chargeItem, int? explicitOtherMeasurementUnitQuantity = null)
     {
         if (!row.measurementUnitSpecified || row.measurementUnit != MyDataMeasurementUnit.OtherPieces)
         {
@@ -760,9 +765,29 @@ public static class AADEMappings
 
         if (!row.otherMeasurementUnitQuantitySpecified)
         {
-            row.otherMeasurementUnitQuantity = (int) Math.Round(Math.Abs(chargeItem.Quantity), MidpointRounding.AwayFromZero);
+            row.otherMeasurementUnitQuantity = explicitOtherMeasurementUnitQuantity
+                ?? ToOtherMeasurementUnitQuantity(chargeItem.Quantity);
             row.otherMeasurementUnitQuantitySpecified = true;
         }
+    }
+
+    /// <summary>
+    /// Converts a <see cref="ChargeItem.Quantity"/> (decimal) to the AADE
+    /// <c>otherMeasurementUnitQuantity</c> (int). Throws if the value would lose precision —
+    /// callers that need a fractional source-quantity must supply the value explicitly via
+    /// <c>ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity</c>.
+    /// </summary>
+    private static int ToOtherMeasurementUnitQuantity(decimal chargeItemQuantity)
+    {
+        var abs = Math.Abs(chargeItemQuantity);
+        if (abs != Math.Truncate(abs))
+        {
+            throw new Exception(
+                $"ChargeItem.Quantity ({chargeItemQuantity}) must be a whole number to populate "
+                + "otherMeasurementUnitQuantity for AADE measurementUnit=7 (OtherPieces). "
+                + "Set ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity explicitly to override.");
+        }
+        return (int) abs;
     }
 
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/CaseDataPayloads.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/CaseDataPayloads.cs
@@ -30,4 +30,7 @@ public class ftChargeItemCaseDataGreekPayload
 {
     [JsonPropertyName("mydataoverride")]
     public ChargeItemMyDataOverride? MyDataOverride { get; set; }
+
+    [JsonPropertyName("othermeasurementunitquantity")]
+    public int? OtherMeasurementUnitQuantity { get; set; }
 }

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/CaseDataPayloads.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/CaseDataPayloads.cs
@@ -30,7 +30,4 @@ public class ftChargeItemCaseDataGreekPayload
 {
     [JsonPropertyName("mydataoverride")]
     public ChargeItemMyDataOverride? MyDataOverride { get; set; }
-
-    [JsonPropertyName("othermeasurementunitquantity")]
-    public int? OtherMeasurementUnitQuantity { get; set; }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -220,5 +220,102 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             row.otherMeasurementUnitQuantity.Should().Be(4);
             row.quantity.Should().Be(4m);
         }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithoutUnit_NormalizesNegativeRowQuantityToPositive()
+        {
+            // Refund flows pre-set row.quantity to a negative value (AADEFactory line 1189).
+            // AADE schema requires quantity > 0 even on the empty-Unit / default-Pieces path.
+            var row = new InvoiceRowType { quantity = -5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 5m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.Pieces);
+            row.quantity.Should().Be(5m);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithStandardUnit_AndNegativeRowQuantity_NormalizesToPositive()
+        {
+            // Same normalization applies when Unit maps to a standard code and UnitQuantity is missing.
+            var row = new InvoiceRowType { quantity = -2.5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "kg" };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.Kg);
+            row.quantity.Should().Be(2.5m);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithFractionalQuantityForOtherPieces_Throws()
+        {
+            // otherMeasurementUnitQuantity is an int in the AADE schema. We refuse silent
+            // rounding of fractional ChargeItem.Quantity; the caller must set the explicit
+            // named property if they really need a non-whole source.
+            var row = new InvoiceRowType { quantity = 1.5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels" };
+
+            var act = () => AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            act.Should().Throw<Exception>()
+                .WithMessage("*whole number*otherMeasurementUnitQuantity*");
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithExplicitOtherMeasurementUnitQuantity_BypassesFractionalCheck()
+        {
+            // When the caller supplies ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity,
+            // the fractional ChargeItem.Quantity is irrelevant — the int value wins.
+            var row = new InvoiceRowType { quantity = 1.5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels", UnitQuantity = 9m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem, explicitOtherMeasurementUnitQuantity: 3);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
+            row.otherMeasurementUnitTitle.Should().Be("barrels");
+            row.otherMeasurementUnitQuantity.Should().Be(3);
+            row.quantity.Should().Be(9m);
+        }
+
+        [Fact]
+        public void EnsureOtherPiecesMandatoryFields_WithFractionalQuantity_Throws()
+        {
+            // Same whole-number contract applies in the post-override guard.
+            var row = new InvoiceRowType
+            {
+                quantity = 5m,
+                quantitySpecified = true,
+                measurementUnit = MyDataMeasurementUnit.OtherPieces,
+                measurementUnitSpecified = true
+            };
+            var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "barrels" };
+
+            var act = () => AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem);
+
+            act.Should().Throw<Exception>()
+                .WithMessage("*whole number*otherMeasurementUnitQuantity*");
+        }
+
+        [Fact]
+        public void EnsureOtherPiecesMandatoryFields_WithExplicitQuantity_BypassesFractionalCheck()
+        {
+            // Guard accepts an explicit GR.OtherMeasurementUnitQuantity, even when the
+            // ChargeItem.Quantity would otherwise have failed the whole-number check.
+            var row = new InvoiceRowType
+            {
+                quantity = 5m,
+                quantitySpecified = true,
+                measurementUnit = MyDataMeasurementUnit.OtherPieces,
+                measurementUnitSpecified = true
+            };
+            var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "barrels" };
+
+            AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem, explicitOtherMeasurementUnitQuantity: 4);
+
+            row.otherMeasurementUnitTitle.Should().Be("barrels");
+            row.otherMeasurementUnitQuantity.Should().Be(4);
+        }
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -102,16 +102,16 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithRefundSignedQuantity_AndUnitQuantity_PreservesSign()
+        public void ApplyMeasurementUnit_WithUnitQuantity_AlwaysEmitsPositiveQuantity()
         {
-            // The caller has already set row.quantity = -ChargeItem.Quantity for a refund. When we
-            // override with UnitQuantity we must keep the negative sign so refund semantics survive.
-            var row = new InvoiceRowType { quantity = -3m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "kg", UnitQuantity = 12.5m };
+            // AADE schema requires quantity > 0 (minExclusive="0"). Even if UnitQuantity is provided
+            // as a negative value, the row must carry the absolute value.
+            var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "kg", UnitQuantity = -12.5m };
 
             AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
-            row.quantity.Should().Be(-12.5m);
+            row.quantity.Should().Be(12.5m);
         }
 
         [Fact]

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -54,13 +54,15 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.Pieces);
             row.quantity.Should().Be(5m);
             row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithUnit_WithoutUnitQuantity_KeepsQuantity()
+        public void ApplyMeasurementUnit_WithStandardUnit_WithoutUnitQuantity_KeepsQuantity()
         {
             // Rule: Unit set, UnitQuantity missing → ChargeItem.Quantity is used as UnitQuantity
-            // (i.e. the row's quantity stays as ChargeItem.Quantity).
+            // (i.e. the row's quantity stays as ChargeItem.Quantity). Standard units (kg, ...)
+            // do not populate otherMeasurement* fields (those are reserved for measurementUnit=7).
             var row = new InvoiceRowType { quantity = 2.5m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "kg" };
 
@@ -70,10 +72,11 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.Kg);
             row.quantity.Should().Be(2.5m);
             row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithUnit_AndUnitQuantity_UsesUnitQuantityForRowQuantity()
+        public void ApplyMeasurementUnit_WithStandardUnit_AndUnitQuantity_UsesUnitQuantityForRowQuantity()
         {
             // Rule: Unit set, UnitQuantity set → row.quantity = UnitQuantity.
             var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
@@ -85,20 +88,44 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             row.quantity.Should().Be(12.5m);
             row.quantitySpecified.Should().BeTrue();
             row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithFreeFormUnit_PreservesTitleAndAppliesQuantityRule()
+        public void ApplyMeasurementUnit_WithFreeFormUnit_AndUnitQuantity_FillsAllOtherFields()
         {
-            // Free-form Unit ("barrels"): goes to OtherPieces, title preserved; quantity rule applies.
+            // Per myDATA spec §5.4 rule #9: measurementUnit=7 requires both
+            // otherMeasurementUnitTitle (packaging description) and otherMeasurementUnitQuantity
+            // (packaging count). The row's quantity is the item count (UnitQuantity).
             var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "barrels", UnitQuantity = 8m };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "Παλέτες", UnitQuantity = 30m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
+            row.otherMeasurementUnitTitle.Should().Be("Παλέτες");
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(3);
+            row.quantity.Should().Be(30m);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithFreeFormUnit_WithoutUnitQuantity_FallsBackToQuantity()
+        {
+            // When UnitQuantity is missing, ChargeItem.Quantity stands in as item count (per the
+            // user fallback rule). otherMeasurementUnitQuantity still carries the same value, since
+            // we only have one count to work with — but the spec contract (both fields populated)
+            // is satisfied.
+            var row = new InvoiceRowType { quantity = 7m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 7m, Unit = "barrels" };
 
             AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
             row.otherMeasurementUnitTitle.Should().Be("barrels");
-            row.quantity.Should().Be(8m);
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(7);
+            row.quantity.Should().Be(7m);
         }
 
         [Fact]
@@ -115,16 +142,20 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithExplicitOtherPiecesCode_DoesNotSetTitle()
+        public void ApplyMeasurementUnit_WithExplicitOtherPiecesCode_StillSetsMandatoryOtherFields()
         {
-            // "OtherPieces" matches the AADE-defined enum name, so we don't carry a title.
+            // Even when the caller passes the AADE code name "OtherPieces" as Unit, the spec
+            // mandates that both otherMeasurementUnitTitle and otherMeasurementUnitQuantity are
+            // filled. We pass the original string through as the title.
             var row = new InvoiceRowType { quantity = 4m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 4m, Unit = "OtherPieces", UnitQuantity = 4m };
 
             AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
-            row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitTitle.Should().Be("OtherPieces");
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(4);
             row.quantity.Should().Be(4m);
         }
     }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -42,8 +42,9 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithoutUnit_DefaultsToPiecesAndDoesNotSetOtherFields()
+        public void ApplyMeasurementUnit_WithoutUnit_DefaultsToPiecesAndKeepsQuantity()
         {
+            // Rule: empty Unit → quantity stays as ChargeItem.Quantity, measurementUnit = Pieces.
             var row = new InvoiceRowType { quantity = 5m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 5m };
 
@@ -51,15 +52,15 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
 
             row.measurementUnitSpecified.Should().BeTrue();
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.Pieces);
-            row.otherMeasurementUnitTitle.Should().BeNull();
-            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
-            // The line-level quantity stays untouched.
             row.quantity.Should().Be(5m);
+            row.otherMeasurementUnitTitle.Should().BeNull();
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithStandardUnit_SetsCodeAndDoesNotSetOtherFields()
+        public void ApplyMeasurementUnit_WithUnit_WithoutUnitQuantity_KeepsQuantity()
         {
+            // Rule: Unit set, UnitQuantity missing → ChargeItem.Quantity is used as UnitQuantity
+            // (i.e. the row's quantity stays as ChargeItem.Quantity).
             var row = new InvoiceRowType { quantity = 2.5m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "kg" };
 
@@ -67,41 +68,56 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
 
             row.measurementUnitSpecified.Should().BeTrue();
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.Kg);
+            row.quantity.Should().Be(2.5m);
             row.otherMeasurementUnitTitle.Should().BeNull();
-            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithFreeFormUnit_AndUnitQuantity_UsesUnitQuantity()
+        public void ApplyMeasurementUnit_WithUnit_AndUnitQuantity_UsesUnitQuantityForRowQuantity()
         {
+            // Rule: Unit set, UnitQuantity set → row.quantity = UnitQuantity.
             var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "barrels", UnitQuantity = 12m };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "kg", UnitQuantity = 12.5m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.Kg);
+            row.quantity.Should().Be(12.5m);
+            row.quantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitTitle.Should().BeNull();
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithFreeFormUnit_PreservesTitleAndAppliesQuantityRule()
+        {
+            // Free-form Unit ("barrels"): goes to OtherPieces, title preserved; quantity rule applies.
+            var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "barrels", UnitQuantity = 8m };
 
             AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
             row.otherMeasurementUnitTitle.Should().Be("barrels");
-            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
-            row.otherMeasurementUnitQuantity.Should().Be(12);
+            row.quantity.Should().Be(8m);
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithFreeFormUnit_WithoutUnitQuantity_FallsBackToQuantity()
+        public void ApplyMeasurementUnit_WithRefundSignedQuantity_AndUnitQuantity_PreservesSign()
         {
-            var row = new InvoiceRowType { quantity = 7m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 7m, Unit = "barrels" };
+            // The caller has already set row.quantity = -ChargeItem.Quantity for a refund. When we
+            // override with UnitQuantity we must keep the negative sign so refund semantics survive.
+            var row = new InvoiceRowType { quantity = -3m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "kg", UnitQuantity = 12.5m };
 
             AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
-            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
-            row.otherMeasurementUnitTitle.Should().Be("barrels");
-            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
-            row.otherMeasurementUnitQuantity.Should().Be(7);
+            row.quantity.Should().Be(-12.5m);
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithExplicitOtherPieces_DoesNotSetTitleButFillsQuantity()
+        public void ApplyMeasurementUnit_WithExplicitOtherPiecesCode_DoesNotSetTitle()
         {
+            // "OtherPieces" matches the AADE-defined enum name, so we don't carry a title.
             var row = new InvoiceRowType { quantity = 4m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 4m, Unit = "OtherPieces", UnitQuantity = 4m };
 
@@ -109,8 +125,7 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
 
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
             row.otherMeasurementUnitTitle.Should().BeNull();
-            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
-            row.otherMeasurementUnitQuantity.Should().Be(4);
+            row.quantity.Should().Be(4m);
         }
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using fiskaltrust.ifPOS.v2;
+using fiskaltrust.Middleware.SCU.GR.MyData.Models;
 using FluentAssertions;
 using Xunit;
 
@@ -18,10 +19,13 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         [InlineData("SquareMeters", 5)]
         [InlineData("CubicMeters", 6)]
         [InlineData("OtherPieces", 7)]
-        // legacy / fallback behavior
-        [InlineData("Unknown", 1)]
+        // Empty / null Unit defaults to Pieces (issue #182).
         [InlineData("", 1)]
         [InlineData(null, 1)]
+        // A non-empty, free-form Unit string is routed to OtherPieces (issue #182);
+        // the original string is preserved by AADEMappings.ApplyMeasurementUnit.
+        [InlineData("Unknown", 7)]
+        [InlineData("barrels", 7)]
         public void GetMeasurementUnit_ShouldReturnExpectedValue(string unit, int expectedValue)
         {
             // Arrange
@@ -35,6 +39,78 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
 
             // Assert
             result.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithoutUnit_DefaultsToPiecesAndDoesNotSetOtherFields()
+        {
+            var row = new InvoiceRowType { quantity = 5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 5m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnitSpecified.Should().BeTrue();
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.Pieces);
+            row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
+            // The line-level quantity stays untouched.
+            row.quantity.Should().Be(5m);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithStandardUnit_SetsCodeAndDoesNotSetOtherFields()
+        {
+            var row = new InvoiceRowType { quantity = 2.5m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "kg" };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnitSpecified.Should().BeTrue();
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.Kg);
+            row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithFreeFormUnit_AndUnitQuantity_UsesUnitQuantity()
+        {
+            var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 3m, Unit = "barrels", UnitQuantity = 12m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
+            row.otherMeasurementUnitTitle.Should().Be("barrels");
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(12);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithFreeFormUnit_WithoutUnitQuantity_FallsBackToQuantity()
+        {
+            var row = new InvoiceRowType { quantity = 7m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 7m, Unit = "barrels" };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
+            row.otherMeasurementUnitTitle.Should().Be("barrels");
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(7);
+        }
+
+        [Fact]
+        public void ApplyMeasurementUnit_WithExplicitOtherPieces_DoesNotSetTitleButFillsQuantity()
+        {
+            var row = new InvoiceRowType { quantity = 4m, quantitySpecified = true };
+            var chargeItem = new ChargeItem { Quantity = 4m, Unit = "OtherPieces", UnitQuantity = 4m };
+
+            AADEMappings.ApplyMeasurementUnit(row, chargeItem);
+
+            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
+            row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(4);
         }
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -142,6 +142,68 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
+        public void EnsureOtherPiecesMandatoryFields_WhenOverrideFlipsToSeven_FillsTitleFromUnit()
+        {
+            // Simulates an override that set measurementUnit=7 without populating the title.
+            // The guard must back-fill from chargeItem.Unit so the row stays spec-valid.
+            var row = new InvoiceRowType
+            {
+                quantity = 5m,
+                quantitySpecified = true,
+                measurementUnit = MyDataMeasurementUnit.OtherPieces,
+                measurementUnitSpecified = true
+            };
+            var chargeItem = new ChargeItem { Quantity = 5m, Unit = "Παλέτες" };
+
+            AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem);
+
+            row.otherMeasurementUnitTitle.Should().Be("Παλέτες");
+            row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
+            row.otherMeasurementUnitQuantity.Should().Be(5);
+        }
+
+        [Fact]
+        public void EnsureOtherPiecesMandatoryFields_WithExistingTitle_DoesNotOverwrite()
+        {
+            // If the override already supplied a title we must respect it.
+            var row = new InvoiceRowType
+            {
+                quantity = 10m,
+                quantitySpecified = true,
+                measurementUnit = MyDataMeasurementUnit.OtherPieces,
+                measurementUnitSpecified = true,
+                otherMeasurementUnitTitle = "Δοχεία",
+                otherMeasurementUnitQuantity = 2,
+                otherMeasurementUnitQuantitySpecified = true
+            };
+            var chargeItem = new ChargeItem { Quantity = 5m, Unit = "Παλέτες" };
+
+            AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem);
+
+            row.otherMeasurementUnitTitle.Should().Be("Δοχεία");
+            row.otherMeasurementUnitQuantity.Should().Be(2);
+        }
+
+        [Fact]
+        public void EnsureOtherPiecesMandatoryFields_WhenMeasurementUnitNotSeven_DoesNothing()
+        {
+            // Other measurement units must not get otherMeasurement* fields.
+            var row = new InvoiceRowType
+            {
+                quantity = 5m,
+                quantitySpecified = true,
+                measurementUnit = MyDataMeasurementUnit.Kg,
+                measurementUnitSpecified = true
+            };
+            var chargeItem = new ChargeItem { Quantity = 5m, Unit = "kg" };
+
+            AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem);
+
+            row.otherMeasurementUnitTitle.Should().BeNull();
+            row.otherMeasurementUnitQuantitySpecified.Should().BeFalse();
+        }
+
+        [Fact]
         public void ApplyMeasurementUnit_WithExplicitOtherPiecesCode_StillSetsMandatoryOtherFields()
         {
             // Even when the caller passes the AADE code name "OtherPieces" as Unit, the spec

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsChargeItemTests.cs
@@ -95,8 +95,9 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         public void ApplyMeasurementUnit_WithFreeFormUnit_AndUnitQuantity_FillsAllOtherFields()
         {
             // Per myDATA spec §5.4 rule #9: measurementUnit=7 requires both
-            // otherMeasurementUnitTitle (packaging description) and otherMeasurementUnitQuantity
-            // (packaging count). The row's quantity is the item count (UnitQuantity).
+            // otherMeasurementUnitTitle (packaging description) and otherMeasurementUnitQuantity.
+            // Both row.quantity and row.otherMeasurementUnitQuantity are sourced from
+            // ChargeItem.UnitQuantity when present.
             var row = new InvoiceRowType { quantity = 3m, quantitySpecified = true };
             var chargeItem = new ChargeItem { Quantity = 3m, Unit = "Παλέτες", UnitQuantity = 30m };
 
@@ -105,7 +106,7 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
             row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
             row.otherMeasurementUnitTitle.Should().Be("Παλέτες");
             row.otherMeasurementUnitQuantitySpecified.Should().BeTrue();
-            row.otherMeasurementUnitQuantity.Should().Be(3);
+            row.otherMeasurementUnitQuantity.Should().Be(30);
             row.quantity.Should().Be(30m);
         }
 
@@ -249,13 +250,12 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithFractionalQuantityForOtherPieces_Throws()
+        public void ApplyMeasurementUnit_WithFractionalUnitQuantityForOtherPieces_Throws()
         {
-            // otherMeasurementUnitQuantity is an int in the AADE schema. We refuse silent
-            // rounding of fractional ChargeItem.Quantity; the caller must set the explicit
-            // named property if they really need a non-whole source.
+            // otherMeasurementUnitQuantity is an int in the AADE schema; we refuse silent
+            // rounding of fractional source quantities (UnitQuantity takes precedence over Quantity).
             var row = new InvoiceRowType { quantity = 1.5m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels" };
+            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels", UnitQuantity = 1.5m };
 
             var act = () => AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
@@ -264,19 +264,17 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
         }
 
         [Fact]
-        public void ApplyMeasurementUnit_WithExplicitOtherMeasurementUnitQuantity_BypassesFractionalCheck()
+        public void ApplyMeasurementUnit_WithFractionalQuantityFallbackForOtherPieces_Throws()
         {
-            // When the caller supplies ftChargeItemCaseData.GR.OtherMeasurementUnitQuantity,
-            // the fractional ChargeItem.Quantity is irrelevant — the int value wins.
+            // When UnitQuantity is absent the fallback is ChargeItem.Quantity, which must
+            // also be a whole number for measurementUnit=7.
             var row = new InvoiceRowType { quantity = 1.5m, quantitySpecified = true };
-            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels", UnitQuantity = 9m };
+            var chargeItem = new ChargeItem { Quantity = 1.5m, Unit = "barrels" };
 
-            AADEMappings.ApplyMeasurementUnit(row, chargeItem, explicitOtherMeasurementUnitQuantity: 3);
+            var act = () => AADEMappings.ApplyMeasurementUnit(row, chargeItem);
 
-            row.measurementUnit.Should().Be(MyDataMeasurementUnit.OtherPieces);
-            row.otherMeasurementUnitTitle.Should().Be("barrels");
-            row.otherMeasurementUnitQuantity.Should().Be(3);
-            row.quantity.Should().Be(9m);
+            act.Should().Throw<Exception>()
+                .WithMessage("*whole number*otherMeasurementUnitQuantity*");
         }
 
         [Fact]
@@ -296,26 +294,6 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest
 
             act.Should().Throw<Exception>()
                 .WithMessage("*whole number*otherMeasurementUnitQuantity*");
-        }
-
-        [Fact]
-        public void EnsureOtherPiecesMandatoryFields_WithExplicitQuantity_BypassesFractionalCheck()
-        {
-            // Guard accepts an explicit GR.OtherMeasurementUnitQuantity, even when the
-            // ChargeItem.Quantity would otherwise have failed the whole-number check.
-            var row = new InvoiceRowType
-            {
-                quantity = 5m,
-                quantitySpecified = true,
-                measurementUnit = MyDataMeasurementUnit.OtherPieces,
-                measurementUnitSpecified = true
-            };
-            var chargeItem = new ChargeItem { Quantity = 2.5m, Unit = "barrels" };
-
-            AADEMappings.EnsureOtherPiecesMandatoryFields(row, chargeItem, explicitOtherMeasurementUnitQuantity: 4);
-
-            row.otherMeasurementUnitTitle.Should().Be("barrels");
-            row.otherMeasurementUnitQuantity.Should().Be(4);
         }
     }
 }


### PR DESCRIPTION
## Summary
- Free-form `ChargeItem.Unit` values are now mapped to AADE `OtherPieces (7)` and preserved as `otherMeasurementUnitTitle`, instead of silently collapsing to `Pieces`.
- `ChargeItem.UnitQuantity` populates `otherMeasurementUnitQuantity`, with a fallback to `ChargeItem.Quantity` when `UnitQuantity` is not set.
- Empty/null `Unit` continues to default to `Pieces` and the row's `quantity` stays as `ChargeItem.Quantity`.

Refs: [market-gr#182](https://github.com/fiskaltrust/market-gr/issues/182)

## Behaviour matrix

| `chargeItem.Unit` | `chargeItem.UnitQuantity` | AADE `measurementUnit` | AADE `otherMeasurementUnitTitle` | AADE `otherMeasurementUnitQuantity` |
|---|---|---|---|---|
| _empty / null_ | _any_ | `1` (Pieces) | – | – |
| `kg` / `litres` / `meters` / ... | _any_ | mapped code | – | – |
| `barrels` (free-form) | `12` | `7` (OtherPieces) | `barrels` | `12` |
| `barrels` (free-form) | _missing_ | `7` (OtherPieces) | `barrels` | `Quantity` (fallback) |

These rules are applied for the delivery-note / order paths in `AADEFactory.GetInvoiceDetails`, where `measurementUnit` is already part of the AADE row.

## Notes
- This is a follow-up branch dedicated to this fallback mechanism — it is intentionally narrow in scope. The `UnitPrice` named property on `ChargeItem` has no dedicated counterpart in the AADE schema (price is implied via `netValue`/`quantity`), so it is not consumed in this PR.
- Existing semantics for non-delivery-note flows are unchanged.

## Test plan
- [x] `dotnet test fiskaltrust.Middleware.SCU.GR.MyData.UnitTest` (769/769 passing)
- [x] New unit tests added in `AADEMappingsChargeItemTests` covering each branch of the fallback matrix
- [ ] Manual smoke against the AADE sandbox (delivery note with custom unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)