### PR TITLE
fix(epsonrtserver): map VAT from VATRate when ftChargeItemCase is 0x0 (market-it #634)

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -418,8 +418,21 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 case 0x3: vatId = 1; return true;  // 22%
                 case 0x4: vatId = 4; return true;  // 5%
                 case 0x7: vatId = 13; return true; // 0%
+                // No VAT nibble (0x0): honour the item's stated VATRate so receipts that omit ftChargeItemCase
+                // are not rejected; unrecognised rates stay strict (fall through to throw).
+                case 0x0: return TryGetVatIdFromVatRate(chargeItem.VATRate, out vatId);
                 default: vatId = -1; return false;
             }
+        }
+
+        private static bool TryGetVatIdFromVatRate(decimal vatRate, out int vatId)
+        {
+            if (vatRate == 22m) { vatId = 1; return true; }
+            if (vatRate == 10m) { vatId = 2; return true; }
+            if (vatRate == 5m) { vatId = 4; return true; }
+            if (vatRate == 4m) { vatId = 3; return true; }
+            vatId = -1;
+            return false;
         }
 
         // Resolves the vatID for an emitted item line. Tips and multi-use vouchers are outside the taxable

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
@@ -2,9 +2,12 @@ using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
@@ -184,6 +187,90 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
             voidResult.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentType)).Subject.Data.Should().Be("VOID");
             voidResult.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTReferenceZNumber));
             voidResult.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTReferenceDocumentNumber));
+        }
+
+        // #634/PR #727: a POS receipt whose charge items omit the VAT nibble (ftChargeItemCase & 0xF == 0x0)
+        // but carry a numeric VATRate must be mapped to the correct department index (22->1, 10->2, 4->3, 5->4)
+        // and accepted by the device cleanly (no anomaly warning). Device-confirmed: the RT Server's own VAT table
+        // (fiscalInformation/vatCount) reports vatId 1=22%, 2=10%, 3=4%, 4=5%, matching this mapping.
+        [Fact]
+        public async Task ProcessPosReceipt_VatFallbackFromVatRate_ShouldBeAcceptedCleanly()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            new ScuBootstrapper
+            {
+                Id = _queueId,
+                Configuration = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(_config))!
+            }.ConfigureServices(services);
+            services.RemoveAll<IEpsonRTServerClient>();
+            services.AddSingleton<IEpsonRTServerClient>(sp => new CapturingClient(
+                new EpsonRTServerClient(sp.GetRequiredService<EpsonRTServerConfiguration>(), sp.GetRequiredService<ILogger<EpsonRTServerClient>>())));
+            var provider = services.BuildServiceProvider();
+            var capturing = (CapturingClient) provider.GetRequiredService<IEpsonRTServerClient>();
+            var itsscd = provider.GetRequiredService<IITSSCD>();
+
+            var request = new ReceiptRequest
+            {
+                ftReceiptCase = 0x4954_2000_0000_0001,
+                cbReceiptMoment = DateTime.Now,
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbChargeItems = new[]
+                {
+                    VatRateFallbackItem(12.20m, 22m, "IVA22"),
+                    VatRateFallbackItem(11.00m, 10m, "IVA10"),
+                    VatRateFallbackItem(10.40m, 4m, "IVA04"),
+                    VatRateFallbackItem(10.50m, 5m, "IVA05")
+                },
+                cbPayItems = new[] { new PayItem { Amount = 44.10m, Quantity = 1, Description = "CONTANTE", ftPayItemCase = 0x4954_2000_0000_0000 } }
+            };
+
+            var result = await itsscd.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = request, ReceiptResponse = NewReceiptResponse });
+
+            using var scope = new AssertionScope();
+            AssertDocumentSignatures(result);
+            result.ReceiptResponse.ftSignatures.Should().NotContain(x => x.Caption == "rt-server-receipt-warning");
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentType)).Subject.Data.Should().Be("POSRECEIPT");
+            // The #727 fallback must map each item's VATRate to the correct department index.
+            capturing.CreateReceiptCalls.Last().Request.Should()
+                .Contain("vatID=\"1\"").And.Contain("vatID=\"2\"").And.Contain("vatID=\"3\"").And.Contain("vatID=\"4\"");
+        }
+
+        private static ChargeItem VatRateFallbackItem(decimal amount, decimal vatRate, string description) => new()
+        {
+            Amount = amount,
+            Quantity = 1,
+            Description = description,
+            VATRate = vatRate,
+            ftChargeItemCase = 0x4954_2000_0000_0000 // VAT nibble 0x0 -> exercises the VATRate fallback (PR #727)
+        };
+
+        private sealed class CapturingClient : IEpsonRTServerClient
+        {
+            private readonly IEpsonRTServerClient _inner;
+            public readonly List<(string Request, RtServerResponse Response)> CreateReceiptCalls = new();
+
+            public CapturingClient(IEpsonRTServerClient inner) => _inner = inner;
+
+            public async Task<RtServerResponse> CreateReceiptAsync(string createReceiptXml)
+            {
+                var response = await _inner.CreateReceiptAsync(createReceiptXml);
+                CreateReceiptCalls.Add((createReceiptXml, response));
+                return response;
+            }
+
+            public Task<RtServerResponse> CreateTokenAsync(string tillId) => _inner.CreateTokenAsync(tillId);
+            public Task<RtServerResponse> CreateTillsAsync(string userId, string password, IEnumerable<string> tillMap, IEnumerable<string> tillsToAdd) => _inner.CreateTillsAsync(userId, password, tillMap, tillsToAdd);
+            public Task<RtServerResponse> GetTillMapAsync() => _inner.GetTillMapAsync();
+            public Task<RtServerResponse> CreateDailyClosureAsync(string tillId, int closureType) => _inner.CreateDailyClosureAsync(tillId, closureType);
+            public Task<RtServerResponse> GetServerInfoAsync() => _inner.GetServerInfoAsync();
+            public Task<RtServerResponse> GetServerTimeAsync() => _inner.GetServerTimeAsync();
+            public Task<RtServerResponse> GetFirmwareVersionAsync() => _inner.GetFirmwareVersionAsync();
+            public Task<RtServerResponse> GetFiscalInformationAsync(string tillId) => _inner.GetFiscalInformationAsync(tillId);
+            public Task<RtServerResponse> GetReceiptAsync(string tillId, long zRepNumber, long recNumber, string date) => _inner.GetReceiptAsync(tillId, zRepNumber, recNumber, date);
+            public Task<RtServerResponse> GetPublicKeyAsync() => _inner.GetPublicKeyAsync();
+            public Task<RtServerResponse> PrintServerZReportAsync() => _inner.PrintServerZReportAsync();
+            public Task<RtServerResponse> RebootWebServerAsync() => _inner.RebootWebServerAsync();
         }
 
         [Fact]

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
@@ -346,6 +346,23 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         }
 
         [Theory]
