### PR TITLE
Introduce possibility to void initiate-scu-switch receipts

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/Factories/RequestCommandFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/Factories/RequestCommandFactory.cs
@@ -44,7 +44,7 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands.Factories
             }
 
             // In failed mode, don't even try to access the SCU
-            if (queueDE.SSCDFailCount > 0 && !request.IsZeroReceipt() && !request.IsFailTransactionReceipt() && !request.IsOutOfOperationReceipt() && !request.IsInitiateScuSwitchReceiptForce() && !request.IsFinishScuSwitchReceipt())
+            if (queueDE.SSCDFailCount > 0 && !request.IsZeroReceipt() && !request.IsFailTransactionReceipt() && !request.IsOutOfOperationReceipt() && !request.IsInitiateScuSwitchReceipt() && !request.IsFinishScuSwitchReceipt())
             {
                 return _serviceProvider.GetRequiredService<SSCDFailedReceiptCommand>();
             }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/Factories/RequestCommandFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/Factories/RequestCommandFactory.cs
@@ -20,7 +20,7 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands.Factories
                 return _serviceProvider.GetRequiredService<DisabledQueueReceiptCommand>();
             }
             // In the process of switching SCUs, and receipt is not finish-switch
-            if (queue.IsActive() && queueDE.ftSignaturCreationUnitDEId == null && !request.IsFinishScuSwitchReceipt())
+            if (queue.IsActive() && queueDE.ftSignaturCreationUnitDEId == null && !request.IsFinishScuSwitchReceipt() && !(request.IsInitiateScuSwitchReceipt() && request.IsVoid()))
             {
                 return _serviceProvider.GetRequiredService<DisabledScuReceiptCommand>();
             }
@@ -44,7 +44,7 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands.Factories
             }
 
             // In failed mode, don't even try to access the SCU
-            if (queueDE.SSCDFailCount > 0 && !request.IsZeroReceipt() && !request.IsFailTransactionReceipt() && !request.IsOutOfOperationReceipt() && !request.IsInitiateScuSwitchReceipt() && !request.IsFinishScuSwitchReceipt())
+            if (queueDE.SSCDFailCount > 0 && !request.IsZeroReceipt() && !request.IsFailTransactionReceipt() && !request.IsOutOfOperationReceipt() && !request.IsInitiateScuSwitchReceiptForce() && !request.IsFinishScuSwitchReceipt())
             {
                 return _serviceProvider.GetRequiredService<SSCDFailedReceiptCommand>();
             }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/InitiateScuSwitchReceiptCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/InitiateScuSwitchReceiptCommand.cs
