### PR TITLE
fix(epsonrtserver): clamp non-cash payment tender to receipt total (market-it #636)

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -119,16 +119,18 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
 
             AppendChargeItemLines(sb, receiptRequest, docType);
 
-            foreach (var payItem in receiptRequest.cbPayItems ?? Array.Empty<PayItem>())
+            var payItems = receiptRequest.cbPayItems ?? Array.Empty<PayItem>();
+            var paymentAmounts = GetEffectivePaymentAmounts(payItems, recAmount);
+            for (var i = 0; i < payItems.Length; i++)
             {
-                var paymentType = GetEpsonPaymentType(payItem);
+                var paymentType = GetEpsonPaymentType(payItems[i]);
                 sb.Append("<printRecTotal");
-                sb.Append($" description=\"{Escape(payItem.Description)}\"");
-                sb.Append($" payment=\"{FormatAmount(Math.Abs(payItem.Amount))}\"");
+                sb.Append($" description=\"{Escape(payItems[i].Description)}\"");
+                sb.Append($" payment=\"{FormatAmount(paymentAmounts[i])}\"");
                 sb.Append($" paymentType=\"{paymentType.PaymentType}\" index=\"{paymentType.Index}\" />");
             }
 
-            if ((receiptRequest.cbPayItems?.Length ?? 0) == 0)
+            if (payItems.Length == 0)
             {
                 // No pay items: fall back to a single cash payment covering the receipt total. The cash bucket in
                 // fiscalInformation is aligned by GetPaymentTotals so the amounts stay consistent (error -38).
@@ -353,17 +355,18 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 return totals;
             }
 
-            foreach (var payItem in payItems)
+            var amounts = GetEffectivePaymentAmounts(payItems, recAmount);
+            for (var i = 0; i < payItems.Length; i++)
             {
-                var amount = Math.Abs(payItem.Amount);
-                switch (GetEpsonPaymentType(payItem).PaymentType)
+                var amount = amounts[i];
+                switch (GetEpsonPaymentType(payItems[i]).PaymentType)
                 {
                     case 0: totals.Cash += amount; break;
                     case 1: totals.Check += amount; break;
                     case 2: totals.EPay += amount; break;
                     case 3:
                         totals.Ticket += amount;
-                        totals.TicketNum += Math.Max(1, (int) Math.Abs(payItem.Quantity));
+                        totals.TicketNum += Math.Max(1, (int) Math.Abs(payItems[i].Quantity));
                         break;
                     case 4: totals.NoPayServices += amount; break;
                     case 5: totals.NoPayGoods += amount; break;
@@ -375,6 +378,30 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 }
             }
             return totals;
+        }
+
+        // Only cash (paymentType 0) may be tendered above the amount still owed (the surplus becomes changeAmount).
+        // Every other method is clamped to the outstanding balance: the device forbids change on non-cash payments
+        // (Metadata Guide 3.4.2/3.8.1) and rejects an over-tendered non-cash printRecTotal with -39.
+        private static decimal[] GetEffectivePaymentAmounts(PayItem[] payItems, decimal recAmount)
+        {
+            var amounts = new decimal[payItems.Length];
+            var nonCashOutstanding = recAmount;
+            for (var i = 0; i < payItems.Length; i++)
+            {
+                var tendered = Math.Abs(payItems[i].Amount);
+                if (GetEpsonPaymentType(payItems[i]).PaymentType == 0)
+                {
+                    amounts[i] = tendered;
+                }
+                else
+                {
+                    var capped = Math.Min(tendered, Math.Max(0m, nonCashOutstanding));
+                    amounts[i] = capped;
+                    nonCashOutstanding -= capped;
+                }
+            }
+            return amounts;
         }
 
         private static long ToCents(decimal value) => (long) Math.Round(value * 100, MidpointRounding.AwayFromZero);

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
@@ -187,6 +187,26 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
         }
 
         [Fact]
