### PR TITLE
fix(epsonrtserver): make SCU cloud-safe on the stateless CloudCashbox host

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -22,6 +22,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         private readonly ILogger<EpsonRTServerCommunicationQueue> _logger;
         private readonly EpsonRTServerConfiguration _configuration;
         private readonly string _documentsPath;
+        private readonly bool _diskCacheAvailable;
 
         private bool _requestCancellation;
         private bool _processingReceipts;
@@ -34,22 +35,31 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             _logger = logger;
             _configuration = configuration;
 
+            var personalFolder = personalFolderProvider ?? (() => Environment.GetFolderPath(Environment.SpecialFolder.Personal));
             var cacheFolder = configuration.ServiceFolder;
             if (string.IsNullOrEmpty(cacheFolder))
             {
-                cacheFolder = (personalFolderProvider ?? (() => Environment.GetFolderPath(Environment.SpecialFolder.Personal)))();
+                cacheFolder = personalFolder();
             }
-
-            _documentsPath = Path.Combine(cacheFolder!, "epsonrtservercache", id.ToString());
+            _documentsPath = Path.Combine(string.IsNullOrEmpty(cacheFolder) ? "." : cacheFolder!, "epsonrtservercache", id.ToString());
             if (!string.IsNullOrEmpty(configuration.CacheDirectory))
             {
                 _documentsPath = configuration.CacheDirectory!;
             }
+
+            _diskCacheAvailable = !string.IsNullOrEmpty(configuration.CacheDirectory) || !string.IsNullOrEmpty(cacheFolder);
+            if (!_diskCacheAvailable)
+            {
+                // Stateless host (no writable folder): the on-disk offline buffer cannot survive a restart, so
+                // documents are always sent synchronously and the background drain is not started.
+                _logger.LogWarning("No writable cache folder for the Epson RT Server queue; documents are sent synchronously (offline buffering disabled).");
+                return;
+            }
+
             if (!Directory.Exists(_documentsPath))
             {
                 Directory.CreateDirectory(_documentsPath);
             }
-
             _ = Task.Run(ProcessReceiptsInBackground);
         }
 