@@ -39,9 +39,15 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands
 
         public override async Task<RequestCommandResponse> ExecuteAsync(ftQueue queue, ftQueueDE queueDE, ReceiptRequest request, ftQueueItem queueItem)
         {
+            if (request.IsVoid())
+            {
+                return await ExecuteVoidAsync(queue, queueDE, request, queueItem);
+            }
+
             _logger.LogTrace("InitiateScuSwitchReceiptCommand.ExecuteAsync [enter].");
             ThrowIfNoImplicitFlow(request);
             ThrowIfTraining(request);
+
 
             var (processType, payload) = _transactionPayloadFactory.CreateReceiptPayload(request);
             var receiptResponse = CreateReceiptResponse(request, queueItem, queueDE);
@@ -193,6 +199,151 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands
             await _configurationRepository.InsertOrUpdateQueueDEAsync(queueDE).ConfigureAwait(false);
             _logger.LogInformation("Disconnected from SCU with ID '{ScuId}'.", specifiedSourceScuId);
             _logger.LogTrace("InitiateScuSwitchReceiptCommand.ExecuteAsync [exit].");
+            return new RequestCommandResponse()
+            {
+                ActionJournals = actionJournals,
+                ReceiptResponse = receiptResponse,
+                Signatures = signatures,
+                TransactionNumber = transactionNumber
+            };
+        }
+        private async Task<RequestCommandResponse> ExecuteVoidAsync(ftQueue queue, ftQueueDE queueDE, ReceiptRequest request, ftQueueItem queueItem)
+        {
+            _logger.LogTrace("InitScuSwitchReceiptCommand.ExecuteVoidAsync [enter].");
+            var (processType, payload) = _transactionPayloadFactory.CreateReceiptPayload(request);
+            var receiptResponse = CreateReceiptResponse(request, queueItem, queueDE);
+
+            ThrowIfNoImplicitFlow(request);
+            ThrowIfTraining(request);
+
+            var ajs = await _actionJournalRepository.GetAsync().ConfigureAwait(false);
+            var lastInitiateSwitchJournal = ajs.OrderBy(x => x.Moment).LastOrDefault(x => x.Type == $"{0x4445000000000003:X}-{nameof(InitiateSCUSwitch)}");
+            var initiateSwitchNotification = (!string.IsNullOrEmpty(lastInitiateSwitchJournal?.DataJson)
+                ? JsonConvert.DeserializeObject<InitiateSCUSwitch>(lastInitiateSwitchJournal.DataJson)
+                : null) ?? throw new Exception($"The SCU switch can't be voided because it is not in progress. See https://link.fiskaltrust.cloud/market-de/scu-switch for more details.");
+
+            if (queueDE.ftSignaturCreationUnitDEId != null && !(queueDE.ftSignaturCreationUnitDEId == initiateSwitchNotification.SourceSCUId))
+            {
+                throw new Exception($"The SCU switch can't be voided because it is not in progress. See https://link.fiskaltrust.cloud/market-de/scu-switch for more details.");
+            }
+
+            queueDE.ftSignaturCreationUnitDEId = initiateSwitchNotification.SourceSCUId;
+            await _configurationRepository.InsertOrUpdateQueueDEAsync(queueDE).ConfigureAwait(false);
+            _logger.LogInformation("Connected to SCU with ID '{ScuId}'.", queueDE.ftSignaturCreationUnitDEId);
+
+            bool success = false;
+            ulong? transactionNumber = null;
+            List<SignaturItem> signatures = new() { };
+            string clientId = null;
+            string signatureAlgorithm = null;
+            string publicKeyBase64 = null;
+            string serialnumberOctet = null;
+
+            try
+            {
+                await _deSSCDProvider.RegisterCurrentScuAsync().ConfigureAwait(false);
+                _certificationIdentification = null;
+
+                (transactionNumber, signatures, clientId, signatureAlgorithm, publicKeyBase64, serialnumberOctet) = await ProcessInitialOperationReceiptAsync(request.cbReceiptReference, processType, payload, queueItem, queueDE, false).ConfigureAwait(false);
+                success = true;
+            }
+            catch (Exception ex)
+            {
+                if (ex.GetType().Name == RETRYPOLICYEXCEPTION_NAME)
+                {
+                    _logger.LogDebug(ex, "TSE not reachable.");
+                }
+
+                if (!request.IsInitiateScuSwitchReceiptForce() && !_middlewareConfiguration.AllowUnsafeScuSwitch)
+                {
+                    queueDE.ftSignaturCreationUnitDEId = null;
+                    await _configurationRepository.InsertOrUpdateQueueDEAsync(queueDE).ConfigureAwait(false);
+
+                    throw;
+                }
+            }
+
+            var actionJournals = new List<ftActionJournal>();
+            var typeNumber = 0x4445000000000003;
+
+            var notification = new FinishSCUSwitch()
+            {
+                CashBoxId = Guid.Parse(request.ftCashBoxID),
+                QueueId = queueItem.ftQueueId,
+                Moment = DateTime.UtcNow,
+                CashBoxIdentification = clientId ?? "",
+                SourceSCUId = initiateSwitchNotification.SourceSCUId,
+                TargetSCUId = initiateSwitchNotification.SourceSCUId,
+                TargetSCUSignatureAlgorithm = signatureAlgorithm ?? "",
+                TargetSCUPublicKeyBase64 = publicKeyBase64 ?? "",
+                TargetSCUSerialNumberOctet = serialnumberOctet ?? "",
+                Version = "V0"
+            };
+
+            if (success)
+            {
+                signatures.Add(_signatureFactory.CreateFinishScuSwitchSignature(queue.ftQueueId, clientId, serialnumberOctet));
+                signatures.Add(
+                        new SignaturItem()
+                        {
+                            ftSignatureType = typeNumber,
+                            ftSignatureFormat = (long) fiskaltrust.ifPOS.v0.SignaturItem.Formats.AZTEC,
+                            Caption = $"SCU mit Queue verbunden. Kassenseriennummer: {clientId}, TSE-Seriennummer: {serialnumberOctet}, Queue-ID: {queue.ftQueueId}, SCU-ID: {initiateSwitchNotification.SourceSCUId}",
+                            Data = JsonConvert.SerializeObject(notification)
+                        }
+                    );
+
+                actionJournals.Add(
+                        new ftActionJournal()
+                        {
+                            ftActionJournalId = Guid.NewGuid(),
+                            ftQueueId = queueItem.ftQueueId,
+                            ftQueueItemId = queueItem.ftQueueItemId,
+                            Moment = DateTime.UtcNow,
+                            Priority = -1,
+                            TimeStamp = 0,
+                            Message = $"SCU mit Queue verbunden. Kassenseriennummer: {clientId}, TSE-Seriennummer: {serialnumberOctet}, Queue-ID: {queue.ftQueueId}, SCU-ID: {initiateSwitchNotification.SourceSCUId}",
+                            Type = $"{typeNumber:X}-{nameof(FinishSCUSwitch)}",
+                            DataJson = JsonConvert.SerializeObject(notification)
+                        }
+                    );
+            }
+            else
+            {
+                signatures.Add(
+                        new SignaturItem()
+                        {
+                            ftSignatureType = typeNumber,
+                            ftSignatureFormat = (long) fiskaltrust.ifPOS.v0.SignaturItem.Formats.AZTEC,
+                            Caption = $"SCU mit Queue verbunden. Queue-ID: {queue.ftQueueId}, SCU-ID: {initiateSwitchNotification.SourceSCUId}",
+                            Data = JsonConvert.SerializeObject(notification)
+                        }
+                    );
+
+                actionJournals.Add(
+                        new ftActionJournal()
+                        {
+                            ftActionJournalId = Guid.NewGuid(),
+                            ftQueueId = queueItem.ftQueueId,
+                            ftQueueItemId = queueItem.ftQueueItemId,
+                            Moment = DateTime.UtcNow,
+                            Priority = -1,
+                            TimeStamp = 0,
+                            Message = $"SCU mit Queue verbunden. Queue-ID: {queue.ftQueueId}, SCU-ID: {initiateSwitchNotification.SourceSCUId}",
+                            Type = $"{typeNumber:X}-{nameof(FinishSCUSwitch)}",
+                            DataJson = JsonConvert.SerializeObject(notification)
+                        }
+                    );
+            }
+
+            receiptResponse.ftReceiptIdentification = request.GetReceiptIdentification(queue.ftReceiptNumerator, transactionNumber);
+            receiptResponse.ftSignatures = signatures.ToArray();
+            if (success)
+            {
+                (receiptResponse.ftStateData, _) = await StateDataFactory.AppendTseInfoAsync(_deSSCDProvider.Instance, receiptResponse.ftStateData).ConfigureAwait(false);
+            }
+
+            _logger.LogTrace("InitiateScuSwitchReceiptCommand.ExecuteVoidAsync [exit].");
             return new RequestCommandResponse()
             {
                 ActionJournals = actionJournals,

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/RequestCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/RequestCommand.cs
@@ -425,7 +425,8 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands
                 }
                 catch { }
                 var clientids = await _deSSCDProvider.Instance.UnregisterClientIdAsync(new UnregisterClientIdRequest { ClientId = queueDE.CashBoxIdentification }).ConfigureAwait(false);
-                _logger.LogInformation("Deregistered TSE Clients {}", string.Join(", ", clientids.ClientIds));
+                if (clientids?.ClientIds is not null)
+                { _logger.LogInformation("Deregistered TSE Clients {}", string.Join(", ", clientids.ClientIds)); }
                 if (!request.IsModifyClientIdOnlyRequest())
                 {
                     await _deSSCDProvider.Instance.SetTseStateAsync(new TseState { CurrentState = TseStates.Terminated }).ConfigureAwait(false);

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/RequestCommand.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueDE/RequestCommands/RequestCommand.cs
@@ -424,7 +424,8 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands
                     }
                 }
                 catch { }
