### PR TITLE
feat: add RT printer reboot command via zero receipt flag

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
@@ -37,6 +37,10 @@ public static class ReceiptCaseHelper
 
     public static bool IsXReportZeroReceipt(this ReceiptRequest receiptRequest) => (receiptRequest.ftReceiptCase & 0x0000_0001_0000_0000) > 0x0000;
 
+    // Local ZeroReceipt flags 0x01..0x20 are already taken (XReport, ZReport, FuoriServizio Entry/Exit, FileSearch, FileExtraction
+    // - see SCU.IT.TRS ReceiptCase). 0x40 is the next free bit and signals an RT printer reboot.
+    public static bool IsRebootRequest(this ReceiptRequest receiptRequest) => (receiptRequest.ftReceiptCase & 0x0000_0040_0000_0000) > 0x0000;
+
     public static bool IsVoid(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0001_0000) > 0x0000;
 
     public static bool IsVoid(this PayItem payItem) => (payItem.ftPayItemCase & 0x0000_0000_0001_0000) > 0x0000;

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -818,6 +818,10 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
 
     private async Task<ProcessResponse> PerformZeroReceiptOperationAsync(ReceiptRequest request, ReceiptResponse receiptResponse)
     {
+        if (request.IsRebootRequest())
+        {
+            return await PerformRebootAsync(receiptResponse);
+        }
         await ResetPrinter();
         var result = await QueryPrinterStatusAsync();
         var signatures = SignatureFactory.CreateZeroReceiptSignatures().ToList();
@@ -842,6 +846,21 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             PrinterStatus = result
         });
         return ProcessResponseHelpers.CreateResponse(receiptResponse, stateData, signatures);
+    }
+
+    private async Task<ProcessResponse> PerformRebootAsync(ReceiptResponse receiptResponse)
+    {
+        try
+        {
+            // Sent immediately; a directIO restart blocks the response, so the printer reboots without replying.
+            await _httpClient.SendCommandAsync(EpsonCommandFactory.RebootCommand());
+        }
+        catch (Exception e)
+        {
+            // ponytail: reboot drops the connection before answering (protocol note [3]: FP_NO_ANSWER) — expected, not an error.
+            _logger.LogInformation(e, "Reboot command sent; the printer restarts without responding.");
+        }
+        return ProcessResponseHelpers.CreateResponse(receiptResponse, SignatureFactory.CreateZeroReceiptSignatures().ToList());
     }
 
     private async Task<HttpResponseMessage> LoginAsync() => await _httpClient.SendCommandAsync(EpsonCommandFactory.LoginCommand(_configuration.Password));

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -285,6 +285,24 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
 """;
         }
 
+        // Restart printer via directIO 4034 (Communication Protocol 7.00, H1=4;H2=034):
+        // data = PARAM(01 Web server) + INDEX(98 Restart printer) + FUNCTION(00) + STRING(64-byte space pad).
+        // Note [3]: a directIO restart blocks the XML response (FP_NO_ANSWER), so no meaningful reply is returned.
+        public static string RebootCommand()
+        {
+            var data = "019800" + new string(' ', 64);
+            return $"""
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Body>
+        <printerCommand>
+            <directIO command="4034" data="{data}" />
+        </printerCommand>
+    </s:Body>
+</s:Envelope>
+""";
+        }
+
         public static string LoginCommand(string configuredPassword)
         {
             var password = (configuredPassword ?? "").PadRight(100, ' ').PadRight(32, ' ');

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/RebootCommandTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/RebootCommandTests.cs
@@ -1,0 +1,31 @@
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    public class RebootCommandTests
+    {
+        [Fact]
+        public void RebootCommand_IsDirectIO4034_RestartPrinter()
+        {
+            var xml = EpsonCommandFactory.RebootCommand();
+
+            Assert.Contains("<printerCommand>", xml);
+            Assert.Contains("command=\"4034\"", xml);
+            // PARAM=01 (Web server) + INDEX=98 (Restart printer) + FUNCTION=00 + 64-byte space padding.
+            Assert.Contains("data=\"019800" + new string(' ', 64) + "\"", xml);
+        }
+
+        [Theory]
+        [InlineData(0x4954_2040_0000_2000, true)]   // ZeroReceipt + reboot flag
+        [InlineData(0x4954_2000_0000_2000, false)]  // plain ZeroReceipt
+        [InlineData(0x4954_2001_0000_2000, false)]  // XReport flag must not be read as reboot
+        public void IsRebootRequest_DetectsOnlyTheRebootFlag(long ftReceiptCase, bool expected)
+        {
+            var request = new ReceiptRequest { ftReceiptCase = ftReceiptCase };
+
+            Assert.Equal(expected, request.IsRebootRequest());
+        }
+    }
+}


### PR DESCRIPTION
Triggered by a ZeroReceipt carrying a new local flag (0x0000_0040_0000_0000 - the first free bit after the existing XReport/ZReport/FuoriServizio/FileSearch/FileExtraction flags).

When set, the SCU sends directIO command 4034 (INDEX 98, "Restart printer") immediately and tolerates the blocked response a directIO restart produces (protocol note: FP_NO_ANSWER is expected).

Fixes https://github.com/fiskaltrust/market-it/issues/550


