### PR TITLE
Fix - owner tip on 11.1; Task 178 service goods

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -252,6 +252,13 @@ public static class AADEMappings
             return IncomeClassificationCategoryType.category1_1;
         }
 
+        //Owner tip falls into category1_3 - service revenue
+        if (chargeItem.ftChargeItemCase.IsTypeOfService(ChargeItemCaseTypeOfService.Tip)
+            && receiptRequest.ftReceiptCase.IsType(ReceiptCaseType.Receipt))
+        {
+            return IncomeClassificationCategoryType.category1_3;
+        }
+
         return chargeItem.ftChargeItemCase.TypeOfService() switch
         {
             ChargeItemCaseTypeOfService.UnknownService => IncomeClassificationCategoryType.category1_95,
@@ -260,7 +267,7 @@ public static class AADEMappings
             ChargeItemCaseTypeOfService.OtherService => IncomeClassificationCategoryType.category1_3,
             ChargeItemCaseTypeOfService.NotOwnSales => IncomeClassificationCategoryType.category1_7,
             ChargeItemCaseTypeOfService.OwnConsumption => IncomeClassificationCategoryType.category1_6,
-            _ => IncomeClassificationCategoryType.category1_95,
+        _ => IncomeClassificationCategoryType.category1_95,
         };
     }
 

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsIncomeClassificationTypeTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsIncomeClassificationTypeTests.cs
@@ -432,4 +432,61 @@ public class AADEMappingsIncomeClassificationTypeTests
     }
 
     #endregion
+
+    #region Tests for Tip (S=3) on PointOfSaleReceipt (11.1)
+
+    [Fact]
+    public void GetIncomeClassificationType_ServiceCharge_S2_On_11_1_ReturnsCat1_3()
+    {
+        // Arrange
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.PointOfSaleReceipt0x0001);
+        var chargeItem = CreateChargeItem(amount: 1.0m, vatAmount: 0.19m, typeOfService: ChargeItemCaseTypeOfService.OtherService);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationType(receiptRequest, chargeItem);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.classificationCategory.Should().Be(IncomeClassificationCategoryType.category1_3);
+        result.classificationType.Should().Be(IncomeClassificationValueType.E3_561_003);
+        result.classificationTypeSpecified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetIncomeClassificationType_OwnerTip_S3_Taxable_On_11_1_ShouldFallbackToCat1_3_NotCat1_95()
+    {
+        // Arrange
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.PointOfSaleReceipt0x0001);
+        var chargeItem = CreateChargeItem(amount: 1.0m, vatAmount: 0.19m, typeOfService: ChargeItemCaseTypeOfService.Tip);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationType(receiptRequest, chargeItem);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.classificationCategory.Should().NotBe(IncomeClassificationCategoryType.category1_95,
+            because: "AADE rejects category1_95 on invoiceType 11.1 with error 313");
+        result.classificationCategory.Should().Be(IncomeClassificationCategoryType.category1_3,
+            because: "S=3 owner tip on 11.1 must fall back to category1_3 (other service revenue)");
+        result.classificationType.Should().Be(IncomeClassificationValueType.E3_561_007);
+        result.classificationTypeSpecified.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GetIncomeClassificationType_OwnerTip_S3_Taxable_On_1_1_ShouldKeepCat1_95()
+    {
+        // Arrange — invoice type (t=1), NOT retail receipt
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.InvoiceB2B0x1002);
+        var chargeItem = CreateChargeItem(amount: 1.0m, vatAmount: 0.19m, typeOfService: ChargeItemCaseTypeOfService.Tip);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationType(receiptRequest, chargeItem);
+
+        // Assert — category1_95 is valid on 1.1 invoice type, no fallback should trigger
+        result.Should().NotBeNull();
+        result.classificationCategory.Should().Be(IncomeClassificationCategoryType.category1_95,
+            because: "category1_95 is allowed on invoice types (1.x/2.x), fallback must NOT fire here");
+    }
+
+    #endregion
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsIncomeClassificationValueTypeTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsIncomeClassificationValueTypeTests.cs
@@ -407,4 +407,54 @@ public class AADEMappingsIncomeClassificationValueTypeTests
     }
 
     #endregion
+
+    // Add this region to the existing file:
+    // scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/AADEMappingsIncomeClassificationValueTypeTests.cs
+
+    #region Tests for Tip (S=3) classification value type
+
+    [Fact]
+    public void GetIncomeClassificationValueType_ServiceCharge_S2_On_Receipt_ReturnsE3_561_003()
+    {
+        // Arrange
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.PointOfSaleReceipt0x0001);
+        var chargeItem = CreateChargeItem(ChargeItemCaseTypeOfService.OtherService);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationValueType(receiptRequest, chargeItem);
+
+        // Assert
+        result.Should().Be(IncomeClassificationValueType.E3_561_003);
+    }
+
+    [Fact]
+    public void GetIncomeClassificationValueType_OwnerTip_S3_On_Receipt_ShouldReturnE3_561_007_NotE3_561_003()
+    {
+        // Arrange
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.PointOfSaleReceipt0x0001);
+        var chargeItem = CreateChargeItem(ChargeItemCaseTypeOfService.Tip);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationValueType(receiptRequest, chargeItem);
+
+        // Assert — Owner tip on receipt falls back to E3_561_007 + category1_3
+        result.Should().Be(IncomeClassificationValueType.E3_561_007,
+            because: "S=3 owner tip on 11.1 must use E3_561_007 as part of the category1_3 fallback");
+    }
+
+    [Fact]
+    public void GetIncomeClassificationValueType_OwnerTip_S3_On_Invoice_ReturnsE3_561_007_NoChange()
+    {
+        // Arrange
+        var receiptRequest = CreateReceiptRequest(ReceiptCase.InvoiceB2B0x1002);
+        var chargeItem = CreateChargeItem(ChargeItemCaseTypeOfService.Tip);
+
+        // Act
+        var result = AADEMappings.GetIncomeClassificationValueType(receiptRequest, chargeItem);
+
+        // Assert
+        result.Should().Be(IncomeClassificationValueType.E3_561_007);
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Description

When a POS sends a charge item with Tip ChargeItemCase and a taxable VAT rate on a `PointOfSaleReceipt` (invoice type `11.1`), the middleware was mapping it to `category1_95` (Other Income Information). AADE rejects this combination with error **313** — `category1_95` is forbidden on invoice type `11.1`.

The fix adds a guard in `GetIncomeClassificationCategoryType`: when owner/company tip is detected on a Receipt type, the category is remapped to `category1_3` (Provision of Services Income), which is allowed on `11.1`. The VAT rate and `E3_561_007` classification type are preserved.

The fix does **not** affect:
- Owner Tip on invoice types (`1.x`, `2.x`) — `category1_95` remains correct there
- Owner Tip with `V=8` (employee tip) — separate concern, not in scope for this fix
- Service charge — was already working correctly, no change

Changes in connection with [#178](https://github.com/fiskaltrust/market-gr/issues/178) to ensure correct semantics.

Fixes fiskaltrust/market-gr#178