### PR TITLE
chore(epsonrtserver): sandbox deployment trigger

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/README.md
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/README.md
@@ -243,3 +243,6 @@ the background queue after the receipt already returned `StateOk`, so the warnin
   `recTotTicketNum` on `printRecTotal` are not emitted yet.
 - Reprint and non-fiscal print receipt cases are not handled (printer-oriented; not part of the RT Server
   model).
+
+<!-- Sandbox deployment trigger for scu-it/EpsonRTServer (no functional change). -->
+


### PR DESCRIPTION
Dummy PR to enable a **sandbox deployment** of the `scu-it` EpsonRTServer SCU via `/deploy` (the deployment cannot be triggered from the GitHub UI directly).

Branched off the latest `main`, which already contains all of the recent EpsonRTServer fixes:

- #726 — Queue SignProcessor null-throw (market-it #635)
- #727 — VAT-from-VATRate fallback (market-it #634)
- #728 — non-cash tender clamping (market-it #636)
- #729 — unreferenced (ND) refund with refDateTime (market-it #633)
- #730 — drain/daily-closing deadlock + refund read-back regex (#725)

The only change here is a no-op marker comment inside the EpsonRTServer package path, so Nerdbank.GitVersioning produces a fresh package version. **Not intended to be merged** — it exists so the deploy pipeline has a PR to run against.

To deploy, comment: `/deploy scu-it EpsonRTServer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
