### PR TITLE
fix(queue): don't throw null on V1 error-state responses (market-it #635)

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Queue/SignProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Queue/SignProcessor.cs
@@ -228,7 +228,9 @@ namespace fiskaltrust.Middleware.Queue
                     var errorMessage = "An error occurred during receipt processing, resulting in ftState = 0xEEEE_EEEE.";
                     await CreateActionJournalAsync(errorMessage, $"{receiptResponse.ftState:X}", queueItem.ftQueueItemId).ConfigureAwait(false);
 
-                    if (!data.IsV2())
+                    // V1 rethrows only a genuine processor exception; when the country processor returned an error
+                    // response (ftState EEEE) without throwing, surface it like V2 rather than `throw null` (market-it #635).
+                    if (!data.IsV2() && exception != null)
                     {
                         throw exception;
                     }

--- a/queue/test/fiskaltrust.Middleware.Queue.AcceptanceTest/SignProcessorUnitTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Queue.AcceptanceTest/SignProcessorUnitTests.cs
@@ -7,6 +7,7 @@ using fiskaltrust.Middleware.Contracts.Interfaces;
 using fiskaltrust.Middleware.Contracts.Models;
 using fiskaltrust.Middleware.Contracts.Repositories;
 using fiskaltrust.storage.V0;
+using fiskaltrust.Middleware.Queue.Extensions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -187,6 +188,67 @@ namespace fiskaltrust.Middleware.Queue.AcceptanceTest
 
             var response = await sut.ProcessAsync(request);
             response.Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData(0x0000_0000_0000_0001L, false)] // V1: no 0x2000 version nibble
+        [InlineData(0x0000_2000_0000_0001L, true)]  // V2: 0x2000 version nibble
+        public async Task ProcessAsync_WhenCountryProcessorReturnsErrorStateWithoutThrowing_ReturnsResponseAndDoesNotThrow(long ftReceiptCase, bool isV2)
+        {
+            // Regression for market-it #635: every IT SCU (TRS, EpsonRTServer, CustomRTServer) handles its own
+            // failure and RETURNS an error response (ftState EEEE) without throwing. Pre-fix the V1 case threw a
+            // NullReferenceException ("throw null") at SignProcessor.InternalSign; the V2 case already returned the
+            // response. Both must return the error response and keep the host up.
+            var logger = new Mock<ILogger<SignProcessor>>(MockBehavior.Loose);
+            var receiptJournalRepository = new Mock<IMiddlewareReceiptJournalRepository>(MockBehavior.Strict);
+            var actionJournalRepository = new Mock<IMiddlewareActionJournalRepository>(MockBehavior.Strict);
+            actionJournalRepository.Setup(x => x.InsertAsync(It.IsAny<ftActionJournal>())).Returns(Task.CompletedTask);
+            var cryptoHelper = new Mock<ICryptoHelper>(MockBehavior.Strict);
+            cryptoHelper.Setup(x => x.GenerateBase64Hash(It.IsAny<string>())).Returns("MyHash");
+
+            var queueId = Guid.NewGuid();
+            var cashboxId = Guid.NewGuid();
+            var queue = new ftQueue { ftCashBoxId = cashboxId, ftQueueId = queueId, ftCurrentRow = 1 };
+            var configuration = new MiddlewareConfiguration { QueueId = queueId, CashBoxId = cashboxId, ProcessingVersion = "test" };
+
+            var configurationRepository = new Mock<IConfigurationRepository>(MockBehavior.Strict);
+            configurationRepository.Setup(x => x.GetQueueAsync(queueId)).ReturnsAsync(queue);
+            configurationRepository.Setup(x => x.InsertOrUpdateQueueAsync(queue)).Returns(Task.CompletedTask);
+
+            var request = new ReceiptRequest
+            {
+                ftCashBoxID = cashboxId.ToString(),
+                ftQueueID = queueId.ToString(),
+                cbTerminalID = "MyTerminalId",
+                ftReceiptCase = ftReceiptCase
+            };
+            request.IsV2().Should().Be(isV2);
+
+            var errorResponse = new ReceiptResponse
+            {
+                ftCashBoxID = cashboxId.ToString(),
+                ftQueueID = queueId.ToString(),
+                cbTerminalID = request.cbTerminalID,
+                ftState = 0xEEEE_EEEE,
+                ftSignatures = Array.Empty<SignaturItem>()
+            };
+
+            var marketSpecificSignProcessor = new Mock<IMarketSpecificSignProcessor>(MockBehavior.Strict);
+            marketSpecificSignProcessor.Setup(x => x.FirstTaskAsync()).Returns(Task.CompletedTask);
+            marketSpecificSignProcessor.Setup(x => x.ProcessAsync(request, queue, It.IsAny<ftQueueItem>())).ReturnsAsync((errorResponse, new List<ftActionJournal>()));
+            marketSpecificSignProcessor.Setup(x => x.FinalTaskAsync(queue, It.IsAny<ftQueueItem>(), request, actionJournalRepository.Object, It.IsAny<IMiddlewareQueueItemRepository>(), receiptJournalRepository.Object)).Returns(Task.CompletedTask);
+
+            var queueItemRepository = new Mock<IMiddlewareQueueItemRepository>(MockBehavior.Strict);
+            queueItemRepository.Setup(x => x.InsertOrUpdateAsync(It.IsAny<ftQueueItem>())).Returns(Task.CompletedTask);
+
+            var sut = new SignProcessor(logger.Object, configurationRepository.Object, queueItemRepository.Object, receiptJournalRepository.Object, actionJournalRepository.Object, cryptoHelper.Object, marketSpecificSignProcessor.Object, configuration);
+
+            ReceiptResponse response = null;
+            Func<Task> act = async () => response = await sut.ProcessAsync(request);
+
+            await act.Should().NotThrowAsync();
+            response.Should().NotBeNull();
+            response.ftState.Should().Match(x => (x & 0xFFFF_FFFF) == 0xEEEE_EEEE);
         }
 
         private static (ReceiptRequest request, MiddlewareConfiguration config, Mock<IMiddlewareQueueItemRepository> repo) SetupTestEnvironment(long ftReceiptCase, long ftState)


