### PR TITLE
feat: auto-reboot Epson RT printer after daily closing

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -807,6 +807,8 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             {
                 receiptResponse.AddWarningSignatureItem(Helpers.GetPrinterStatus(result?.ReportInfo?.PrinterStatus) ?? "");
             }
+            // #549: reboot the Epson printer after a successful daily closing — it sometimes gets stuck during the day.
+            await SendRebootCommandAsync();
             return receiptResponse;
         }
         catch (Exception e)
@@ -850,6 +852,12 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
 
     private async Task<ProcessResponse> PerformRebootAsync(ReceiptResponse receiptResponse)
     {
+        await SendRebootCommandAsync();
+        return ProcessResponseHelpers.CreateResponse(receiptResponse, SignatureFactory.CreateZeroReceiptSignatures().ToList());
+    }
+
+    private async Task SendRebootCommandAsync()
+    {
         try
         {
             // Sent immediately; a directIO restart blocks the response, so the printer reboots without replying.
@@ -860,7 +868,6 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             // ponytail: reboot drops the connection before answering (protocol note [3]: FP_NO_ANSWER) — expected, not an error.
             _logger.LogInformation(e, "Reboot command sent; the printer restarts without responding.");
         }
-        return ProcessResponseHelpers.CreateResponse(receiptResponse, SignatureFactory.CreateZeroReceiptSignatures().ToList());
     }
 
     private async Task<HttpResponseMessage> LoginAsync() => await _httpClient.SendCommandAsync(EpsonCommandFactory.LoginCommand(_configuration.Password));

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
@@ -1,0 +1,53 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.ifPOS.v1.it;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    public class DailyClosingRebootTests
+    {
+        // directIO 4034 = restart printer (EpsonCommandFactory.RebootCommand, issue #550).
+        private static bool IsRebootCommand(string payload) => payload.Contains("4034");
+
+        private static ReceiptRequest DailyClosing() => new() { ftReceiptCase = 0x4954_2000_0000_2011 };
+
+        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client) =>
+            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration(), client);
+
+        private static Mock<IEpsonFpMateClient> ClientReturning(ReportResponse zReportResult)
+        {
+            var xml = SoapSerializer.Serialize(zReportResult);
+            var client = new Mock<IEpsonFpMateClient>();
+            client.Setup(c => c.SendCommandAsync(It.IsAny<string>()))
+                  .ReturnsAsync(() => new HttpResponseMessage { Content = new StringContent(xml) });
+            return client;
+        }
+
+        [Fact]
+        public async Task DailyClosing_WhenZReportSucceeds_SendsRebootCommand()
+        {
+            var client = ClientReturning(new ReportResponse { Success = true, ReportInfo = new ReportInfo { ZRepNumber = "1", PrinterStatus = "00000000" } });
+            var sut = CreateSut(client.Object);
+
+            await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
+
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Once);
+        }
+
+        [Fact]
+        public async Task DailyClosing_WhenZReportFails_DoesNotReboot()
+        {
+            var client = ClientReturning(new ReportResponse { Success = false, Code = "1", Status = "1" });
+            var sut = CreateSut(client.Object);
+
+            await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
+
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
**Stacked on #691** (RT printer reboot command). This PR's base is the #691 branch, so the diff is only the issue-#549 change (1 commit, 2 files). Merge #691 first; GitHub then retargets this to `main` automatically.

## What
Implements fiskaltrust/market-it#549: automatically reboot the Epson RT printer during the daily closing — the printer sometimes gets stuck during the day.

After a **successful** daily closing (ZReport), `PerformDailyCosing` sends the directIO 4034 restart command (the reboot command from #691). On a failed closing, no reboot is sent — don't restart a printer whose closing just failed.

## Scope
- **Epson only** — local and cloud both run through `EpsonRTPrinterSCU`, so one change covers both.
- CustomRTPrinter / CustomRTServer are untouched — the issue excludes RT servers and custom printers.
- Always-on, no config flag.

## Implementation
- Extracted `SendRebootCommandAsync()` (send + swallow the expected FP_NO_ANSWER) from #691's `PerformRebootAsync`; the manual-flag path and this automatic path now share one helper.
- ~8 lines of production change.

## Known trade-off
The reboot send blocks up to `ClientTimeoutMs` (~15s) waiting for a reply that never comes, then swallows the timeout — daily closing takes up to ~15s longer. Same behaviour as #691's manual reboot.

## Tests
`DailyClosingRebootTests`: successful closing → reboot sent once; failed closing → reboot never sent. Full Epson unit project: **8/8 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)