+        public async Task ProcessPosReceipt_Lottery_CardOverpayment_ShouldBeAcceptedCleanly()
+        {
+            var request = new ReceiptRequest
+            {
+                ftReceiptCase = 0x4954_2000_0000_0001,
+                cbReceiptMoment = DateTime.Now,
+                cbReceiptReference = Guid.NewGuid().ToString(),
+                cbChargeItems = new[] { new ChargeItem { Amount = 3.30m, Quantity = 1, Description = "COFFEE", VATRate = 22m, ftChargeItemCase = 0x4954_2000_0000_0003 } },
+                cbPayItems = new[] { new PayItem { Amount = 3.50m, Quantity = 1, Description = "CARTA", ftPayItemCase = 0x4954_2000_0000_0004 } },
+                ftReceiptCaseData = "{\"servizi_lotteriadegliscontrini_gov_it\":{\"codicelotteria\":\"ABCD1234\"}}"
+            };
+            var result = await GetSUT().ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = request, ReceiptResponse = NewReceiptResponse });
+            using var scope = new AssertionScope();
+            AssertDocumentSignatures(result);
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTLotteryID)).Subject.Data.Should().Be("ABCD1234");
+            // #636: card tender clamped to the total -> device accepts with no payment warning (-39).
+            result.ReceiptResponse.ftSignatures.Should().NotContain(x => x.Caption == "rt-server-receipt-warning");
+        }
+
+        [Fact]
         public async Task ProcessZeroReceipt_ShouldReport_DeviceState()
         {
             var request = new ReceiptRequest

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
@@ -353,5 +353,29 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         {
             EpsonRTServerMapping.GetEpsonPaymentType(new PayItem { ftPayItemCase = payItemCase }).PaymentType.Should().Be(expectedPaymentType);
         }
+
+        [Fact]
+        public void BuildFiscalDocument_NonCashOverpayment_Should_Clamp_To_Total_And_Emit_No_Change()
+        {
+            var request = new ReceiptRequest
+            {
+                ftReceiptCase = 0x0001,
+                cbReceiptMoment = new DateTime(2026, 7, 2, 12, 0, 0),
+                cbChargeItems = new[] { new ChargeItem { Amount = 3.30m, Quantity = 1, Description = "Coffee", VATRate = 22m, ftChargeItemCase = 0x3 } },
+                cbPayItems = new[] { new PayItem { Amount = 3.50m, Quantity = 1, Description = "CARTA", ftPayItemCase = 0x04 } },
+                ftReceiptCaseData = "{\"servizi_lotteriadegliscontrini_gov_it\":{\"codicelotteria\":\"ABCD1234\"}}"
+            };
+
+            var doc = EpsonRTServerMapping.BuildFiscalDocument(request, NewTillState(), 0);
+
+            using (new AssertionScope())
+            {
+                doc.CreateReceiptXml.Should().Contain("<printRecTotal description=\"CARTA\" payment=\"3.30\" paymentType=\"2\"");
+                doc.CreateReceiptXml.Should().Contain("ePayAmount=\"3.30\"");
+                doc.CreateReceiptXml.Should().Contain("changeAmount=\"0.00\"");
+                doc.CreateReceiptXml.Should().Contain("paidAmount=\"3.30\"");
+                doc.CreateReceiptXml.Should().Contain("recAmount=\"3.30\"");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem
A receipt whose non-cash payment (card/electronic) is tendered **above the goods total** is registered by the Epson RT Server with warning **-39** ("receipt payments error", error list 42-47). The SCU emitted the raw tendered amount on the `printRecTotal` line and produced a `changeAmount` on the electronic bucket. The device forbids change on electronic payments (Metadata Guide 3.4.2 / 3.8.1), and lottery receipts are electronic-only (3.6.9), so any non-cash overpayment trips -39.

## Fix (minimal)
Add one pure helper, `GetEffectivePaymentAmounts`, that clamps every non-cash payment to the outstanding balance (cash may still be tendered above the total → `changeAmount`). It is used by **both** the `printRecTotal` lines and the `fiscalInformation` buckets, so they can't diverge (the device recomputes totals from the lines — clamping only the buckets would still fail). Cash semantics are unchanged.

Example (Coffee 3.30 @22%, card 3.50): before → `payment="3.50"`, `ePayAmount="3.50"`, `changeAmount="0.20"` → -39. After → `payment="3.30"`, `ePayAmount="3.30"`, `changeAmount="0.00"`.

## Tests
Added `BuildFiscalDocument_NonCashOverpayment_Should_Clamp_To_Total_And_Emit_No_Change` (card overpay + lottery). RED first, GREEN after. Existing cash-overpayment test (cash still produces change) stays green. Full EpsonRTServer unit suite 80/80.

## Follow-up
Needs a confirmation run on the Fiberland device (register Coffee 3.30 + card 3.50 + lottery) to verify -39 no longer appears.

Refs: fiskaltrust/market-it#636
