### PR TITLE
fix(epsonrtserver): force synchronous signing on stateless hosts (LauncherEnvironment)

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -47,12 +47,25 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 _documentsPath = configuration.CacheDirectory!;
             }
 
-            _diskCacheAvailable = !string.IsNullOrEmpty(configuration.CacheDirectory) || !string.IsNullOrEmpty(cacheFolder);
+            // Host-injected signal (set by the launcher on CloudCashbox): a folder resolving on a stateless host
+            // (e.g. Environment.SpecialFolder.Personal -> "/root" on the cloud image, root, no $HOME) still looks
+            // writable, so the folder heuristic alone cannot be trusted there. LauncherEnvironment="cloud"
+            // overrides it explicitly.
+            var stateless = string.Equals(configuration.LauncherEnvironment?.Trim(), "cloud", StringComparison.OrdinalIgnoreCase);
+            _diskCacheAvailable = (!string.IsNullOrEmpty(configuration.CacheDirectory) || !string.IsNullOrEmpty(cacheFolder)) && !stateless;
             if (!_diskCacheAvailable)
             {
-                // Stateless host (no writable folder): the on-disk offline buffer cannot survive a restart, so
-                // documents are always sent synchronously and the background drain is not started.
-                _logger.LogWarning("No writable cache folder for the Epson RT Server queue; documents are sent synchronously (offline buffering disabled).");
+                // Stateless host (no writable folder, or explicitly flagged stateless via LauncherEnvironment):
+                // the on-disk offline buffer cannot survive a restart, so documents are always sent
+                // synchronously and the background drain is not started.
+                if (!_configuration.SendReceiptsSync)
+                {
+                    _logger.LogWarning("SendReceiptsSync=false requested but this host is stateless (LauncherEnvironment='{launcherEnvironment}') or has no persistent cache folder; enforcing synchronous signing to avoid losing fiscal documents on restart.", configuration.LauncherEnvironment);
+                }
+                else
+                {
+                    _logger.LogWarning("No writable cache folder for the Epson RT Server queue; documents are sent synchronously (offline buffering disabled).");
+                }
                 return;
             }
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerConfiguration.cs
@@ -91,6 +91,16 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         /// Overrides the folder used by the communication queue to cache pending documents.
         /// </summary>
         public string? CacheDirectory { get; set; }
+
+        /// <summary>
+        /// Host-injected signal describing where the SCU is running. Set to "cloud" by the launcher on
+        /// CloudCashbox: those hosts are stateless (pods are recycled and have no persistent disk), so the
+        /// folder-based disk-cache heuristic cannot be trusted (e.g. on the cloud image
+        /// <see cref="Environment.SpecialFolder.Personal"/> resolves to "/root", which looks writable but does
+        /// not survive a restart). When this is "cloud" the communication queue forces synchronous signing so
+        /// no fiscal document is ever buffered where it could be lost on restart.
+        /// </summary>
+        public string? LauncherEnvironment { get; set; }
     }
 
     public class AccountMasterData

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
@@ -11,6 +12,52 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
 {
     public class EpsonRTServerCommunicationQueueTests
     {
+        [Fact]
+        public async Task EnqueueDocument_Should_Send_Synchronously_When_LauncherEnvironment_Is_Cloud_Even_With_Writable_Folder()
+        {
+            // Regression for the cloud image: Environment.GetFolderPath(SpecialFolder.Personal) resolves to
+            // "/root" there (root, no $HOME), which IS a writable/creatable folder, so the disk-cache heuristic
+            // alone would allow async and buffer fiscal documents on a pod with no durable storage. The host
+            // must be able to force sync explicitly via LauncherEnvironment="cloud" regardless of what the
+            // folder heuristic says.
+            var tempServiceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-cloud-test-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempServiceFolder);
+            try
+            {
+                var client = new Mock<IEpsonRTServerClient>();
+                client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                    .ReturnsAsync(new RtServerResponse { Success = true, Code = "0", Status = "OK" });
+
+                var configuration = new EpsonRTServerConfiguration
+                {
+                    ServerUrl = "https://localhost",
+                    SendReceiptsSync = false,
+                    ServiceFolder = tempServiceFolder,
+                    LauncherEnvironment = "cloud",
+                };
+                var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object,
+                    NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+
+                var response = await queue.EnqueueDocument("FISK0001", "<createReceipt/>", 1, 1);
+
+                using (new AssertionScope())
+                {
+                    // Async would cache to disk and return null; on a stateless/cloud host it must send synchronously.
+                    response.Should().NotBeNull();
+                    client.Verify(x => x.CreateReceiptAsync("<createReceipt/>"), Times.Once);
+
+                    // No document must ever have been written to disk: a stateless host cannot durably hold a
+                    // buffered fiscal document, so nothing may be persisted even transiently.
+                    Directory.EnumerateFileSystemEntries(tempServiceFolder, "*", SearchOption.AllDirectories)
+                        .Should().BeEmpty("a stateless/cloud host must never buffer fiscal documents to disk");
+                }
+            }
+            finally
+            {
+                Directory.Delete(tempServiceFolder, recursive: true);
+            }
+        }
+
         [Fact]
         public async Task EnqueueDocument_Should_Send_Synchronously_When_No_Writable_Folder_Even_If_Async_Configured()
         {


### PR DESCRIPTION
## Problem

The "async only when a writable folder exists" guard (from #711) is an unreliable foundation for a fiscal invariant. `Environment.GetFolderPath(SpecialFolder.Personal)` is **environment-dependent** on Linux:
- On the CloudCashbox image (`aspnet:8.0-bookworm-slim`, root, no `$HOME`) it resolves to **`/root`** (non-empty) → `_diskCacheAvailable = true` → async is **not** forced. With `SendReceiptsSync=false`, fiscal documents buffer to the ephemeral `/root` and are **lost on pod restart** (no PVC, 2 replicas).
- In the original incident container it resolved to `""` (hence the crash we fixed) — proving the value varies by environment.

So async signing must not depend on inferring "cloud" from the disk.

## Change

- Add `EpsonRTServerConfiguration.LauncherEnvironment` (host-injected).
- `EpsonRTServerCommunicationQueue` treats `LauncherEnvironment == "cloud"` (case-insensitive, trimmed) as **no durable cache**, AND-ing it into `_diskCacheAvailable`. This single change flows through every existing guard → forced synchronous send, no disk buffering, no background drain.
- Warns (never hard-fails) when `SendReceiptsSync=false` is overridden.

## The rule

Asynchronous (offline-buffered) signing is enabled **iff** `SendReceiptsSync == false` **AND** `LauncherEnvironment != "cloud"` **AND** a cache folder resolves — otherwise **synchronous**. Async is for **on-prem/local (persistent disk) only**.

## Requires companion change

This is **inert until the host injects `LauncherEnvironment=cloud`** into the SCU's config — see the companion `service-cloudcashbox` PR. Until then it safely defaults to today's behavior. (The queue already receives `LauncherEnvironment=cloud`; the SCU config did not — the companion PR fixes that.)

## Tests

New test proves the invariant: a real `ServiceFolder` is present (so the folder heuristic alone *would* allow async) + `SendReceiptsSync=false` + `LauncherEnvironment=cloud` → sync path taken (`CreateReceiptAsync` called, non-null response) and **zero** files written under the folder. Full suite: **64/64**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