-                await _deSSCDProvider.Instance.UnregisterClientIdAsync(new UnregisterClientIdRequest { ClientId = queueDE.CashBoxIdentification }).ConfigureAwait(false);
+                var clientids = await _deSSCDProvider.Instance.UnregisterClientIdAsync(new UnregisterClientIdRequest { ClientId = queueDE.CashBoxIdentification }).ConfigureAwait(false);
+                _logger.LogInformation("Deregistered TSE Clients {}", string.Join(", ", clientids.ClientIds));
                 if (!request.IsModifyClientIdOnlyRequest())
                 {
                     await _deSSCDProvider.Instance.SetTseStateAsync(new TseState { CurrentState = TseStates.Terminated }).ConfigureAwait(false);
@@ -482,7 +483,7 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.RequestCommands
                 (true, 0x0006) => (0x4445_0000_0800_0006, "Yearly-closing receipt was processed, and a master data update was performed."),
                 (false, 0x0006) => (0x4445_0000_0000_0006, "Yearly-closing receipt was processed."),
                 // Migration receipt executes a daily closing as well
-                (true, 0x0019) => (0x4445_0000_0800_0007, "Daily-closing receipt was processed, and a master data update was performed."),  
+                (true, 0x0019) => (0x4445_0000_0800_0007, "Daily-closing receipt was processed, and a master data update was performed."),
                 (false, 0x0019) => (0x4445_0000_0000_0007, "Daily-closing receipt was processed."),
                 _ => throw new ArgumentException($"ReceiptCase {request.ftReceiptCase:X} is not supported for master data update.")
             };

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest/SignProcessorDETests/Fixtures/SignProcessorDependenciesFixture.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest/SignProcessorDETests/Fixtures/SignProcessorDependenciesFixture.cs
@@ -95,7 +95,6 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest.SignProces
                     ftSignaturCreationUnitDEId = _signaturCreationUnitDETargetId,
                     Mode = targetIsScuSwitch ? 0x20000 : 0x00000,
                     ModeConfigurationJson = $"{{\"SourceScuId\": \"{_signaturCreationUnitDEId}\"}}"
