### PR TITLE
Add lottery code to RequestResponse in Epson, Custom PrinterRT and RT…

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
@@ -545,6 +545,7 @@ public sealed class CustomRTPrinterSCU : LegacySCU
             await EnsurePrinterReadyAsync();
             var records = new List<IFiscalRecord>();
 
+            var lotteryCode = receiptRequest.GetLotteryData()?.servizi_lotteriadegliscontrini_gov_it?.codicelotteria ?? "";
             var customer = receiptRequest.GetCustomer();
             if (customer != null)
             {
@@ -660,7 +661,7 @@ public sealed class CustomRTPrinterSCU : LegacySCU
                 RTDocNumber = long.TryParse(response.AddInfo?.FiscalDoc, out var dfd) ? dfd : 0,
                 RTDocMoment = response.AddInfo?.DateTime ?? DateTime.UtcNow,
                 RTDocType = "POSRECEIPT",
-                RTCodiceLotteria = "",
+                RTCodiceLotteria = lotteryCode,
                 RTCustomerID = customer?.CustomerId ?? ""
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignature).ToArray();

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -198,6 +198,9 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         return fiscalReceiptResponse;
     }
 
+    private static string GetLotteryCode(ReceiptRequest receiptRequest)
+        => receiptRequest.GetLotteryData()?.servizi_lotteriadegliscontrini_gov_it?.codicelotteria ?? "";
+
     public async Task<ReceiptResponse> PerformProtocolReceiptAsync(ReceiptRequest receiptRequest, ReceiptResponse receiptResponse)
     {
         string? data = null;
@@ -255,7 +258,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocNumber = fiscalReceiptResponse.ReceiptNumber,
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "POSRECEIPT",
-                RTCodiceLotteria = "",
+                RTCodiceLotteria = GetLotteryCode(receiptRequest),
                 RTCustomerID = "", // Todo dread customerid from data
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignatur).ToArray();
@@ -311,7 +314,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocNumber = fiscalReceiptResponse.ReceiptNumber,
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "POSRECEIPT",
-                RTCodiceLotteria = "",
+                RTCodiceLotteria = GetLotteryCode(receiptRequest),
                 RTCustomerID = "", // Todo dread customerid from data
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignatur).ToArray();
@@ -353,7 +356,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             var reason = hasProgressed ? "progression detected" : "amount matches, no cache";
             _logger.LogInformation("({receiptreference}) Document found: Z#{zNum} Doc#{docNum} ({reason}) — printer already printed, skipping retry.",
                 receiptRequest.cbReceiptReference, docBeforeRetry!.ZNumber, docBeforeRetry.DocNumber, reason);
-            return ApplyRecoveredDoc(receiptResponse, docBeforeRetry);
+            return ApplyRecoveredDoc(receiptResponse, docBeforeRetry, GetLotteryCode(receiptRequest));
         }
 
         return await RetryReceiptWithRecoveryAsync(receiptRequest, receiptResponse, xmlData, docBeforeRetry);
@@ -382,7 +385,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                         RTDocNumber = retryFiscalResponse.ReceiptNumber,
                         RTDocMoment = retryFiscalResponse.ReceiptDateTime,
                         RTDocType = "POSRECEIPT",
-                        RTCodiceLotteria = "",
+                        RTCodiceLotteria = GetLotteryCode(receiptRequest),
                         RTCustomerID = "",
                     }).ToArray();
                     return receiptResponse;
@@ -404,7 +407,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 if (baseline.HasValue && IsDocAdvanced(lastDoc, baseline.Value))
                 {
                     _logger.LogInformation("({receiptreference}) Document found: Z#{zNum} Doc#{docNum} — printer already printed, skipping retry.", receiptRequest.cbReceiptReference, lastDoc!.ZNumber, lastDoc.DocNumber);
-                    return ApplyRecoveredDoc(receiptResponse, lastDoc);
+                    return ApplyRecoveredDoc(receiptResponse, lastDoc, GetLotteryCode(receiptRequest));
                 }
             }
             catch (Exception queryEx)
@@ -426,7 +429,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
              (doc.ZNumber == baseline.ZNumber && doc.DocNumber > baseline.DocNumber));
     }
 
-    private ReceiptResponse ApplyRecoveredDoc(ReceiptResponse receiptResponse, LastEmittedDocStatus doc)
+    private ReceiptResponse ApplyRecoveredDoc(ReceiptResponse receiptResponse, LastEmittedDocStatus doc, string lotteryCode)
     {
         receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(new POSReceiptSignatureData
         {
@@ -435,7 +438,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             RTDocNumber = doc.DocNumber,
             RTDocMoment = doc.DocumentDateTime,
             RTDocType = "POSRECEIPT",
-            RTCodiceLotteria = "",
+            RTCodiceLotteria = lotteryCode,
             RTCustomerID = "",
         }).ToArray();
         _lastSuccessfulDoc = (doc.ZNumber, doc.DocNumber);


### PR DESCRIPTION
## Context
For sale receipts (`POSRECEIPT`), the EpsonRTPrinter and CustomRTPrinter SCUs did not
expose the receipt lottery code (`codicelotteria`) in the `ReceiptResponse` signatures:
`RTCodiceLotteria` was hardcoded to an empty string. As a result the code did not appear
in either of the two places the QueueIT layer derives it from:
- the `<rt-lottery-id>` signature, and
- the `Codice Lotteria:` line in the `[www.fiskaltrust.it]` footer (built by the queue from `RTLotteryID`).

This aligns both printer SCUs with the existing behavior: populating `RTCodiceLotteria`
on the sale signature data drives both outputs automatically.

## Changes
**EpsonRTPrinter (`EpsonRTPrinterSCU.cs`)**
- Added a `GetLotteryCode(ReceiptRequest)` helper
  (`GetLotteryData()?.servizi_lotteriadegliscontrini_gov_it?.codicelotteria ?? ""`).
- Populated `RTCodiceLotteria` on every `POSRECEIPT` signature path:
  `PerformProtocolReceiptAsync`, `PerformClassicReceiptAsync`, and the two network-recovery
  paths `RetryReceiptWithRecoveryAsync` and `ApplyRecoveredDoc`
  (the latter gained a `lotteryCode` parameter, passed by its callers that hold the `ReceiptRequest`).

**CustomRTPrinter (`CustomRTPrinterSCU.cs`)**
- `PerformDeliveryNoteAsync` (POSRECEIPT) now reads the lottery code and sets `RTCodiceLotteria`.
- `PerformClassicReceiptAsync` already set it → unchanged.

Refund / Void / management documents keep `RTCodiceLotteria = ""`: the lottery code is only
attached to sale receipts (`POSRECEIPT`), consistent with the rest of the IT integration.

## Resulting signature output
For a sale carrying a lottery code, the response now contains:
- `<rt-lottery-id>` → `ftSignatureType 0x4954200000000015`, `ftSignatureFormat 0x1`, `Data = <code>`
- `[www.fiskaltrust.it]` footer (`ftSignatureType 0x4954200000000001`) with a `Codice Lotteria: <code>` line

## Testing
- Both projects build.
- EpsonRTPrinter unit tests pass (8); CustomRTPrinter integration tests are skipped (require real hardware), none failing

Issue
https://github.com/fiskaltrust/middleware/issues/696