### PR TITLE
fix(epsonrtserver): record local emission time from the UTC receipt moment

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -35,9 +35,10 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         {
             var docNumber = tillState.LastDocNumber + 1;
             var zNumber = tillState.LastZNumber;
-            // cbReceiptMoment is UTC, but the RT Server records the LOCAL emission time (Metadata Guide 3.8:
-            // dateTime "YYYYMMDDThhmmss" + srtUtcOffset 1=winter/2=summer). Convert with the device-reported
-            // offset so the time is correct on any host (the cloud host runs in UTC; ToLocalTime would be wrong).
+            // The RT Server records the LOCAL emission time (Metadata Guide 3.8: dateTime "YYYYMMDDThhmmss"
+            // + srtUtcOffset 1=winter/2=summer). cbReceiptMoment is defined as UTC (fiskaltrust interface-doc),
+            // so convert with the device-reported offset — correct on any host (the cloud host runs in UTC,
+            // where ToLocalTime would be wrong).
             var moment = ToRtServerLocalTime(receiptRequest.cbReceiptMoment, tillState.SrtUtcOffset);
 
             var recAmount = GetReceiptTotal(receiptRequest, docType);
@@ -78,13 +79,18 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         }
 
         /// <summary>
-        /// Converts a UTC receipt moment to the RT Server's local wall-clock time using the device-reported
-        /// <paramref name="srtUtcOffset"/> (1 = winter/+1h, 2 = summer/+2h). Returns an Unspecified-kind value
-        /// so it formats without a timezone designator, as the metadata format requires.
+        /// Converts the receipt moment to the RT Server's local wall-clock time using the device-reported
+        /// <paramref name="srtUtcOffset"/> (1 = winter/+1h, 2 = summer/+2h). cbReceiptMoment is defined as UTC
+        /// (fiskaltrust interface-doc: "Must be provided in UTC"); since the DateTimeKind is not guaranteed
+        /// after deserialization, a Local value is normalised via ToUniversalTime and a zoneless (Unspecified)
+        /// value is honoured as UTC per that contract. Returns an Unspecified-kind value so it formats without
+        /// a timezone designator, as the metadata format requires.
         /// </summary>
         public static DateTime ToRtServerLocalTime(DateTime moment, int srtUtcOffset)
         {
-            var utc = moment.Kind == DateTimeKind.Local ? moment.ToUniversalTime() : moment;
+            var utc = moment.Kind == DateTimeKind.Local
+                ? moment.ToUniversalTime()
+                : DateTime.SpecifyKind(moment, DateTimeKind.Utc);
             return DateTime.SpecifyKind(utc.AddHours(srtUtcOffset), DateTimeKind.Unspecified);
         }
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -35,7 +35,10 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         {
             var docNumber = tillState.LastDocNumber + 1;
             var zNumber = tillState.LastZNumber;
-            var moment = receiptRequest.cbReceiptMoment;
+            // cbReceiptMoment is UTC, but the RT Server records the LOCAL emission time (Metadata Guide 3.8:
+            // dateTime "YYYYMMDDThhmmss" + srtUtcOffset 1=winter/2=summer). Convert with the device-reported
+            // offset so the time is correct on any host (the cloud host runs in UTC; ToLocalTime would be wrong).
+            var moment = ToRtServerLocalTime(receiptRequest.cbReceiptMoment, tillState.SrtUtcOffset);
 
             var recAmount = GetReceiptTotal(receiptRequest, docType);
             var recVat = GetReceiptVat(receiptRequest, docType);
@@ -72,6 +75,17 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 ReferenceDocNumber = referenceDocNumber,
                 ReferenceDocMoment = referenceDocMoment
             };