@@ -59,7 +69,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         /// </summary>
         public async Task<Models.RtServerResponse?> EnqueueDocument(string tillId, string createReceiptXml, long zRepNumber, long docNumber)
         {
-            if (_configuration.SendReceiptsSync)
+            if (_configuration.SendReceiptsSync || !_diskCacheAvailable)
             {
                 return await _client.CreateReceiptAsync(createReceiptXml).ConfigureAwait(false);
             }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -27,7 +27,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         private bool _processingReceipts;
         private readonly Dictionary<string, int> _rejectionCounts = new();
 
-        public EpsonRTServerCommunicationQueue(Guid id, IEpsonRTServerClient client, ILogger<EpsonRTServerCommunicationQueue> logger, EpsonRTServerConfiguration configuration)
+        public EpsonRTServerCommunicationQueue(Guid id, IEpsonRTServerClient client, ILogger<EpsonRTServerCommunicationQueue> logger, EpsonRTServerConfiguration configuration, Func<string>? personalFolderProvider = null)
         {
             _id = id;
             _client = client;
@@ -37,7 +37,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             var cacheFolder = configuration.ServiceFolder;
             if (string.IsNullOrEmpty(cacheFolder))
             {
-                cacheFolder = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+                cacheFolder = (personalFolderProvider ?? (() => Environment.GetFolderPath(Environment.SpecialFolder.Personal)))();
             }
 
             _documentsPath = Path.Combine(cacheFolder!, "epsonrtservercache", id.ToString());

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -86,6 +86,14 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
 
         public async Task ProcessReceiptsInBackground()
         {
+            if (!_diskCacheAvailable)
+            {
+                // Belt-and-suspenders: there is no disk cache to drain, and _documentsPath was never created,
+                // so never touch it even if this ever gets invoked despite the guard in ProcessAllReceipts.
+                _processingReceipts = false;
+                return;
+            }
+
             while (true)
             {
                 _processingReceipts = true;
@@ -128,6 +136,14 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
 
         public async Task ProcessAllReceipts(string tillId)
         {
+            if (!_diskCacheAvailable)
+            {
+                // No disk cache means nothing to drain; skip so the `finally` below never restarts the
+                // background drain against a cache folder that was never created (it would loop forever
+                // throwing DirectoryNotFoundException every ~2s).
+                return;
+            }
+
             _requestCancellation = true;
             while (_processingReceipts)
             {

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -29,6 +29,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
     private readonly IEpsonRTServerClient _client;
     private readonly EpsonRTServerCommunicationQueue _queue;
     private readonly string _scuCacheFolder;
+    private bool _persistDisabled;
 
     private Dictionary<Guid, TillState> _tillStates = new();
 
@@ -38,7 +39,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
 
     private string StateCacheFilePath => Path.Combine(_scuCacheFolder, $"{_id}_epsonrtserver_statecache.json");
 
-    public EpsonRTServerSCU(Guid id, ILogger<EpsonRTServerSCU> logger, EpsonRTServerConfiguration configuration, IEpsonRTServerClient client, EpsonRTServerCommunicationQueue queue)
+    public EpsonRTServerSCU(Guid id, ILogger<EpsonRTServerSCU> logger, EpsonRTServerConfiguration configuration, IEpsonRTServerClient client, EpsonRTServerCommunicationQueue queue, Func<string>? personalFolderProvider = null)
     {
         _id = id;
         _logger = logger;
@@ -46,8 +47,9 @@ public sealed class EpsonRTServerSCU : LegacySCU
         _client = client;
         _queue = queue;
 
+        var personalFolder = personalFolderProvider ?? (() => Environment.GetFolderPath(Environment.SpecialFolder.Personal));
         _scuCacheFolder = string.IsNullOrEmpty(configuration.ServiceFolder)
-            ? Environment.GetFolderPath(Environment.SpecialFolder.Personal)
+            ? personalFolder()
             : configuration.ServiceFolder!;
     }
 
@@ -492,7 +494,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
 
     private void LoadStateFromDisk()
     {
-        if (!File.Exists(StateCacheFilePath))
+        if (string.IsNullOrEmpty(_scuCacheFolder) || !File.Exists(StateCacheFilePath))
         {
             return;
         }
@@ -500,31 +502,45 @@ public sealed class EpsonRTServerSCU : LegacySCU
         {
             _tillStates = JsonConvert.DeserializeObject<Dictionary<Guid, TillState>>(File.ReadAllText(StateCacheFilePath)) ?? new Dictionary<Guid, TillState>();
         }
-        catch (JsonException ex)
+        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
         {
-            // A corrupt cache is recoverable: the state is re-seeded from the server (token + fiscalInformation).
-            _logger.LogWarning(ex, "The state cache '{path}' is corrupt and will be rebuilt from the RT Server.", StateCacheFilePath);
+            // A corrupt/unreadable cache is recoverable: the state is re-seeded from the server (token + fiscalInformation).
+            _logger.LogWarning(ex, "The state cache '{path}' could not be read and will be rebuilt from the RT Server.", StateCacheFilePath);
             _tillStates = new Dictionary<Guid, TillState>();
         }
     }
 
     private void PersistState()
     {
-        if (!Directory.Exists(_scuCacheFolder))
+        if (_persistDisabled || string.IsNullOrEmpty(_scuCacheFolder))
         {
-            Directory.CreateDirectory(_scuCacheFolder);
+            return;
         }
-        // Write-temp-then-swap: a crash mid-write must not corrupt the chain state (the fingerprint in this
-        // file is the Section A of the next document).
-        var tempPath = StateCacheFilePath + ".tmp";
-        File.WriteAllText(tempPath, JsonConvert.SerializeObject(_tillStates));
-        if (File.Exists(StateCacheFilePath))
+        try
         {
-            File.Replace(tempPath, StateCacheFilePath, null);
+            if (!Directory.Exists(_scuCacheFolder))
+            {
+                Directory.CreateDirectory(_scuCacheFolder);
+            }
+            // Write-temp-then-swap: a crash mid-write must not corrupt the chain state (the fingerprint in this
+            // file is the Section A of the next document).
+            var tempPath = StateCacheFilePath + ".tmp";
+            File.WriteAllText(tempPath, JsonConvert.SerializeObject(_tillStates));
+            if (File.Exists(StateCacheFilePath))
+            {
+                File.Replace(tempPath, StateCacheFilePath, null);
+            }
+            else
+            {
+                File.Move(tempPath, StateCacheFilePath);
+            }
         }
-        else
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
         {
-            File.Move(tempPath, StateCacheFilePath);
+            // No writable service folder (e.g. stateless cloud host): till state is a pure cache re-seeded from
+            // the RT Server via createToken, so persistence is best-effort. Disable to avoid repeated churn.
+            _persistDisabled = true;
+            _logger.LogWarning(ex, "Could not persist Epson RT Server till state to '{folder}'; continuing in-memory (state is re-seeded from the device via createToken).", _scuCacheFolder);
         }
     }
 }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -502,10 +502,10 @@ public sealed class EpsonRTServerSCU : LegacySCU
         {
             _tillStates = JsonConvert.DeserializeObject<Dictionary<Guid, TillState>>(File.ReadAllText(StateCacheFilePath)) ?? new Dictionary<Guid, TillState>();
         }
-        catch (Exception ex) when (ex is JsonException or IOException or UnauthorizedAccessException)
+        catch (JsonException ex)
         {
-            // A corrupt/unreadable cache is recoverable: the state is re-seeded from the server (token + fiscalInformation).
-            _logger.LogWarning(ex, "The state cache '{path}' could not be read and will be rebuilt from the RT Server.", StateCacheFilePath);
+            // A corrupt cache is recoverable: the state is re-seeded from the server (token + fiscalInformation).
+            _logger.LogWarning(ex, "The state cache '{path}' is corrupt and will be rebuilt from the RT Server.", StateCacheFilePath);
             _tillStates = new Dictionary<Guid, TillState>();
         }
     }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
 using FluentAssertions;
@@ -28,6 +29,41 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
                 // Async would cache to disk and return null; with no folder it must send synchronously.
                 response.Should().NotBeNull();
                 client.Verify(x => x.CreateReceiptAsync("<createReceipt/>"), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task ProcessAllReceipts_Should_Not_Throw_Or_Call_Client_When_No_Writable_Folder()
+        {
+            var client = new Mock<IEpsonRTServerClient>();
+
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false };
+            var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object,
+                NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration, personalFolderProvider: () => string.Empty);
+
+            // Reached on every daily closing (EpsonRTServerSCU.PerformDailyClosingAsync). With no disk cache
+            // there is nothing to drain, so this must be a no-op that never touches the (never-created) cache path.
+            Func<Task> act = () => queue.ProcessAllReceipts("FISK0001");
+
+            using (new AssertionScope())
+            {
+                await act.Should().NotThrowAsync();
+                client.Verify(x => x.CreateReceiptAsync(It.IsAny<string>()), Times.Never);
+
+                // The awaited call alone doesn't reveal the real defect: the `finally` block used to
+                // unconditionally restart the drain via a fire-and-forget `Task.Run`, which then hit
+                // Directory.GetDirectories on a path that was never created, throwing every ~2s forever
+                // (caught and logged, never surfacing here). That loop sets this flag true on its very first
+                // iteration, so poll briefly for the regression instead of trusting a fixed sleep.
+                var processingField = typeof(EpsonRTServerCommunicationQueue)
+                    .GetField("_processingReceipts", BindingFlags.NonPublic | BindingFlags.Instance)!;
+                var deadline = DateTime.UtcNow.AddMilliseconds(300);
+                while (DateTime.UtcNow < deadline && !(bool)processingField.GetValue(queue)!)
+                {
+                    await Task.Delay(10);
+                }
+                ((bool)processingField.GetValue(queue)!).Should().BeFalse(
+                    "the background drain must never (re)start when there is no writable cache folder");
             }
         }
     }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Threading.Tasks;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
+{
+    public class EpsonRTServerCommunicationQueueTests
+    {
+        [Fact]
+        public async Task EnqueueDocument_Should_Send_Synchronously_When_No_Writable_Folder_Even_If_Async_Configured()
+        {
+            var client = new Mock<IEpsonRTServerClient>();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .ReturnsAsync(new RtServerResponse { Success = true, Code = "0", Status = "OK" });
+
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false };
+            var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object,
+                NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration, personalFolderProvider: () => string.Empty);
+
+            var response = await queue.EnqueueDocument("FISK0001", "<createReceipt/>", 1, 1);
+
+            using (new AssertionScope())
+            {
+                // Async would cache to disk and return null; with no folder it must send synchronously.
+                response.Should().NotBeNull();
+                client.Verify(x => x.CreateReceiptAsync("<createReceipt/>"), Times.Once);
+            }
+        }
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
@@ -201,5 +201,65 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
             ((ulong) result.ReceiptResponse.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
             result.ReceiptResponse.ftSignatures.Should().Contain(x => x.Data.Contains("8 characters"));
         }
+
+        [Fact]
+        public async Task ProcessReceiptAsync_Should_Not_Crash_And_Reseed_Once_When_No_Writable_Folder()
+        {
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>())).ReturnsAsync(Ok(("fingerPrint", "ignored")));
+
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = true };
+            var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object,
+                NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration, personalFolderProvider: () => string.Empty);
+            var scu = new EpsonRTServerSCU(Guid.NewGuid(), NullLogger<EpsonRTServerSCU>.Instance,
+                configuration, client.Object, queue, personalFolderProvider: () => string.Empty);
+
+            var queueId = Guid.NewGuid();
+            var first = await scu.ProcessReceiptAsync(SaleProcessRequest(queueId));
+            var second = await scu.ProcessReceiptAsync(SaleProcessRequest(queueId));
+
+            using (new AssertionScope())
+            {
+                ((ulong) first.ReceiptResponse.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+                ((ulong) second.ReceiptResponse.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+                first.ReceiptResponse.ftSignatures.Should().Contain(x => x.Caption == "<rt-doc-number>" && x.Data == "0001");
+                second.ReceiptResponse.ftSignatures.Should().Contain(x => x.Caption == "<rt-doc-number>" && x.Data == "0002");
+                // In-memory state survived across receipts on one instance -> token requested only once.
+                client.Verify(x => x.CreateTokenAsync("FISK0001"), Times.Once);
+            }
+        }
+
+        [Fact]
+        public async Task ProcessReceiptAsync_Should_Not_Crash_When_Service_Folder_Is_Unwritable()
+        {
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>())).ReturnsAsync(Ok(("fingerPrint", "ignored")));
+
+            // A FILE where a directory is expected makes Directory.CreateDirectory throw (cross-platform).
+            var filePath = Path.Combine(Path.GetTempPath(), $"epsonrtserver-unwritable-{Guid.NewGuid()}");
+            File.WriteAllText(filePath, "x");
+            var cacheDir = Path.Combine(Path.GetTempPath(), $"epsonrtserver-cache-{Guid.NewGuid()}");
+            try
+            {
+                // ServiceFolder = the file (breaks the SCU state cache path); CacheDirectory = a real dir so the queue is fine.
+                var configuration = new EpsonRTServerConfiguration
+                {
+                    ServerUrl = "https://localhost", SendReceiptsSync = true, ServiceFolder = filePath, CacheDirectory = cacheDir
+                };
+                var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object,
+                    NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+                var scu = new EpsonRTServerSCU(Guid.NewGuid(), NullLogger<EpsonRTServerSCU>.Instance,
+                    configuration, client.Object, queue);
+
+                var result = await scu.ProcessReceiptAsync(SaleProcessRequest());
+
+                ((ulong) result.ReceiptResponse.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+            }
+            finally
+            {
+                File.Delete(filePath);
+                if (Directory.Exists(cacheDir)) Directory.Delete(cacheDir, true);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

The `EpsonRTServer` SCU crashes at init on the hosted **CloudCashbox** platform:

```
System.ArgumentException: The value cannot be an empty string. (Parameter 'path')
  at System.IO.Directory.CreateDirectory(String path)
  at EpsonRTServerSCU.PersistState()
```

`_scuCacheFolder` falls back to `Environment.GetFolderPath(SpecialFolder.Personal)`, which returns `""` in the Linux container (no `$HOME`), and `PersistState()` called `Directory.CreateDirectory("")`.

## Why "best-effort", not a state store

Validated against the *RT Server Security Communication Protocol Rev27* + *Fiscal ePOS Metadata Guide Rev17*:

- The **device is authoritative** — it stores the whole per-till chain (last `CCDC/Hash/Token`, next receipt number, Z, daily amount). `createToken` re-anchors all of it and is the sanctioned recovery. `CCDC` is plain SHA-256 — no client-only secret. So the local state file is a **pure cache**; losing it loses nothing.
- **Single-writer per till is already guaranteed** by CloudCashbox's per-cashbox `Medallion.Threading` Redis sign-lock (one cashbox → one queue → one tillId) + header-based routing.

So the fix makes local persistence best-effort rather than adding any state-store abstraction, flag, or shared store.

## What changed

- **`EpsonRTServerSCU`** — `PersistState`/`LoadStateFromDisk` guard on an empty/unwritable folder (best-effort, latched); on the stateless host the till state is in-memory and re-seeded from the device via `createToken`. On-prem behavior is unchanged.
- **`EpsonRTServerCommunicationQueue`** — when no writable cache folder exists: skip directory creation, do not start (or restart, on daily closing) the background drain, and **force synchronous send** even if `SendReceiptsSync == false`. This prevents silent loss of fiscal documents to ephemeral disk — the one genuinely dangerous behavior.
- A tiny test-only seam (`Func<string>? personalFolderProvider = null`) makes the no-folder path deterministically testable; production callers pass nothing.

## Testing

`dotnet test scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest` → **63/63 passing**. New tests: no-crash + re-seed-once with no folder, force-sync with no folder, and the daily-closing drain guard (RED→GREEN).

## Cross-repo / deployment

Host registration (add `EpsonRTServer` to `ScuPackages` + the factory switch) is a **separate PR in `service-cloudcashbox`** (branch `epsonrtserver-scu-registration`). It only takes effect once that repo's `middleware` submodule pointer is bumped to a commit containing this PR.

## Follow-up (separate ticket)

`CustomRTServer` has the same bug class **live today** — its `SendReceiptsSync` defaults to `false` and buffers fiscal documents to an ephemeral relative path in cloud. Recommend prioritizing an audit / the same force-sync guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