### PR DESCRIPTION
## Problem
`Queue.SignProcessor.InternalSign` rethrows the local `exception` for V1 receipts when `receiptResponse.IsError()`. But `exception` is only assigned when the country processor **throws**. When a country SCU handles its own failure and **returns** an error response (`ftState … EEEE`) without throwing — which every IT SCU does (TRS, EpsonRTServer, CustomRTServer via `SetReceiptResponseError`/`CreateResponse`) — `exception` stays `null`, so `throw exception;` raises a `NullReferenceException` that propagates unhandled → **HTTP 500**, crashing the request.

V2 receipts already return the error response gracefully; only V1 (`ftReceiptCase` without the `0x2000` version nibble) hit the crash.

## Scope
Confirmed **cross-SCU** (not EpsonRTServer-specific, not cross-market): reproduced live on the **TRS** SCU under the legacy QueueIT stack — the identical `SignProcessor.cs` NRE / 500 for a V1 receipt, while the same receipt sent as V2 returned `201` with the error surfaced as a signature. The defect is in the shared legacy `Queue.SignProcessor` (IT/DE/FR/ME/AT); the `Localization.v2` stack is unaffected.

## Fix (minimal)
Guard the rethrow on `exception != null`:
- V1 + genuine processor exception → rethrow (unchanged).
- V1 + handled error response (no exception) → return the response, like V2.
- V2 → unchanged.

## Tests
Added a market-agnostic Theory in `SignProcessorUnitTests` covering V1 and V2 error-state-without-throw. RED first (V1 threw the NRE), GREEN after the guard. Full class 6/6 on net6.0 + net461; the existing genuine-exception rethrow test still passes.

Refs: fiskaltrust/market-it#635
