### PR TITLE
Compare PT refund CaseData fields by value and fix mislabeled error

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/RefundValidator.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/RefundValidator.cs
@@ -113,7 +113,7 @@ public class RefundValidator
             return (flowControl: false, value: Mismatch("ReceiptCase"));
         }
 
-        if (originalItem.ftReceiptCaseData != refundItem.ftReceiptCaseData)
+        if (!CaseDataEquals(originalItem.ftReceiptCaseData, refundItem.ftReceiptCaseData))
         {
             return (flowControl: false, value: Mismatch("ReceiptCaseData"));
         }
@@ -229,9 +229,9 @@ public class RefundValidator
             return (flowControl: false, value: Mismatch("ReceiptCase"));
         }
 
-        if (originalItem.ftChargeItemCaseData != refundItem.ftChargeItemCaseData)
+        if (!CaseDataEquals(originalItem.ftChargeItemCaseData, refundItem.ftChargeItemCaseData))
         {
-            return (flowControl: false, value: Mismatch("cbCustomer"));
+            return (flowControl: false, value: Mismatch("ftChargeItemCaseData"));
         }
 
         if (Math.Abs(Math.Abs(originalItem.GetVATAmount()) - Math.Abs(refundItem.GetVATAmount())) > 0.001m)
@@ -335,7 +335,7 @@ public class RefundValidator
             return (flowControl: false, value: Mismatch("ftPayItemCase"));
         }
 
-        if (originalItem.ftPayItemCaseData != refundItem.ftPayItemCaseData)
+        if (!CaseDataEquals(originalItem.ftPayItemCaseData, refundItem.ftPayItemCaseData))
         {
             return (flowControl: false, value: Mismatch("ftPayItemCaseData"));
         }
@@ -486,6 +486,26 @@ public class RefundValidator
             return ErrorMessagesPT.EEEE_PartialRefundItemsMismatch(originalReceiptReference, "PayItem OtherPayments Exceeded");
         }
         return null; // Validation passed
+    }
+
+    private static bool CaseDataEquals(object? original, object? refundValue)
+    {
+        var originalIsEmpty = original is null || (original is string s1 && s1.Length == 0);
+        var refundIsEmpty = refundValue is null || (refundValue is string s2 && s2.Length == 0);
+        if (originalIsEmpty && refundIsEmpty)
+        {
+            return true;
+        }
+
+        if (originalIsEmpty || refundIsEmpty)
+        {
+            return false;
+        }
+
+        // ftReceiptCaseData/ftChargeItemCaseData/ftPayItemCaseData are typed as object,
+        // so after JSON deserialization both sides are typically distinct JsonElement
+        // instances. Compare by serialized value rather than by reference.
+        return JsonSerializer.Serialize(original) == JsonSerializer.Serialize(refundValue);
     }
 
     private static bool AreOppositeWithTolerance(decimal original, decimal refundValue, decimal tolerance)


### PR DESCRIPTION
## Summary

Full refunds in QueuePT were rejected with `Validation error []: EEEE_Full refund does not match the original invoice '<ref>'. ... (Field: cbCustomer)` whenever the receipt's `ftChargeItemCaseData` (or `ftReceiptCaseData` / `ftPayItemCaseData`) was a non-null value such as `""` on both sides.

### Root cause

`ftReceiptCaseData`, `ftChargeItemCaseData`, and `ftPayItemCaseData` are typed as `System.Object` on the v2 `ReceiptRequest`, `ChargeItem`, and `PayItem`. `RefundValidator` compared them with `!=`, which on `object` is reference equality. After JSON deserialization both sides are distinct `JsonElement` instances, so equal values (e.g. `""` on the stored original and `""` on the incoming refund) always compared as different and the refund failed.

The check inside `CompareChargeItems` additionally reported the failure as `(Field: cbCustomer)` — a copy-paste of the cbCustomer mismatch label one method above — which made the error look like a customer-object problem rather than a CaseData problem.

Existing tests didn't catch this because none of them set the `*CaseData` fields, so both sides were `null` and `null != null` is `false`.

### Fix

- Add a `CaseDataEquals(object?, object?)` helper that treats `null` and `""` as equivalent and otherwise compares via `JsonSerializer.Serialize`.
- Replace the three reference comparisons in `CompareReceiptRequest`, `CompareChargeItems`, and `ComparePayItems` with `CaseDataEquals`.
- Correct the `Mismatch("cbCustomer")` label inside `CompareChargeItems` to `Mismatch("ftChargeItemCaseData")`.

## Test plan

- [ ] Re-run the failing scenario: refund a B2C invoice where the original was persisted with `"ftChargeItemCaseData": ""` and the refund payload also sends `""`. Validation should now pass.
- [ ] Existing PT refund acceptance/unit tests still pass (`fiskaltrust.Middleware.Localization.QueuePT.AcceptanceTest`, `fiskaltrust.Middleware.Localization.v2.UnitTest`).
- [ ] Spot check: a refund whose `ftChargeItemCaseData` actually differs from the original still fails, and the error message now reads `(Field: ftChargeItemCaseData)` rather than `(Field: cbCustomer)`.

## Follow-ups (not in this PR)

- Consider replacing the `JsonSerializer.Serialize` string compare with `JsonNode.DeepEquals` so structurally-equal but differently-ordered objects also compare equal.
- The same `object`-typed `*CaseData` fields exist in QueueES's `RefundValidator` — worth a follow-up audit there.
- Decide whether the `"" ≡ null` leniency should be policy across the codebase or scoped to refund validation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)