### PR TITLE
fix(epsonrtserver): realign token on Z-session shift in the offline drain

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerClient.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerClient.cs
@@ -93,6 +93,9 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         public Task<RtServerResponse> GetFiscalInformationAsync(string tillId)
             => SendToFpServerAsync($"<createReport><fiscalInformation tillId=\"{tillId}\" /></createReport>");
 
+        public Task<RtServerResponse> GetReceiptAsync(string tillId, long zRepNumber, long recNumber, string date)
+            => SendToFpServerAsync($"<createReport><receipt tillId=\"{tillId}\" zRepNumber=\"{zRepNumber:D4}\" recNumber=\"{recNumber:D4}\" date=\"{date}\" reportType=\"txt\" /></createReport>");
+
         public Task<RtServerResponse> GetPublicKeyAsync()
             => SendToFpServerAsync("<createReport><publicKey /></createReport>");
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -244,9 +245,10 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             }
 
             // Out-of-sync (-21/-22/-23/-25): the RT Server session/chain has moved on (e.g. a forced or daily
-            // closure, Metadata Guide §3.4.7); replaying the same document number can never succeed. Realign the
-            // till to the device's current session so subsequent documents are built correctly, then park this
-            // one — it belongs to a closed session and must never be resent (that would double-register it).
+            // closure, Metadata Guide §3.4.7). Realign the till to the device's current session so subsequent
+            // documents are built correctly. This document must never be resent (that would double-register it):
+            // if the device confirms it already stored it (these codes register the receipt with an anomaly)
+            // consume the redundant local copy, otherwise park it for manual review.
             if (EpsonRTServerErrorCodes.IsLocalStateOutOfSync(code))
             {
                 var tillId = Path.GetFileName(Path.GetDirectoryName(documentPath))!;
@@ -254,7 +256,15 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 {
                     await TillStateRealigner(tillId).ConfigureAwait(false);
                 }
-                ParkDocument(documentPath, $"the RT Server session moved on (code {code}); it belongs to a closed session");
+                if (await IsAlreadyRegisteredAsync(documentPath, tillId).ConfigureAwait(false))
+                {
+                    _logger.LogWarning("Cached document {document} is already registered on the RT Server (code {code}); consuming the redundant local copy.",
+                        Path.GetFileName(documentPath), code);
+                    File.Delete(documentPath);
+                    _rejectionCounts.Remove(documentPath);
+                    return true;
+                }
+                ParkDocument(documentPath, $"the RT Server session moved on (code {code}) and it is not registered on the device");
                 return true;
             }
 
@@ -282,6 +292,43 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             _rejectionCounts.Remove(documentPath);
             _logger.LogError("Cached document {document} was parked in '{failedFolder}' because {reason}. It will NOT be transmitted automatically and needs manual review.",
                 Path.GetFileName(documentPath), failedFolder, reason);
+        }
+
+        /// <summary>
+        /// Confirms whether the RT Server already stored this document: reads it back by its original
+        /// coordinates and suffix-matches the device's prefixed CCDC (dateTime+till+Z+rec+ccdc) against the
+        /// CCDC in the cached document. Any read failure (e.g. -31 file not found) is treated as "not
+        /// confirmed" so the document is preserved (parked), never consumed on doubt.
+        /// </summary>
+        private async Task<bool> IsAlreadyRegisteredAsync(string documentPath, string tillId)
+        {
+            try
+            {
+                var (zRep, rec, date, ccdc) = ParseReceiptCoordinates(File.ReadAllText(documentPath));
+                if (string.IsNullOrEmpty(ccdc) || string.IsNullOrEmpty(date))
+                {
+                    return false;
+                }
+                var stored = await _client.GetReceiptAsync(tillId, zRep, rec, date!).ConfigureAwait(false);
+                var storedHash = stored?.GetAddInfo("hash");
+                return !string.IsNullOrEmpty(storedHash) && storedHash!.EndsWith(ccdc!, StringComparison.OrdinalIgnoreCase);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Could not confirm whether cached document {document} is already registered; treating it as not registered.", Path.GetFileName(documentPath));
+                return false;
+            }
+        }
+
+        private static (long zRep, long rec, string? date, string? ccdc) ParseReceiptCoordinates(string createReceiptXml)
+        {
+            long ParseLong(string pattern) => long.TryParse(Regex.Match(createReceiptXml, pattern).Groups[1].Value, out var value) ? value : 0;
+            string? ParseString(string pattern) { var match = Regex.Match(createReceiptXml, pattern); return match.Success ? match.Groups[1].Value : null; }
+            return (
+                ParseLong("zRepNumber=\"(\\d+)\""),
+                ParseLong("recNumber=\"(\\d+)\""),
+                ParseString("dateTime=\"(\\d{8})T"),
+                ParseString("receiptSecurity><hash fingerPrint=\"([^\"]+)\""));
         }
 
         public long GetCountOfDocumentsForInCache()

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -28,6 +28,11 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         private bool _processingReceipts;
         private readonly Dictionary<string, int> _rejectionCounts = new();
 
