### PR TITLE
fix(it): handle unreferenced refund/void — ND header + refRefundVoidType (market-it #633)

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueIT/Factories/SignaturItemFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueIT/Factories/SignaturItemFactory.cs
@@ -106,7 +106,9 @@ namespace fiskaltrust.Middleware.Localization.QueueIT.Factories
                 stringBuilder.AppendLine("emesso per RESO MERCE");
                 if (string.IsNullOrEmpty(referenceZNumberString) || string.IsNullOrEmpty(referenceDocNumberString))
                 {
-                    stringBuilder.AppendLine($"ND del {DateTime.Parse(referenceDateTimeString).ToString("dd-MM-yyyy")}");
+                    stringBuilder.AppendLine(string.IsNullOrEmpty(referenceDateTimeString)
+                        ? "ND"
+                        : $"ND del {DateTime.Parse(referenceDateTimeString).ToString("dd-MM-yyyy")}");
                 }
                 else
                 {
@@ -126,7 +128,9 @@ namespace fiskaltrust.Middleware.Localization.QueueIT.Factories
                 stringBuilder.AppendLine("emesso per ANNULLAMENTO");
                 if (string.IsNullOrEmpty(referenceZNumberString) || string.IsNullOrEmpty(referenceDocNumberString))
                 {
-                    stringBuilder.AppendLine($"ND del {DateTime.Parse(referenceDateTimeString).ToString("dd-MM-yyyy")}");
+                    stringBuilder.AppendLine(string.IsNullOrEmpty(referenceDateTimeString)
+                        ? "ND"
+                        : $"ND del {DateTime.Parse(referenceDateTimeString).ToString("dd-MM-yyyy")}");
                 }
                 else
                 {

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueIT.UnitTest/SignaturItemFactoryTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueIT.UnitTest/SignaturItemFactoryTests.cs
@@ -44,5 +44,30 @@ namespace fiskaltrust.Middleware.Localization.QueueIT.UnitTest
             var footer = signatures.Single(x => x.Caption == "[www.fiskaltrust.it]");
             footer.Data.Should().NotContain("Codice Lotteria");
         }
+
+        [Fact]
+        public void CreatePOSReceiptFormatSignatures_UnreferencedRefund_RendersND_WithoutThrowing()
+        {
+            var data = new POSReceiptSignatureData
+            {
+                RTSerialNumber = "96SRT001239",
+                RTZNumber = 8,
+                RTDocNumber = 3,
+                RTDocMoment = new DateTime(2026, 6, 29, 10, 9, 0),
+                RTDocType = "REFUND"
+            };
+            var response = new ReceiptResponse
+            {
+                ftCashBoxIdentification = "00040005",
+                ftSignatures = POSReceiptSignatureData.CreateDocumentoCommercialeSignatures(data).ToArray()
+            };
+
+            var header = SignaturItemFactory.CreatePOSReceiptFormatSignatures(response)
+                .Single(x => x.Caption == "DOCUMENTO COMMERCIALE").Data;
+
+            header.Should().Contain("emesso per RESO MERCE");
+            header.Should().Contain("ND");
+            header.Should().NotContain("del ");
+        }
     }
 }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -107,14 +107,20 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             {
                 sb.Append("<beginFiscalReceipt />");
             }
-            else
+            else if (referenceDocMoment.HasValue)
             {
                 sb.Append($"<beginFiscalReceipt docType=\"{docType}\"");
                 if (referenceZNumber.HasValue) sb.Append($" refZRepNum=\"{referenceZNumber.Value:D4}\"");
                 if (referenceDocNumber.HasValue) sb.Append($" refRecNum=\"{referenceDocNumber.Value:D4}\"");
-                if (referenceDocMoment.HasValue) sb.Append($" refDateTime=\"{referenceDocMoment.Value:yyyyMMddTHHmmss}\"");
+                sb.Append($" refDateTime=\"{referenceDocMoment.Value:yyyyMMddTHHmmss}\"");
                 if (!string.IsNullOrEmpty(referenceTillId)) sb.Append($" refTillID=\"{referenceTillId}\"");
                 sb.Append(" />");
+            }
+            else
+            {
+                // Unreferenced refund/void: no traceable original (Metadata Guide 3.7.2 "ND"). Emit the ND type
+                // rather than zeroed reference numbers, which the device logs as a wrong reference (-35).
+                sb.Append($"<beginFiscalReceipt docType=\"{docType}\" refRefundVoidType=\"ND\" />");
             }
 
             AppendChargeItemLines(sb, receiptRequest, docType);

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -118,9 +118,11 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             }
             else
             {
-                // Unreferenced refund/void: no traceable original (Metadata Guide 3.7.2 "ND"). Emit the ND type
-                // rather than zeroed reference numbers, which the device logs as a wrong reference (-35).
-                sb.Append($"<beginFiscalReceipt docType=\"{docType}\" refRefundVoidType=\"ND\" />");
+                // Unreferenced refund/void: no traceable original (Metadata Guide 3.7.2 "ND"). Emit the ND type with
+                // the receipt's own moment as refDateTime: zeroed reference numbers are logged as a wrong reference
+                // (-35) and an omitted/zeroed time as a reference-document error (-45); ND with a real datetime is
+                // accepted cleanly (device-confirmed on Fiberland).
+                sb.Append($"<beginFiscalReceipt docType=\"{docType}\" refDateTime=\"{moment:yyyyMMddTHHmmss}\" refRefundVoidType=\"ND\" />");
             }
 
             AppendChargeItemLines(sb, receiptRequest, docType);

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/EpsonRTServerTests.cs
@@ -187,6 +187,19 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
         }
 
         [Fact]