+        }
+
+        /// <summary>
+        /// Converts a UTC receipt moment to the RT Server's local wall-clock time using the device-reported
+        /// <paramref name="srtUtcOffset"/> (1 = winter/+1h, 2 = summer/+2h). Returns an Unspecified-kind value
+        /// so it formats without a timezone designator, as the metadata format requires.
+        /// </summary>
+        public static DateTime ToRtServerLocalTime(DateTime moment, int srtUtcOffset)
+        {
+            var utc = moment.Kind == DateTimeKind.Local ? moment.ToUniversalTime() : moment;
+            return DateTime.SpecifyKind(utc.AddHours(srtUtcOffset), DateTimeKind.Unspecified);
         }
 
         private static string BuildPrinterFiscalReceipt(

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -248,10 +248,11 @@ public sealed class EpsonRTServerSCU : LegacySCU
             }
             else if (string.IsNullOrEmpty(receiptRequest.cbPreviousReceiptReference))
             {
-                // Unreferenced refund/void: use neutral references and the current moment.
+                // Unreferenced refund/void: use neutral references and the current moment (converted to the
+                // RT Server's local time, consistent with the receipt's own dateTime).
                 referenceZNumber = 0;
                 referenceDocNumber = 0;
-                referenceDocMoment = receiptRequest.cbReceiptMoment;
+                referenceDocMoment = EpsonRTServerMapping.ToRtServerLocalTime(receiptRequest.cbReceiptMoment, tillState.SrtUtcOffset);
                 referenceTillId = tillState.TillId;
             }
             else

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -248,11 +248,12 @@ public sealed class EpsonRTServerSCU : LegacySCU
             }
             else if (string.IsNullOrEmpty(receiptRequest.cbPreviousReceiptReference))
             {
-                // Unreferenced refund/void: use neutral references and the current moment (converted to the
-                // RT Server's local time, consistent with the receipt's own dateTime).
+                // Unreferenced refund/void: no original document exists, so its emission moment is unknown.
+                // Send neutral references and omit the reference date (referenceDocMoment stays null) rather
+                // than inventing one from cbReceiptMoment (~today): the device logs the missing reference
+                // (-45, accepted with warning) but still registers the document.
                 referenceZNumber = 0;
                 referenceDocNumber = 0;
-                referenceDocMoment = EpsonRTServerMapping.ToRtServerLocalTime(receiptRequest.cbReceiptMoment, tillState.SrtUtcOffset);
                 referenceTillId = tillState.TillId;
             }
             else

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
@@ -91,6 +91,46 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
             }
         }
 
+        [Fact]
+        public void BuildFiscalDocument_UnreferencedRefund_Should_Omit_RefDateTime()
+        {
+            var doc = EpsonRTServerMapping.BuildFiscalDocument(SaleRequest(), NewTillState(), 1, 0, 0, null, "FISK0001");
+
+            using (new AssertionScope())
+            {
+                doc.CreateReceiptXml.Should().Contain("<beginFiscalReceipt docType=\"1\"");
+                doc.CreateReceiptXml.Should().NotContain("refDateTime=");
+                doc.ReferenceDocMoment.Should().BeNull();
+            }
+        }
+
+        [Theory]
+        [InlineData(DateTimeKind.Utc)]
+        [InlineData(DateTimeKind.Unspecified)]
+        public void ToRtServerLocalTime_Should_Treat_Utc_And_Zoneless_As_Utc(DateTimeKind kind)
+        {
+            var moment = DateTime.SpecifyKind(new DateTime(2026, 7, 2, 12, 0, 0), kind);
+
+            var local = EpsonRTServerMapping.ToRtServerLocalTime(moment, 2);
+
+            using (new AssertionScope())
+            {
+                local.Should().Be(new DateTime(2026, 7, 2, 14, 0, 0));
+                local.Kind.Should().Be(DateTimeKind.Unspecified);
+            }
+        }
+
+        [Fact]
+        public void ToRtServerLocalTime_Should_Normalise_Local_Kind_Independent_Of_Host()
+        {
+            // A Local value is converted to UTC first, so the result does not depend on the host time zone.
+            var localKind = new DateTime(2026, 7, 2, 12, 0, 0, DateTimeKind.Utc).ToLocalTime();
+
+            var local = EpsonRTServerMapping.ToRtServerLocalTime(localKind, 2);
+
+            local.Should().Be(new DateTime(2026, 7, 2, 14, 0, 0));
+        }
+
         private static ReceiptRequest RequestWith(ChargeItem[] items, decimal cashPayment) => new()
         {
             ftReceiptCase = 0x0001,

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
@@ -101,6 +101,55 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         }
 
         [Fact]
