### PR TITLE
Handle Epson RT Server accepted receipt warnings

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerClient.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerClient.cs
@@ -76,7 +76,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             => SendToFpServerAsync("<createReport><tillMap /></createReport>");
 
         public Task<RtServerResponse> CreateReceiptAsync(string createReceiptXml)
-            => SendToFpServerAsync(createReceiptXml);
+            => PerformAsync(FpServerEndpoint, createReceiptXml, acceptReceiptWarnings: true);
 
         public Task<RtServerResponse> CreateDailyClosureAsync(string tillId, int closureType)
             => SendToFpServerAsync($"<createDailyClosure><till tillId=\"{tillId}\" closureType=\"{closureType}\" /></createDailyClosure>");
@@ -107,7 +107,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         private Task<RtServerResponse> SendToFpMateAsync(string bodyXml)
             => PerformAsync($"{FpMateEndpoint}?timeout={_configuration.ServerCommandTimeoutInMs}", bodyXml);
 
-        private async Task<RtServerResponse> PerformAsync(string endpoint, string bodyXml)
+        private async Task<RtServerResponse> PerformAsync(string endpoint, string bodyXml, bool acceptReceiptWarnings = false)
         {
             var response = await PerformOnceAsync(endpoint, bodyXml).ConfigureAwait(false);
             // -8 "Server busy" is transient (e.g. while a daily closure or Z report is being processed):
@@ -123,10 +123,17 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             if (!response.Success && response.CodeAsInt < 0)
             {
                 var description = EpsonRTServerErrorCodes.Describe(response.CodeAsInt);
-                _logger.LogError("Calling '{endpoint}' failed with code {code} ({status}): {description}. Raw: {raw}", endpoint, response.Code, response.Status, description, response.RawResponse);
-                if (!_configuration.IgnoreRTServerErrors)
+                if (acceptReceiptWarnings && EpsonRTServerErrorCodes.IsReceiptAcceptedWithWarning(response.CodeAsInt))
                 {
-                    throw new EpsonRTServerCommunicationException($"Calling '{endpoint}' failed with code {response.Code} ({response.Status}): {description}", response.CodeAsInt);
+                    _logger.LogWarning("Calling '{endpoint}' was accepted with warning code {code} ({status}): {description}. Raw: {raw}", endpoint, response.Code, response.Status, description, response.RawResponse);
+                }
+                else
+                {
+                    _logger.LogError("Calling '{endpoint}' failed with code {code} ({status}): {description}. Raw: {raw}", endpoint, response.Code, response.Status, description, response.RawResponse);
+                    if (!_configuration.IgnoreRTServerErrors)
+                    {
+                        throw new EpsonRTServerCommunicationException($"Calling '{endpoint}' failed with code {response.Code} ({response.Status}): {description}", response.CodeAsInt);
+                    }
                 }
             }
             return response;

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerClientTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerClientTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
+{
+    public class EpsonRTServerClientTests
+    {
+        [Fact]
+        public async Task CreateReceiptAsync_Should_Return_Accepted_Warning()
+        {
+            var client = CreateClient(-52, "till offline");
+
+            var response = await client.CreateReceiptAsync("<createReceipt />");
+
+            response.CodeAsInt.Should().Be(-52);
+        }
+
+        [Fact]
+        public async Task CreateReceiptAsync_Should_Throw_For_Blocking_Rejection()
+        {
+            var client = CreateClient(-32, "refund or void not possible");
+
+            Func<Task> act = () => client.CreateReceiptAsync("<createReceipt />");
+
+            var exception = await act.Should().ThrowAsync<EpsonRTServerCommunicationException>();
+            exception.Which.ResponseCode.Should().Be(-32);
+        }
+
+        private static EpsonRTServerClient CreateClient(int code, string status)
+        {
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost" };
+            var client = new EpsonRTServerClient(configuration, NullLogger<EpsonRTServerClient>.Instance);
+            var httpClient = new HttpClient(new ResponseHandler(code, status))
+            {
+                BaseAddress = new Uri(configuration.ServerUrl)
+            };
+            typeof(EpsonRTServerClient).GetField("_httpClient", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(client, httpClient);
+            return client;
+        }
+
+        private sealed class ResponseHandler : HttpMessageHandler
+        {
+            private readonly int _code;
+            private readonly string _status;
+
+            public ResponseHandler(int code, string status)
+            {
+                _code = code;
+                _status = status;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent($"<response success=\"false\" code=\"{_code}\" status=\"{_status}\" />")
+                });
+        }
+    }
+}


### PR DESCRIPTION
Recreated from #719 under a human author because the Copilot bot cannot sign the CLA. The diff is byte-identical to #719.

The Epson RT Server may accept delayed receipts while returning a warning code (e.g. `-52` "till offline"). The client incorrectly treated this as a failed transmission and threw an exception.

- **Receipt handling**
  - Return protocol-defined accepted-warning responses normally for `createReceipt`.
  - Log them as warnings instead of errors.
- **Error handling**
  - Preserve exceptions for blocking rejections.
  - Restrict this behavior to receipt creation; other commands remain unchanged.
- **Coverage**
  - Cover accepted warning `-52` and blocking rejection `-32`.

Supersedes #719.