-
                 }).ConfigureAwait(false);
 
 

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest/SignProcessorDETests/Receipts/InitiateScuSwitchTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest/SignProcessorDETests/Receipts/InitiateScuSwitchTests.cs
@@ -19,6 +19,7 @@ using Newtonsoft.Json;
 using Xunit;
 using fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest.SignProcessorDETests.Helpers;
 using fiskaltrust.Middleware.Contracts.Repositories;
+using fiskaltrust.Middleware.Localization.QueueDE.Extensions;
 
 namespace fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest.SignProcessorDETests.Receipts
 {
@@ -202,6 +203,201 @@ namespace fiskaltrust.Middleware.Localization.QueueDE.IntegrationTest.SignProces
                 ),
                 "The target SCU is not set up correctly for an SCU switch in the local configuration. The SCU switch must be initiated properly in the fiskaltrust.Portal before sending this receipt. See https://link.fiskaltrust.cloud/market-de/scu-switch for more details. (Source SCU: *, Mode: 65536, ModeConfigurationJson: {\"TargetScuId\": \"*\"}; Target SCU: *, Mode: 0, ModeConfigurationJson: {\"SourceScuId\": \"*\"})", true, false).ConfigureAwait(false);
         }
+
+
+        [Fact]
+        public async Task SignProcessor_InitScuSwitchReceiptAndThenVoid_ShouldReset()
+        {
+            var receiptRequest = JsonConvert.DeserializeObject<ReceiptRequest>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "Request.json")));
+            var expectedResponse = JsonConvert.DeserializeObject<ReceiptResponse>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "Response.json")));
+            var queueItem = new ftQueueItem
+            {
+                cbReceiptMoment = receiptRequest.cbReceiptMoment,
+                cbReceiptReference = receiptRequest.cbReceiptReference,
+                cbTerminalID = receiptRequest.cbTerminalID,
+                country = "DE",
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                ftQueueItemId = Guid.Parse(expectedResponse.ftQueueItemID),
+                ftQueueRow = expectedResponse.ftQueueRow,
+                request = JsonConvert.SerializeObject(receiptRequest),
+                requestHash = "test request hash"
+            };
+            var queue = new ftQueue
+            {
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                StartMoment = DateTime.UtcNow
+            };
+
+            var journalRepositoryMock = new Mock<IMiddlewareJournalDERepository>(MockBehavior.Strict);
+            var actionJournalRepository = new InMemoryActionJournalRepository(new List<ftActionJournal>
+            {
+                CreateftActionJournal(queue.ftQueueId, queueItem.ftQueueItemId, 0)
+            });
+            var configurationRepository = _fixture.CreateConfigurationRepository(false, null, null, true, true);
+            var scuId = (await configurationRepository.GetQueueDEListAsync()).First().ftSignaturCreationUnitDEId;
+            var config = new MiddlewareConfiguration
+            {
+                Configuration = new Dictionary<string, object>(),
+                ProcessingVersion = "test"
+            };
+            var sut = RequestCommandFactoryHelper.ConstructSignProcessor(Mock.Of<ILogger<SignProcessorDE>>(), configurationRepository, journalRepositoryMock.Object,
+                actionJournalRepository, _fixture.DeSSCDProvider, new DSFinVKTransactionPayloadFactory(Mock.Of<ILogger<DSFinVKTransactionPayloadFactory>>()), new InMemoryFailedFinishTransactionRepository(),
+                new InMemoryFailedStartTransactionRepository(), new InMemoryOpenTransactionRepository(), Mock.Of<IMasterDataService>(), config,
+                new InMemoryQueueItemRepository(), new SignatureFactoryDE(QueueDEConfiguration.FromMiddlewareConfiguration(Mock.Of<ILogger<QueueDEConfiguration>>(), config)));
+
+            var (receiptResponse, actionJournals) = await sut.ProcessAsync(receiptRequest, queue, queueItem);
+            foreach (var a in actionJournals)
+            {
+                await actionJournalRepository.InsertAsync(a);
+            }
+            receiptResponse.Should().BeEquivalentTo(expectedResponse, x => x
+                .Excluding(x => x.ftReceiptMoment)
+                .Excluding(x => x.ftReceiptIdentification)
+                .Excluding(x => x.ftSignatures));
+            receiptResponse.ftSignatures.Length.Should().Be(expectedResponse.ftSignatures.Length);
+            receiptResponse.ftSignatures.Where(x => x.Caption.Equals("TSE-Trennungs-Beleg")).Should().HaveCount(1);
+
+            receiptRequest.ftReceiptCase = receiptRequest.ftReceiptCase | 0x0004_0000;
+            var (voidReceiptResponse, voidActionJournals) = await sut.ProcessAsync(receiptRequest, queue, queueItem);
+
+            voidReceiptResponse.Should().BeEquivalentTo(expectedResponse, x => x
+                .Excluding(x => x.ftReceiptMoment)
+                .Excluding(x => x.ftReceiptIdentification)
+                .Excluding(x => x.ftSignatures)
+                .Excluding(x => x.ftStateData));
+            voidReceiptResponse.ftSignatures.Length.Should().Be(16);
+            voidReceiptResponse.ftSignatures.Where(x => x.Caption.Equals("TSE-Verbindungs-Beleg")).Should().HaveCount(1);
+
+            voidActionJournals.Should().HaveCount(1);
+            voidActionJournals[0].Message.Should().Be($"SCU mit Queue verbunden. Kassenseriennummer: , TSE-Seriennummer: , Queue-ID: {receiptRequest.ftQueueID}, SCU-ID: {scuId}");
+        }
+
+
+        [Fact]
+        public async Task SignProcessor_InitScuSwitchReceiptAndThenVoidWithBrokenSourceSCU_ShouldFail()
+        {
+            var receiptRequest = JsonConvert.DeserializeObject<ReceiptRequest>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "Request.json")));
+            var expectedResponse = JsonConvert.DeserializeObject<ReceiptResponse>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "Response.json")));
+            var queueItem = new ftQueueItem
+            {
+                cbReceiptMoment = receiptRequest.cbReceiptMoment,
+                cbReceiptReference = receiptRequest.cbReceiptReference,
+                cbTerminalID = receiptRequest.cbTerminalID,
+                country = "DE",
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                ftQueueItemId = Guid.Parse(expectedResponse.ftQueueItemID),
+                ftQueueRow = expectedResponse.ftQueueRow,
+                request = JsonConvert.SerializeObject(receiptRequest),
+                requestHash = "test request hash"
+            };
+            var queue = new ftQueue
+            {
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                StartMoment = DateTime.UtcNow
+            };
+
+            var journalRepositoryMock = new Mock<IMiddlewareJournalDERepository>(MockBehavior.Strict);
+            var actionJournalRepository = new InMemoryActionJournalRepository(new List<ftActionJournal>
+            {
+                CreateftActionJournal(queue.ftQueueId, queueItem.ftQueueItemId, 0)
+            });
+            var configurationRepository = _fixture.CreateConfigurationRepository(false, null, null, true, true);
+            var scuId = (await configurationRepository.GetQueueDEListAsync()).First().ftSignaturCreationUnitDEId;
+            var config = new MiddlewareConfiguration
+            {
+                Configuration = new Dictionary<string, object>(),
+                ProcessingVersion = "test"
+            };
+            var sut = RequestCommandFactoryHelper.ConstructSignProcessor(Mock.Of<ILogger<SignProcessorDE>>(), configurationRepository, journalRepositoryMock.Object,
+                actionJournalRepository, _fixture.DeSSCDProvider, new DSFinVKTransactionPayloadFactory(Mock.Of<ILogger<DSFinVKTransactionPayloadFactory>>()), new InMemoryFailedFinishTransactionRepository(),
+                new InMemoryFailedStartTransactionRepository(), new InMemoryOpenTransactionRepository(), Mock.Of<IMasterDataService>(), config,
+                new InMemoryQueueItemRepository(), new SignatureFactoryDE(QueueDEConfiguration.FromMiddlewareConfiguration(Mock.Of<ILogger<QueueDEConfiguration>>(), config)));
+
+            var (receiptResponse, actionJournals) = await sut.ProcessAsync(receiptRequest, queue, queueItem);
+            foreach (var a in actionJournals)
+            {
+                await actionJournalRepository.InsertAsync(a);
+            }
+            receiptResponse.Should().BeEquivalentTo(expectedResponse, x => x
+                .Excluding(x => x.ftReceiptMoment)
+                .Excluding(x => x.ftReceiptIdentification)
+                .Excluding(x => x.ftSignatures));
+            receiptResponse.ftSignatures.Length.Should().Be(expectedResponse.ftSignatures.Length);
+
+            receiptRequest.ftReceiptCase = receiptRequest.ftReceiptCase | 0x0004_0000;
+            _fixture.InMemorySCU.ShouldFail = true;
+            Func<Task> action = async () => await sut.ProcessAsync(receiptRequest, queue, queueItem);
+            await action.Should().ThrowAsync<Exception>();
+        }
+
+        [Fact]
+        public async Task SignProcessor_InitScuSwitchReceiptAndThenVoidWithBrokenSourceSCUAndForceFlag_ShouldReset()
+        {
+            var receiptRequest = JsonConvert.DeserializeObject<ReceiptRequest>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "Request.json")));
+            var expectedResponse = JsonConvert.DeserializeObject<ReceiptResponse>(File.ReadAllText(Path.Combine("Data", "InitiateScuSwitchReceipt", "UnreachableResponse.json")));
+            var queueItem = new ftQueueItem
+            {
+                cbReceiptMoment = receiptRequest.cbReceiptMoment,
+                cbReceiptReference = receiptRequest.cbReceiptReference,
+                cbTerminalID = receiptRequest.cbTerminalID,
+                country = "DE",
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                ftQueueItemId = Guid.Parse(expectedResponse.ftQueueItemID),
+                ftQueueRow = expectedResponse.ftQueueRow,
+                request = JsonConvert.SerializeObject(receiptRequest),
+                requestHash = "test request hash"
+            };
+            var queue = new ftQueue
+            {
+                ftQueueId = Guid.Parse(receiptRequest.ftQueueID),
+                StartMoment = DateTime.UtcNow
+            };
+
+            var journalRepositoryMock = new Mock<IMiddlewareJournalDERepository>(MockBehavior.Strict);
+            var actionJournalRepository = new InMemoryActionJournalRepository(new List<ftActionJournal>
+            {
+                CreateftActionJournal(queue.ftQueueId, queueItem.ftQueueItemId, 0)
+            });
+            var configurationRepository = _fixture.CreateConfigurationRepository(false, null, null, true, true);
+            var scuId = (await configurationRepository.GetQueueDEListAsync()).First().ftSignaturCreationUnitDEId;
+            var config = new MiddlewareConfiguration
+            {
+                Configuration = new Dictionary<string, object>(),
+                ProcessingVersion = "test"
+            };
+            var sut = RequestCommandFactoryHelper.ConstructSignProcessor(Mock.Of<ILogger<SignProcessorDE>>(), configurationRepository, journalRepositoryMock.Object,
+                actionJournalRepository, _fixture.DeSSCDProvider, new DSFinVKTransactionPayloadFactory(Mock.Of<ILogger<DSFinVKTransactionPayloadFactory>>()), new InMemoryFailedFinishTransactionRepository(),
+                new InMemoryFailedStartTransactionRepository(), new InMemoryOpenTransactionRepository(), Mock.Of<IMasterDataService>(), config,
+                new InMemoryQueueItemRepository(), new SignatureFactoryDE(QueueDEConfiguration.FromMiddlewareConfiguration(Mock.Of<ILogger<QueueDEConfiguration>>(), config)));
+
+            _fixture.InMemorySCU.ShouldFail = true;
+            receiptRequest.ftReceiptCase = receiptRequest.ftReceiptCase | 0x4000_0000;
+            var (receiptResponse, actionJournals) = await sut.ProcessAsync(receiptRequest, queue, queueItem);
+            foreach (var a in actionJournals)
+            {
+                await actionJournalRepository.InsertAsync(a);
+            }
+            receiptResponse.Should().BeEquivalentTo(expectedResponse, x => x
+                .Excluding(x => x.ftReceiptMoment)
+                .Excluding(x => x.ftReceiptIdentification)
+                .Excluding(x => x.ftSignatures));
+            receiptResponse.ftSignatures.Length.Should().Be(expectedResponse.ftSignatures.Length);
+
+            receiptRequest.ftReceiptCase = receiptRequest.ftReceiptCase | 0x0004_0000;
+            var (voidReceiptResponse, voidActionJournals) = await sut.ProcessAsync(receiptRequest, queue, queueItem);
+
+            voidReceiptResponse.Should().BeEquivalentTo(expectedResponse, x => x
+                .Excluding(x => x.ftReceiptMoment)
+                .Excluding(x => x.ftReceiptIdentification)
+                .Excluding(x => x.ftSignatures)
+                .Excluding(x => x.ftStateData));
+            voidReceiptResponse.ftSignatures.Length.Should().Be(1);
+            voidReceiptResponse.ftSignatures.Where(x => x.Caption.Equals("TSE-Verbindungs-Beleg")).Should().HaveCount(0);
+
+            voidActionJournals.Should().HaveCount(1);
+            voidActionJournals[0].Message.Should().Be($"SCU mit Queue verbunden. Queue-ID: {receiptRequest.ftQueueID}, SCU-ID: {scuId}");
+        }
+
 
         private ftActionJournal CreateftActionJournal(Guid ftQueueId, Guid ftQueueItemId, int ftReceiptNumerator)
         {


### PR DESCRIPTION
Introduce the possibility to Void the Initiate-SCU-Switch receipt that sets the source SCU as the current SCU and tries to re-register the client with the source SCU. This should also create a related action journal entry.

If the source SCU is not working and the Force flag is also set then the client registration may fail.

If a Finish-SCU-Switch receipt fails it should be possible to void the Initiate-SCU-Switch receipt to restet the state.

> ### Examples
> #### Source SCU still working
> 1. Initiate-SCU-Switch succeeds
> 2. Finish-SCU-Switch fails
> 3. Initiate-SCU-Switch + Void flag succeeds
> 4. Queue is connected to source SCU again and client is registered SCU
> 5. Reconfigure SCU switch and try again
>
> #### Source SCU broken
> 1. Initiate-SCU-Switch fails
> 2. Initiate-SCU-Switch + Force flag succeeds
> 3. Finish-SCU-Switch fails
> 4. Initiate-SCU-Switch + Void flag fails
> 5. Initiate-SCU-Switch + Void flag + Force flag succeeds
> 6. Queue is connected to source SCU again and but client is not registered on SCU
> 7. Reconfigure SCU switch and try again