+        // Invoked (with the till id) when a cached document is rejected because the RT Server session/chain moved
+        // on (-21/-22/-23/-25). The SCU wires this to reseed the till's token; the drain cannot do it itself as
+        // it holds no till state.
+        public Func<string, Task>? TillStateRealigner { get; set; }
+
         public EpsonRTServerCommunicationQueue(Guid id, IEpsonRTServerClient client, ILogger<EpsonRTServerCommunicationQueue> logger, EpsonRTServerConfiguration configuration)
         {
             _id = id;
@@ -106,23 +111,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
 
                 try
                 {
-                    foreach (var directory in Directory.GetDirectories(_documentsPath))
-                    {
-                        foreach (var document in Directory.GetFiles(directory, DocumentSearchPattern).OrderBy(x => x))
-                        {
-                            if (_requestCancellation)
-                            {
-                                _processingReceipts = false;
-                                return;
-                            }
-                            if (!await SendCachedDocumentAsync(document).ConfigureAwait(false))
-                            {
-                                // Rejected but not yet parked: stop this till's sequence to preserve the
-                                // blockchain order; retried on the next cycle.
-                                break;
-                            }
-                        }
-                    }
+                    await DrainPendingAsync(canRealign: true).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -131,6 +120,33 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 finally
                 {
                     await Task.Delay(2000).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Drains every till's cached documents once, in blockchain order. On an out-of-sync rejection the
+        /// document is parked and, when <paramref name="canRealign"/> is set, the till's token is realigned to
+        /// the device's current session (see <see cref="SendCachedDocumentAsync"/>).
+        /// </summary>
+        private async Task DrainPendingAsync(bool canRealign)
+        {
+            var realignedTills = new HashSet<string>();
+            foreach (var directory in Directory.GetDirectories(_documentsPath))
+            {
+                foreach (var document in Directory.GetFiles(directory, DocumentSearchPattern).OrderBy(x => x))
+                {
+                    if (_requestCancellation)
+                    {
+                        _processingReceipts = false;
+                        return;
+                    }
+                    if (!await SendCachedDocumentAsync(document, canRealign, realignedTills).ConfigureAwait(false))
+                    {
+                        // Rejected but not yet parked: stop this till's sequence to preserve the blockchain
+                        // order; retried on the next cycle.
+                        break;
+                    }
                 }
             }
         }
@@ -157,9 +173,12 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 {
                     return;
                 }
+                // canRealign: false — the daily-closing drain runs under the SCU lock and reseeds the token
+                // itself afterwards; realigning here would re-enter that non-reentrant lock and deadlock.
+                var realignedTills = new HashSet<string>();
                 foreach (var document in Directory.GetFiles(tillFolder, DocumentSearchPattern).OrderBy(x => x))
                 {
-                    if (!await SendCachedDocumentAsync(document).ConfigureAwait(false))
+                    if (!await SendCachedDocumentAsync(document, canRealign: false, realignedTills).ConfigureAwait(false))
                     {
                         throw new EpsonRTServerCommunicationException($"The RT Server rejected the cached document '{Path.GetFileName(document)}'; daily closing cannot proceed until the cache is drained.", -1);
                     }
@@ -182,27 +201,30 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         /// parked in the "failed" subfolder after too many rejections), false when it was rejected and should
         /// be retried later. Network exceptions propagate to the caller (the device is simply unreachable).
         /// </summary>
-        private async Task<bool> SendCachedDocumentAsync(string documentPath)
+        private async Task<bool> SendCachedDocumentAsync(string documentPath, bool canRealign, ISet<string> realignedTills)
         {
             Models.RtServerResponse? response = null;
             var rejected = false;
+            var code = 0;
             try
             {
                 response = await _client.CreateReceiptAsync(File.ReadAllText(documentPath)).ConfigureAwait(false);
+                code = response?.CodeAsInt ?? 0;
                 // "Accepted with error in log" codes are NOT rejections: the document is fiscally registered,
                 // so it must be consumed (not parked). Only genuine "Receipt not accepted" / unknown negatives
                 // count as rejected.
-                rejected = response != null && !response.Success && response.CodeAsInt < 0
-                    && !EpsonRTServerErrorCodes.IsReceiptAcceptedWithWarning(response.CodeAsInt);
-                if (response != null && !rejected && response.CodeAsInt != 0)
+                rejected = response != null && !response.Success && code < 0
+                    && !EpsonRTServerErrorCodes.IsReceiptAcceptedWithWarning(code);
+                if (response != null && !rejected && code != 0)
                 {
                     _logger.LogWarning("Cached document {document} was accepted by the RT Server with warning code {code} ({description}).",
-                        Path.GetFileName(documentPath), response.Code, EpsonRTServerErrorCodes.Describe(response.CodeAsInt));
+                        Path.GetFileName(documentPath), response.Code, EpsonRTServerErrorCodes.Describe(code));
                 }
             }
             catch (EpsonRTServerCommunicationException ex)
             {
-                rejected = !EpsonRTServerErrorCodes.IsReceiptAcceptedWithWarning(ex.ResponseCode);
+                code = ex.ResponseCode;
+                rejected = !EpsonRTServerErrorCodes.IsReceiptAcceptedWithWarning(code);
                 if (rejected)
                 {
                     _logger.LogError(ex, "The RT Server rejected the cached document {document}.", Path.GetFileName(documentPath));
@@ -210,7 +232,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 else
                 {
                     _logger.LogWarning(ex, "Cached document {document} was accepted by the RT Server with warning code {code} ({description}).",
-                        Path.GetFileName(documentPath), ex.ResponseCode, EpsonRTServerErrorCodes.Describe(ex.ResponseCode));
+                        Path.GetFileName(documentPath), code, EpsonRTServerErrorCodes.Describe(code));
                 }
             }
 
@@ -221,25 +243,45 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 return true;
             }
 
+            // Out-of-sync (-21/-22/-23/-25): the RT Server session/chain has moved on (e.g. a forced or daily
+            // closure, Metadata Guide §3.4.7); replaying the same document number can never succeed. Realign the
+            // till to the device's current session so subsequent documents are built correctly, then park this
+            // one — it belongs to a closed session and must never be resent (that would double-register it).
+            if (EpsonRTServerErrorCodes.IsLocalStateOutOfSync(code))
+            {
+                var tillId = Path.GetFileName(Path.GetDirectoryName(documentPath))!;
+                if (canRealign && TillStateRealigner != null && realignedTills.Add(tillId))
+                {
+                    await TillStateRealigner(tillId).ConfigureAwait(false);
+                }
+                ParkDocument(documentPath, $"the RT Server session moved on (code {code}); it belongs to a closed session");
+                return true;
+            }
+
             _rejectionCounts[documentPath] = (_rejectionCounts.TryGetValue(documentPath, out var count) ? count : 0) + 1;
             _logger.LogWarning("Cached document {document} was rejected by the RT Server (code {code}, attempt {attempt}/{max}).",
-                Path.GetFileName(documentPath), response?.Code ?? "n/a", _rejectionCounts[documentPath], _configuration.MaxDocumentSendRetries);
+                Path.GetFileName(documentPath), response?.Code ?? code.ToString(), _rejectionCounts[documentPath], _configuration.MaxDocumentSendRetries);
 
             if (_rejectionCounts[documentPath] >= _configuration.MaxDocumentSendRetries)
             {
-                // Poison document: park it so it stops blocking the queue. It stays on disk for manual analysis.
-                var failedFolder = Path.Combine(Path.GetDirectoryName(documentPath)!, "failed");
-                if (!Directory.Exists(failedFolder))
-                {
-                    Directory.CreateDirectory(failedFolder);
-                }
-                File.Move(documentPath, Path.Combine(failedFolder, Path.GetFileName(documentPath)));
-                _rejectionCounts.Remove(documentPath);
-                _logger.LogError("Cached document {document} was rejected {max} times and has been moved to '{failedFolder}'. It will NOT be transmitted automatically.",
-                    Path.GetFileName(documentPath), _configuration.MaxDocumentSendRetries, failedFolder);
+                ParkDocument(documentPath, $"it was rejected {_configuration.MaxDocumentSendRetries} times");
                 return true;
             }
             return false;
+        }
+
+        /// <summary>Moves a document that cannot be transmitted into the "failed" subfolder for manual review.</summary>
+        private void ParkDocument(string documentPath, string reason)
+        {
+            var failedFolder = Path.Combine(Path.GetDirectoryName(documentPath)!, "failed");
+            if (!Directory.Exists(failedFolder))
+            {
+                Directory.CreateDirectory(failedFolder);
+            }
+            File.Move(documentPath, Path.Combine(failedFolder, Path.GetFileName(documentPath)));
+            _rejectionCounts.Remove(documentPath);
+            _logger.LogError("Cached document {document} was parked in '{failedFolder}' because {reason}. It will NOT be transmitted automatically and needs manual review.",
+                Path.GetFileName(documentPath), failedFolder, reason);
         }
 
         public long GetCountOfDocumentsForInCache()

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -46,6 +46,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
         _configuration = configuration;
         _client = client;
         _queue = queue;
+        _queue.TillStateRealigner = RealignTillStateAsync;
 
         var personalFolder = personalFolderProvider ?? (() => Environment.GetFolderPath(Environment.SpecialFolder.Personal));
         _scuCacheFolder = string.IsNullOrEmpty(configuration.ServiceFolder)
@@ -429,34 +430,74 @@ public sealed class EpsonRTServerSCU : LegacySCU
 
         if (requestToken)
         {
-            var tokenResponse = await _client.CreateTokenAsync(tillId).ConfigureAwait(false);
-            var token = tokenResponse.GetAddInfo("token");
-            if (string.IsNullOrEmpty(token))
-            {
-                _logger.LogWarning("createToken for till {tillId} did not return a token in addInfo. The blockchain seed may be incorrect. Raw: {raw}", tillId, tokenResponse.RawResponse);
-            }
-            tillState.LastFingerPrint = token ?? string.Empty;
-            tillState.TokenInitialized = true;
-
-            // The token carries the authoritative Z number, next expected document number and daily amount for
-            // the current session (validated against firmware 6.01). Prefer it over the ambiguous fiscalInformation
-            // recNumber. LastDocNumber is stored as "last issued", so it is one less than the next expected number.
-            var parsedToken = EpsonToken.TryParse(token);
-            if (parsedToken != null)
-            {
-                tillState.LastZNumber = parsedToken.ZRepNumber;
-                tillState.LastDocNumber = parsedToken.NextDocNumber - 1;
-                tillState.CurrentDailyAmount = parsedToken.DailyAmountCents;
-                if (string.IsNullOrEmpty(tillState.RTServerSerialNumber))
-                {
-                    tillState.RTServerSerialNumber = parsedToken.SerialNumber;
-                }
-            }
+            await ReseedFromTokenAsync(tillState).ConfigureAwait(false);
         }
 
         _tillStates[queueId] = tillState;
         PersistState();
         return tillState;
+    }
+
+    /// <summary>
+    /// Requests a fresh token and adopts the RT Server's authoritative session counters (Z number, next
+    /// document number, daily amount) into <paramref name="tillState"/>. The token is the canonical CCDC seed,
+    /// so this both seeds a new till and realigns one whose session moved on the device. LastDocNumber is stored
+    /// as "last issued", one less than the token's next expected number.
+    /// </summary>
+    private async Task ReseedFromTokenAsync(TillState tillState)
+    {
+        var tokenResponse = await _client.CreateTokenAsync(tillState.TillId).ConfigureAwait(false);
+        var token = tokenResponse.GetAddInfo("token");
+        if (string.IsNullOrEmpty(token))
+        {
+            _logger.LogWarning("createToken for till {tillId} did not return a token in addInfo. The blockchain seed may be incorrect. Raw: {raw}", tillState.TillId, tokenResponse.RawResponse);
+        }
+        tillState.LastFingerPrint = token ?? string.Empty;
+        tillState.TokenInitialized = true;
+
+        var parsedToken = EpsonToken.TryParse(token);
+        if (parsedToken != null)
+        {
+            tillState.LastZNumber = parsedToken.ZRepNumber;
+            tillState.LastDocNumber = parsedToken.NextDocNumber - 1;
+            tillState.CurrentDailyAmount = parsedToken.DailyAmountCents;
+            if (string.IsNullOrEmpty(tillState.RTServerSerialNumber))
+            {
+                tillState.RTServerSerialNumber = parsedToken.SerialNumber;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Realigns the till to the RT Server's current session after the offline queue hit an out-of-sync
+    /// rejection (-21/-22/-25). Requests a fresh token (Metadata Guide §3.4.7) so subsequent documents build on
+    /// the live session. Takes the same per-SCU lock as receipt processing; invoked only from the background
+    /// drain — never the daily-closing path, which already holds that (non-reentrant) lock.
+    /// </summary>
+    private async Task RealignTillStateAsync(string tillId)
+    {
+        var scuLock = _scuLocks.GetOrAdd(_id, _ => new SemaphoreSlim(1, 1));
+        await scuLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            LoadStateFromDisk();
+            var matches = _tillStates.Values.Where(x => x.TillId == tillId).ToList();
+            if (matches.Count == 0)
+            {
+                _logger.LogWarning("Cannot realign till {tillId}: no cached state found; it will be re-seeded on the next receipt.", tillId);
+                return;
+            }
+            foreach (var tillState in matches)
+            {
+                await ReseedFromTokenAsync(tillState).ConfigureAwait(false);
+            }
+            PersistState();
+            _logger.LogWarning("Realigned till {tillId} to the RT Server's current session after an out-of-sync rejection in the offline queue.", tillId);
+        }
+        finally
+        {
+            scuLock.Release();
+        }
     }
 
     private async Task<RtServerResponse?> SafeGetServerTimeAsync()

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/IEpsonRTServerClient.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/IEpsonRTServerClient.cs
@@ -37,6 +37,12 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
         /// <summary>Reads the current-day totals for a till. fpserver.cgi / createReport / fiscalInformation.</summary>
         Task<RtServerResponse> GetFiscalInformationAsync(string tillId);
 
+        /// <summary>
+        /// Reads a stored fiscal receipt by its coordinates. fpserver.cgi / createReport / receipt.
+        /// The response addInfo carries the receipt's <c>hash</c> (the prefixed CCDC); returns -31 when absent.
+        /// </summary>
+        Task<RtServerResponse> GetReceiptAsync(string tillId, long zRepNumber, long recNumber, string date);
+
         /// <summary>Retrieves the RT Server public certificate key (instant lottery). fpserver.cgi / createReport / publicKey.</summary>
         Task<RtServerResponse> GetPublicKeyAsync();
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.csproj
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <Description>The fiskaltrust Middleware implementation of the Epson RT Server SCU for Italy.</Description>
-        <TargetFrameworks>netstandard2.0;net461;net6</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net461;net6.0</TargetFrameworks>
         <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -104,6 +105,82 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
                 {
                     Directory.Delete(serviceFolder, recursive: true);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task ProcessAllReceipts_Should_Park_Out_Of_Sync_Document_Instead_Of_Throwing()
+        {
+            var serviceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-oos-" + Guid.NewGuid());
+            var client = new Mock<IEpsonRTServerClient>();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .ReturnsAsync(new RtServerResponse { Success = false, Code = "-25", Status = "receipt number error" });
+            var id = Guid.NewGuid();
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false, ServiceFolder = serviceFolder };
+            var queue = new EpsonRTServerCommunicationQueue(id, client.Object, NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+            try
+            {
+                await queue.EnqueueDocument("FISK0001", "<createReceipt/>", 798, 15);
+
+                Func<Task> act = () => queue.ProcessAllReceipts("FISK0001");
+
+                using (new AssertionScope())
+                {
+                    // -25 (receipt number error) means the RT Server session moved on; replaying the same
+                    // document can never succeed, so the daily-closing drain must park it and continue, not throw.
+                    await act.Should().NotThrowAsync();
+                    var tillFolder = Path.Combine(serviceFolder, "epsonrtservercache", id.ToString(), "FISK0001");
+                    Directory.GetFiles(tillFolder, "*_createreceipt.xml").Should().BeEmpty();
+                    Directory.GetFiles(Path.Combine(tillFolder, "failed"), "*_createreceipt.xml").Should().HaveCount(1);
+                    // The daily-closing path runs under the SCU lock and must NOT realign (would deadlock).
+                    client.Verify(x => x.CreateTokenAsync(It.IsAny<string>()), Times.Never);
+                }
+            }
+            finally
+            {
+                queue.Dispose();
+                if (Directory.Exists(serviceFolder)) Directory.Delete(serviceFolder, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task Background_Drain_Should_Realign_Till_And_Park_On_Out_Of_Sync()
+        {
+            var serviceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-realign-" + Guid.NewGuid());
+            var client = new Mock<IEpsonRTServerClient>();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .ReturnsAsync(new RtServerResponse { Success = false, Code = "-25", Status = "receipt number error" });
+            var id = Guid.NewGuid();
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false, ServiceFolder = serviceFolder };
+            var queue = new EpsonRTServerCommunicationQueue(id, client.Object, NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+            var realigned = new List<string>();
+            queue.TillStateRealigner = tillId => { lock (realigned) { realigned.Add(tillId); } return Task.CompletedTask; };
+            try
+            {
+                await queue.EnqueueDocument("FISK0001", "<createReceipt/>", 798, 15);
+
+                // The background drain (started in the ctor) picks up the cached document.
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (DateTime.UtcNow < deadline)
+                {
+                    lock (realigned) { if (realigned.Count > 0) break; }
+                    await Task.Delay(50);
+                }
+
+                using (new AssertionScope())
+                {
+                    lock (realigned) { realigned.Should().ContainSingle().Which.Should().Be("FISK0001"); }
+                    var tillFolder = Path.Combine(serviceFolder, "epsonrtservercache", id.ToString(), "FISK0001");
+                    var deadline2 = DateTime.UtcNow.AddSeconds(2);
+                    while (DateTime.UtcNow < deadline2 && Directory.GetFiles(tillFolder, "*_createreceipt.xml").Length > 0) await Task.Delay(50);
+                    Directory.GetFiles(tillFolder, "*_createreceipt.xml").Should().BeEmpty();
+                    Directory.GetFiles(Path.Combine(tillFolder, "failed"), "*_createreceipt.xml").Should().HaveCount(1);
+                }
+            }
+            finally
+            {
+                queue.Dispose();
+                if (Directory.Exists(serviceFolder)) Directory.Delete(serviceFolder, recursive: true);
             }
         }
     }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerCommunicationQueueTests.cs
@@ -183,5 +183,83 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
                 if (Directory.Exists(serviceFolder)) Directory.Delete(serviceFolder, recursive: true);
             }
         }
+
+        private const string OutOfSyncReceiptXml =
+            "<createReceipt><receipt><hash fingerPrint=\"SEED\"/><printerFiscalReceipt>"
+            + "<fiscalInformation zRepNumber=\"0798\" recNumber=\"0015\" dateTime=\"20260723T095711\" />"
+            + "</printerFiscalReceipt></receipt><receiptSecurity><hash fingerPrint=\"CCDC0015\" /></receiptSecurity></createReceipt>";
+
+        [Fact]
+        public async Task Background_Drain_Should_Consume_Out_Of_Sync_Document_Already_Registered_On_Device()
+        {
+            var serviceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-consume-" + Guid.NewGuid());
+            var client = new Mock<IEpsonRTServerClient>();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .ReturnsAsync(new RtServerResponse { Success = false, Code = "-25", Status = "receipt number error" });
+            // Device confirms it already stored the receipt: the read returns the prefixed CCDC (dateTime+till+Z+rec+ccdc).
+            client.Setup(x => x.GetReceiptAsync("FISK0005", 798, 15, "20260723"))
+                .ReturnsAsync(new RtServerResponse { Success = true, Code = "0", Status = "OK",
+                    AddInfo = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { ["hash"] = "20260723T095711FISK000507980015CCDC0015" } });
+            var id = Guid.NewGuid();
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false, ServiceFolder = serviceFolder };
+            var queue = new EpsonRTServerCommunicationQueue(id, client.Object, NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+            queue.TillStateRealigner = _ => Task.CompletedTask;
+            try
+            {
+                await queue.EnqueueDocument("FISK0005", OutOfSyncReceiptXml, 798, 15);
+                var tillFolder = Path.Combine(serviceFolder, "epsonrtservercache", id.ToString(), "FISK0005");
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (DateTime.UtcNow < deadline && Directory.GetFiles(tillFolder, "*_createreceipt.xml").Length > 0) await Task.Delay(50);
+
+                using (new AssertionScope())
+                {
+                    // A document the device already registered is consumed (not parked): no takings loss, no double-send.
+                    await Task.Delay(100);
+                    Directory.GetFiles(tillFolder, "*_createreceipt.xml").Should().BeEmpty();
+                    var failed = Path.Combine(tillFolder, "failed");
+                    (Directory.Exists(failed) ? Directory.GetFiles(failed, "*_createreceipt.xml").Length : 0).Should().Be(0);
+                }
+            }
+            finally
+            {
+                queue.Dispose();
+                if (Directory.Exists(serviceFolder)) Directory.Delete(serviceFolder, recursive: true);
+            }
+        }
+
+        [Fact]
+        public async Task Background_Drain_Should_Park_Out_Of_Sync_Document_Not_Registered_On_Device()
+        {
+            var serviceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-notreg-" + Guid.NewGuid());
+            var client = new Mock<IEpsonRTServerClient>();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .ReturnsAsync(new RtServerResponse { Success = false, Code = "-25", Status = "receipt number error" });
+            // Device does not have it: the read-back throws -31 (file not found).
+            client.Setup(x => x.GetReceiptAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<long>(), It.IsAny<string>()))
+                .ThrowsAsync(new EpsonRTServerCommunicationException("file not found", -31));
+            var id = Guid.NewGuid();
+            var configuration = new EpsonRTServerConfiguration { ServerUrl = "https://localhost", SendReceiptsSync = false, ServiceFolder = serviceFolder };
+            var queue = new EpsonRTServerCommunicationQueue(id, client.Object, NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+            queue.TillStateRealigner = _ => Task.CompletedTask;
+            try
+            {
+                await queue.EnqueueDocument("FISK0005", OutOfSyncReceiptXml, 798, 15);
+                var tillFolder = Path.Combine(serviceFolder, "epsonrtservercache", id.ToString(), "FISK0005");
+                var failed = Path.Combine(tillFolder, "failed");
+                var deadline = DateTime.UtcNow.AddSeconds(5);
+                while (DateTime.UtcNow < deadline && !(Directory.Exists(failed) && Directory.GetFiles(failed, "*_createreceipt.xml").Length == 1)) await Task.Delay(50);
+
+                using (new AssertionScope())
+                {
+                    Directory.GetFiles(tillFolder, "*_createreceipt.xml").Should().BeEmpty();
+                    Directory.GetFiles(failed, "*_createreceipt.xml").Should().HaveCount(1);
+                }
+            }
+            finally
+            {
+                queue.Dispose();
+                if (Directory.Exists(serviceFolder)) Directory.Delete(serviceFolder, recursive: true);
+            }
+        }
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
@@ -378,5 +378,51 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
                 client.Verify(x => x.RebootWebServerAsync(), Times.Never);
             }
         }
+
+        [Fact]
+        public async Task Realign_Should_Reseed_Till_State_To_The_Current_Device_Session()
+        {
+            var sentDocuments = new List<string>();
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .Callback<string>(sentDocuments.Add)
+                .ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var configuration = new EpsonRTServerConfiguration
+            {
+                ServerUrl = "https://localhost",
+                SendReceiptsSync = true,
+                ServiceFolder = Path.Combine(Path.GetTempPath(), "epsonrtserver-tests", Guid.NewGuid().ToString())
+            };
+            Directory.CreateDirectory(configuration.ServiceFolder!);
+            var queue = new EpsonRTServerCommunicationQueue(Guid.NewGuid(), client.Object, NullLogger<EpsonRTServerCommunicationQueue>.Instance, configuration);
+            var scu = new EpsonRTServerSCU(Guid.NewGuid(), NullLogger<EpsonRTServerSCU>.Instance, configuration, client.Object, queue);
+            try
+            {
+                var queueId = Guid.NewGuid();
+                await scu.ProcessReceiptAsync(SaleProcessRequest(queueId)); // seeds session 0743
+
+                // The RT Server rolls to a new session (forced/daily closure); a fresh token now reports Z 0799.
+                var newSessionToken = "99SEA004010FISK0001" + "12345" + "20260723" + "0799" + "0001" + "000000000";
+                client.Setup(x => x.CreateTokenAsync("FISK0001")).ReturnsAsync(Ok(("token", newSessionToken)));
+
+                queue.TillStateRealigner.Should().NotBeNull("the SCU must wire the queue's realign hook");
+                await queue.TillStateRealigner!("FISK0001");
+
+                sentDocuments.Clear();
+                await scu.ProcessReceiptAsync(SaleProcessRequest(queueId));
+
+                using (new AssertionScope())
+                {
+                    sentDocuments.Should().ContainSingle();
+                    sentDocuments[0].Should().Contain("zRepNumber=\"0799\"");
+                    sentDocuments[0].Should().Contain("recNumber=\"0001\"");
+                }
+            }
+            finally
+            {
+                queue.Dispose();
+                if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
+            }
+        }
     }
 }