+        [InlineData(22, 1)]
+        [InlineData(10, 2)]
+        [InlineData(5, 4)]
+        [InlineData(4, 3)]
+        public void GetVatId_Should_Fall_Back_To_VatRate_When_Case_Nibble_Unspecified(double vatRate, int expectedVatId)
+        {
+            EpsonRTServerMapping.GetVatId(new ChargeItem { ftChargeItemCase = 0x0, VATRate = (decimal) vatRate }).Should().Be(expectedVatId);
+        }
+
+        [Fact]
+        public void GetVatId_Should_Throw_For_Unspecified_Case_Without_Recognised_VatRate()
+        {
+            var act = () => EpsonRTServerMapping.GetVatId(new ChargeItem { ftChargeItemCase = 0x0, VATRate = 0m });
+            act.Should().Throw<NotSupportedException>().WithMessage("*no VAT-index mapping*");
+        }
+
+        [Theory]
         [InlineData(0x00, 0)] // cash
         [InlineData(0x03, 1)] // cheque
         [InlineData(0x04, 2)] // electronic


### PR DESCRIPTION
## Problem
A receipt whose charge items carry **no `ftChargeItemCase`** (low nibble `0x0`) but a valid `VATRate` is rejected by the Epson RT Server SCU with `NotSupportedException: The ftChargeItemCase 0x0 has no VAT-index mapping`, failing the whole receipt. Reproduced with a plain cash sale (`VATRate: 22`, no `ftChargeItemCase`). (Originally reported as a "copy receipt" crash; the RT Server has no copy command — the real trigger is the missing case nibble.)

## Fix (minimal)
`TryGetVatId`: add a `case 0x0` that maps the item's explicit `VATRate` to the RT Server VAT index for the standard Italian rates (22→1, 10→2, 5→4, 4→3). `default` is unchanged, so genuinely unknown goods (unrecognised nibble, or `0x0` with a non-standard/zero rate) still throw — the "wrong rate is worse than failing" invariant is preserved. Consistent with the sibling CustomRTServer, which already trusts `VATRate` when set.

## Tests
Added a Theory asserting the `0x0`+`VATRate` fallback for each standard rate, and a Fact asserting `0x0` with an unrecognised rate still throws `NotSupportedException`. RED first (fallback threw), GREEN after. Full EpsonRTServer unit suite 84/84.

Refs: fiskaltrust/market-it#634 (the follow-on host 500 is fixed separately in the #635 PR).