+        public async Task ProcessPosReceipt_UnreferencedRefund_ShouldBeAcceptedCleanly()
+        {
+            var request = Sale(-2.00m, "RESO SENZA RIF");
+            request.ftReceiptCase = 0x4954_2000_0100_0001; // refund flag, no cbPreviousReceiptReference -> ND
+            var result = await GetSUT().ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = request, ReceiptResponse = NewReceiptResponse });
+            using var scope = new AssertionScope();
+            AssertDocumentSignatures(result);
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentType)).Subject.Data.Should().Be("REFUND");
+            // #633: an ND refund carrying a real refDateTime is accepted with no reference warning (-35/-45).
+            result.ReceiptResponse.ftSignatures.Should().NotContain(x => x.Caption == "rt-server-receipt-warning");
+        }
+
+        [Fact]
         public async Task ProcessZeroReceipt_ShouldReport_DeviceState()
         {
             var request = new ReceiptRequest

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
@@ -104,6 +104,18 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
             }
         }
 
+        [Fact]
+        public void BuildFiscalDocument_UnreferencedRefund_Should_Emit_ND_RefundVoidType()
+        {
+            var doc = EpsonRTServerMapping.BuildFiscalDocument(SaleRequest(), NewTillState(), 1, 0, 0, null, "FISK0001");
+
+            using (new AssertionScope())
+            {
+                doc.CreateReceiptXml.Should().Contain("<beginFiscalReceipt docType=\"1\" refRefundVoidType=\"ND\" />");
+                doc.CreateReceiptXml.Should().NotContain("refZRepNum=");
+            }
+        }
+
         [Theory]
         [InlineData(DateTimeKind.Utc)]
         [InlineData(DateTimeKind.Unspecified)]

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerMappingTests.cs
@@ -92,27 +92,15 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         }
 
         [Fact]
-        public void BuildFiscalDocument_UnreferencedRefund_Should_Omit_RefDateTime()
+        public void BuildFiscalDocument_UnreferencedRefund_Should_Emit_ND_With_RefDateTime()
         {
             var doc = EpsonRTServerMapping.BuildFiscalDocument(SaleRequest(), NewTillState(), 1, 0, 0, null, "FISK0001");
 
             using (new AssertionScope())
             {
-                doc.CreateReceiptXml.Should().Contain("<beginFiscalReceipt docType=\"1\"");
-                doc.CreateReceiptXml.Should().NotContain("refDateTime=");
-                doc.ReferenceDocMoment.Should().BeNull();
-            }
-        }
-
-        [Fact]
-        public void BuildFiscalDocument_UnreferencedRefund_Should_Emit_ND_RefundVoidType()
-        {
-            var doc = EpsonRTServerMapping.BuildFiscalDocument(SaleRequest(), NewTillState(), 1, 0, 0, null, "FISK0001");
-
-            using (new AssertionScope())
-            {
-                doc.CreateReceiptXml.Should().Contain("<beginFiscalReceipt docType=\"1\" refRefundVoidType=\"ND\" />");
+                doc.CreateReceiptXml.Should().Contain("<beginFiscalReceipt docType=\"1\" refDateTime=\"20260702T140000\" refRefundVoidType=\"ND\" />");
                 doc.CreateReceiptXml.Should().NotContain("refZRepNum=");
+                doc.ReferenceDocMoment.Should().BeNull();
             }
         }
 


### PR DESCRIPTION
Two independent parts of the unreferenced-refund flow.

## Part 1 — QueueIT crash (the reported bug)
`SignaturItemFactory.CreateHeader` did `DateTime.Parse(referenceDateTimeString)` on the REFUND/VOID "ND" branch. For an **unreferenced** refund/void the RT reference date is absent (the SCU omits it), so `referenceDateTimeString` is null → `ArgumentNullException`, failing the receipt at the queue **even though the device registered the document**. Fix: render `"ND"` (no date) when the reference date is empty. Shared across all IT SCUs; additive guard (every currently-working path has a non-null date and is unchanged).

## Part 2 — device `-35` (refRefundVoidType="ND")
For the unreferenced case the SCU emitted zeroed `refZRepNum="0000"`/`refRecNum="0000"`, which the RT Server logs as *"refund/void with wrong date reference"* (**-35**). Per Metadata Guide §3.7.2, an untraceable refund/void is type **ND** (for POS/VR/ND only `docType` + `refRefundVoidType` apply, not reference numbers). The unreferenced `beginFiscalReceipt` now emits `refRefundVoidType="ND"` instead of the zeroed references. Referenced refunds/voids are unchanged.

## Tests
- QueueIT: unreferenced refund renders `ND` without throwing (RED→GREEN). 16/16.
- EpsonRTServer: unreferenced refund emits `refRefundVoidType="ND"` and no zeroed refs (RED→GREEN); referenced-refund test unchanged. 80/80.

## Follow-up
Part 2 changes device XML — confirm on the Fiberland device that an unreferenced refund now closes without `-35` (and whether the device additionally wants a `refDateTime` for ND; omitted here to avoid inventing a reference date).

Refs: fiskaltrust/market-it#633
