### PR TITLE
fix(epsonrtserver): drain/daily-closing deadlock + refund read-back date (#725)

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerCommunicationQueue.cs
@@ -327,7 +327,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             return (
                 ParseLong("zRepNumber=\"(\\d+)\""),
                 ParseLong("recNumber=\"(\\d+)\""),
-                ParseString("dateTime=\"(\\d{8})T"),
+                // Leading space so the pattern matches fiscalInformation's dateTime, not a refund/void refDateTime.
+                ParseString(" dateTime=\"(\\d{8})T"),
                 ParseString("receiptSecurity><hash fingerPrint=\"([^\"]+)\""));
         }
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -36,6 +36,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
     // The SCU is registered as scoped, so multiple instances can process receipts for the same SCU id
     // concurrently. Serialize per SCU id to protect the CCDC chain counters and the state-cache file.
     private static readonly ConcurrentDictionary<Guid, SemaphoreSlim> _scuLocks = new();
+    private static readonly TimeSpan RealignLockTimeout = TimeSpan.FromSeconds(30);
 
     private string StateCacheFilePath => Path.Combine(_scuCacheFolder, $"{_id}_epsonrtserver_statecache.json");
 
@@ -477,7 +478,14 @@ public sealed class EpsonRTServerSCU : LegacySCU
     private async Task RealignTillStateAsync(string tillId)
     {
         var scuLock = _scuLocks.GetOrAdd(_id, _ => new SemaphoreSlim(1, 1));
-        await scuLock.WaitAsync().ConfigureAwait(false);
+        // Bounded wait: a concurrent daily closing holds this lock while ProcessAllReceipts busy-waits for the
+        // background drain to finish; blocking here would deadlock the two. On timeout, skip — the drain retries
+        // the realignment on its next cycle (realignedTills is scoped to a single cycle).
+        if (!await scuLock.WaitAsync(RealignLockTimeout).ConfigureAwait(false))
+        {
+            _logger.LogWarning("Could not acquire the SCU lock to realign till {tillId} within {timeout}; skipping (the offline drain will retry).", tillId, RealignLockTimeout);
+            return;
+        }
         try
         {
             LoadStateFromDisk();


### PR DESCRIPTION
Addresses the review in #725 (both findings confirmed against the code).

## 🔴 Deadlock: background drain vs daily closing
The timer-based background drain (`ProcessReceiptsInBackground` → `DrainPendingAsync(canRealign: true)`) sets `_processingReceipts = true`, then on an out-of-sync document calls `RealignTillStateAsync`, which did `scuLock.WaitAsync()` with no timeout. If a daily closing runs concurrently, it holds `scuLock` inside `ProcessReceiptAsync` and busy-waits (`while (_processingReceipts)`) in `ProcessAllReceipts`. The drain blocks on the lock → `_processingReceipts` never clears → the two wait on each other forever. The existing `canRealign: false` guard only covers the daily-closing's *own* drain, not the independent background drain.

Fix (reviewer's preferred option): `RealignTillStateAsync` waits for the lock with a timeout (`RealignLockTimeout`, 30s) and, on timeout, logs and returns without realigning. The document is then parked and the realignment is retried on the next drain cycle (`realignedTills` is scoped to a single cycle). Breaking the wait lets the drain finish and clears `_processingReceipts`, so the daily closing proceeds.

## 🟡 Refund/void read-back matched refDateTime
`ParseReceiptCoordinates` used `dateTime="(\d{8})T`, which also matches the `refDateTime="…"` that `beginFiscalReceipt` emits first for referenced refund/void documents — so the "consume if already registered" read-back queried the *referenced* document's date instead of the receipt's own issuance date. Fail-safe (doc parked, never wrongly consumed) but the consume path was broken for cross-day refunds/voids. Fix: match `" dateTime="` (leading space); `refDateTime` is preceded by `f`, so it no longer matches.

## Tests
Existing EpsonRTServer unit suite green (79/79). The deadlock fix is a defensive bounded-wait (a deterministic deadlock unit test would be timing-dependent/flaky); the regex change is a one-character disambiguation and the sale path (`" dateTime="`) still matches.

Closes #725
