### PR TITLE
feat: make Epson RT auto-reboot after daily closing opt-in

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -810,8 +810,11 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             {
                 receiptResponse.AddWarningSignatureItem(Helpers.GetPrinterStatus(result?.ReportInfo?.PrinterStatus) ?? "");
             }
-            // #549: reboot the Epson printer after a successful daily closing — it sometimes gets stuck during the day.
-            await SendRebootCommandAsync();
+            if (_configuration.AutoRebootEnable)
+            {
+                // #549: the printer sometimes gets stuck during the day; a post-closing reboot clears it.
+                await SendRebootCommandAsync();
+            }
             return receiptResponse;
         }
         catch (Exception e)

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -810,7 +810,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             {
                 receiptResponse.AddWarningSignatureItem(Helpers.GetPrinterStatus(result?.ReportInfo?.PrinterStatus) ?? "");
             }
-            if (_configuration.AutoRebootEnable)
+            if (_configuration.ForceRebootAfterDailyClosing)
             {
                 // #549: the printer sometimes gets stuck during the day; a post-closing reboot clears it.
                 await SendRebootCommandAsync();

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
@@ -33,6 +33,6 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter
         /// Opt-in workaround for printers that occasionally get stuck during the day (#549).
         /// Does not affect the manual (zero-receipt) reboot request.
         /// </summary>
-        public bool AutoRebootEnable { get; set; } = false;
+        public bool ForceRebootAfterDailyClosing { get; set; } = false;
     }
 }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
@@ -27,5 +27,12 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter
         public string? Password { get; set; }
 
         public string? AdditionalTrailerLines { get; set;}
+
+        /// <summary>
+        /// Automatically reboots the RT printer after a successful daily closing (Z report).
+        /// Opt-in workaround for printers that occasionally get stuck during the day (#549).
+        /// Does not affect the manual (zero-receipt) reboot request.
+        /// </summary>
+        public bool AutoRebootEnable { get; set; } = false;
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
@@ -16,8 +16,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
 
         private static ReceiptRequest DailyClosing() => new() { ftReceiptCase = 0x4954_2000_0000_2011 };
 
-        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client) =>
-            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration(), client);
+        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client, bool autoRebootEnable = false) =>
+            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration { AutoRebootEnable = autoRebootEnable }, client);
 
         private static Mock<IEpsonFpMateClient> ClientReturning(ReportResponse zReportResult)
         {
@@ -29,10 +29,10 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         }
 
         [Fact]
-        public async Task DailyClosing_WhenZReportSucceeds_SendsRebootCommand()
+        public async Task DailyClosing_WhenEnabledAndZReportSucceeds_SendsRebootCommand()
         {
             var client = ClientReturning(new ReportResponse { Success = true, ReportInfo = new ReportInfo { ZRepNumber = "1", PrinterStatus = "00000000" } });
-            var sut = CreateSut(client.Object);
+            var sut = CreateSut(client.Object, autoRebootEnable: true);
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 
@@ -40,9 +40,20 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         }
 
         [Fact]
-        public async Task DailyClosing_WhenZReportFails_DoesNotReboot()
+        public async Task DailyClosing_WhenEnabledAndZReportFails_DoesNotReboot()
         {
             var client = ClientReturning(new ReportResponse { Success = false, Code = "1", Status = "1" });
+            var sut = CreateSut(client.Object, autoRebootEnable: true);
+
+            await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
+
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Never);
+        }
+
+        [Fact]
+        public async Task DailyClosing_WhenDisabled_DoesNotReboot()
+        {
+            var client = ClientReturning(new ReportResponse { Success = true, ReportInfo = new ReportInfo { ZRepNumber = "1", PrinterStatus = "00000000" } });
             var sut = CreateSut(client.Object);
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
@@ -16,8 +16,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
 
         private static ReceiptRequest DailyClosing() => new() { ftReceiptCase = 0x4954_2000_0000_2011 };
 
-        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client, bool autoRebootEnable = false) =>
-            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration { AutoRebootEnable = autoRebootEnable }, client);
+        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client, bool forceReboot = false) =>
+            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration { ForceRebootAfterDailyClosing = forceReboot }, client);
 
         private static Mock<IEpsonFpMateClient> ClientReturning(ReportResponse zReportResult)
         {
@@ -32,7 +32,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         public async Task DailyClosing_WhenEnabledAndZReportSucceeds_SendsRebootCommand()
         {
             var client = ClientReturning(new ReportResponse { Success = true, ReportInfo = new ReportInfo { ZRepNumber = "1", PrinterStatus = "00000000" } });
-            var sut = CreateSut(client.Object, autoRebootEnable: true);
+            var sut = CreateSut(client.Object, forceReboot: true);
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 
@@ -43,7 +43,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         public async Task DailyClosing_WhenEnabledAndZReportFails_DoesNotReboot()
         {
             var client = ClientReturning(new ReportResponse { Success = false, Code = "1", Status = "1" });
-            var sut = CreateSut(client.Object, autoRebootEnable: true);
+            var sut = CreateSut(client.Object, forceReboot: true);
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 


### PR DESCRIPTION
## What
Makes the automatic Epson RT printer reboot after a successful daily closing (introduced always-on in #693, issue fiskaltrust/market-it#549) **opt-in** via a new SCU configuration parameter:

```json
{ "ForceRebootAfterDailyClosing": true }
```

- `ForceRebootAfterDailyClosing` (`bool`, default `false`) on `EpsonRTPrinterSCUConfiguration` — binds automatically through the existing JsonConvert-based SCU package config, no extra plumbing.
- The reboot call in `PerformDailyCosing` is now gated on the flag; everything else is unchanged.
- The **manual** reboot via zero-receipt flag (#691) is intentionally not gated — that path is explicit user intent.

## Behavior change
Deployments relying on #693's always-on reboot no longer reboot after daily closing until they set `ForceRebootAfterDailyClosing: true` — worth a release-note line.

## Tests
`DailyClosingRebootTests`:
- enabled + successful closing → reboot sent once
- enabled + failed closing → no reboot (failure suppresses reboot even when opted in)
- **new:** disabled (default) + successful closing → no reboot

Full Epson unit project: **9/9 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)