### PR DESCRIPTION
Tracks **fiskaltrust/market-it#631**.

## Problem
Offline (async cache + background drain), when the RT Server crosses a **Z-session boundary** while documents are buffered (forced/daily closure — Metadata Guide §3.4.7/§3.4.5), the SCU kept minting documents for the **closed** session and the drain replayed them → device returned **`-25` "NUMERO DOCUMENTO ERRATO"** on every one. Online is unaffected. (Pre-#720/#722 this surfaced as `-51`; same root cause.)

**Root cause:** the async path never refreshed the token after a session shift — the inline token-reseed recovery only runs on a synchronous response, which async signing never produces.

## Fix
**Part 1 — realign.** On `-21/-22/-25` the drain realigns the till to the device's current session via a fresh token (SCU-owned hook), so subsequent documents build correctly. Realign fires only from the background loop → no lock re-entrancy; daily-closing parks-and-continues instead of throwing.

**Part 2 — consume-if-already-registered.** Live device reads proved these out-of-sync receipts are **already registered** on the device (accepted with error in log — readable by number, returning the prefixed CCDC), *not* rejected. So resending would **double-register**. The drain now reads the doc back by its original coordinates (`createReport/receipt`) and, if the device's `hash` suffix-matches the cached CCDC, **consumes** the redundant local copy + warns; any read failure (`-31`/`-35`/mismatch) **parks** for manual review (never consumed on doubt, never resent).

No renumber/resend, no cache-format change, no new model.

## Tests
`dotnet test` green (**79/79**); builds `netstandard2.0;net461;net6`. New: realign+park, realign reseed, consume-if-registered, park-if-not-registered, daily-closing park-and-continue.

## Known limitation / follow-up (domain)
A device-registered doc flagged `NUMERO DOCUMENTO ERRATO` (with `rtFileRejected=6`): whether it counts as valid AdE takings or is rejected at transmission is a device/AdE-layer question, separate from the SCU send logic. This PR ensures the SCU stops mishandling these and realigns numbering so they stop occurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)