+        public async Task ProcessReceiptAsync_Should_Record_Local_Time_From_Utc_Moment_Summer()
+        {
+            var sentDocuments = new List<string>();
+            var client = CreateClientMock(); // GetServerTimeAsync -> srtUtcOffset "2" (summer)
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .Callback<string>(sentDocuments.Add)
+                .ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var scu = CreateScu(client, out _);
+
+            var request = SaleProcessRequest();
+            request.ReceiptRequest.cbReceiptMoment = new DateTime(2026, 7, 2, 12, 0, 0, DateTimeKind.Utc);
+
+            var result = await scu.ProcessReceiptAsync(request);
+
+            using (new AssertionScope())
+            {
+                // 12:00 UTC + srtUtcOffset 2 => 14:00 local, sent to the device without a timezone designator.
+                sentDocuments.Should().ContainSingle().Which.Should().Contain("dateTime=\"20260702T140000\"");
+                result.ReceiptResponse.ftSignatures.Should().Contain(
+                    x => x.Caption == "<rt-doc-moment>" && x.Data == "2026-07-02 14:00:00");
+            }
+        }
+
+        [Fact]
+        public async Task ProcessReceiptAsync_Should_Record_Local_Time_From_Utc_Moment_Winter()
+        {
+            var sentDocuments = new List<string>();
+            var client = CreateClientMock();
+            client.Setup(x => x.GetServerTimeAsync()).ReturnsAsync(Ok(("srtUtcOffset", "1"))); // winter
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .Callback<string>(sentDocuments.Add)
+                .ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var scu = CreateScu(client, out _);
+
+            var request = SaleProcessRequest();
+            request.ReceiptRequest.cbReceiptMoment = new DateTime(2026, 1, 15, 12, 0, 0, DateTimeKind.Utc);
+
+            var result = await scu.ProcessReceiptAsync(request);
+
+            using (new AssertionScope())
+            {
+                // 12:00 UTC + srtUtcOffset 1 => 13:00 local.
+                sentDocuments.Should().ContainSingle().Which.Should().Contain("dateTime=\"20260115T130000\"");
+                result.ReceiptResponse.ftSignatures.Should().Contain(
+                    x => x.Caption == "<rt-doc-moment>" && x.Data == "2026-01-15 13:00:00");
+            }
+        }
+
+        [Fact]
         public async Task ProcessReceiptAsync_Sale_Should_Advance_Chain_On_Acceptance()
         {
             var sentDocuments = new List<string>();


### PR DESCRIPTION
## Problem
`cbReceiptMoment` is UTC, but the RT Server records the **local** emission time. The SCU sent `cbReceiptMoment` verbatim as the device `dateTime` and the `<rt-doc-moment>` signature while separately declaring `srtUtcOffset` — so the recorded/printed fiscal time was UTC (e.g. 12:00) instead of local (14:00 in summer), and near midnight the **date** could be off by a day.

## Spec (verified in the Metadata Guide Rev17, §3.8)
- `dateTime` = "Fiscal receipt emission date and time (YYYYMMDDThhmmss format)" — local wall time.
- `srtUtcOffset` = "The time offset from UTC. Assumes values 1 (winter) or 2 (summer)".

## Fix
Convert to the device's local time at the single point the moment enters the fiscal document (`EpsonRTServerMapping.BuildFiscalDocument`), using the **device-reported `srtUtcOffset`** — correct on **any** host (the cloud host runs in UTC, so `ToLocalTime()` would be wrong; the device offset is host-independent). EpsonRTServer-only; the shared `SignatureFactory` format is unchanged.

`cbReceiptMoment` is UTC **by contract** ([fiskaltrust interface-doc](https://github.com/fiskaltrust/interface-doc/blob/master/doc/general/data-structures/data-structures.md): "Must be provided in UTC") but the `DateTimeKind` is **not** guaranteed at runtime — QueuePT explicitly rejects `Kind != Utc` (`ReceiptRequestValidations.cs:160`), and IT has no such guard. `ToRtServerLocalTime` therefore normalizes by kind — `Local` → `ToUniversalTime`, zoneless (`Unspecified`) → honored as UTC per the contract — before applying the offset.

## Refunds
- **Referenced** refunds/voids source the moment from the response signatures (`RTReferenceDocumentMoment`, injected by the queue from the original receipt) — unchanged.
- **Unreferenced** refunds/voids no longer fabricate a date from `cbReceiptMoment` (~today): `referenceDocMoment` stays null, so `refDateTime` is omitted. The device logs the missing reference (`-45`, accepted with warning) and still registers the document.

## Context
Replaces the **rejected #718** (`ToString("o")` emitted a `Z` designator that `DateTime.Parse` converts to host-local, corrupting the CCDC-chained `refDateTime`).

## Tests
Summer (offset 2): 12:00 UTC → device `dateTime="20260702T140000"` + signature `2026-07-02 14:00:00`. Winter (offset 1): 12:00 UTC → 13:00. Conversion verified host-independent for `Utc`/`Unspecified`/`Local` kinds; unreferenced refund omits `refDateTime`. Full EpsonRTServer suite **72/72**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
