### PR TITLE
Add ftQueuePL + ftSignaturCreationUnitPL storage support for market PL

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/StorageBaseInitConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/StorageBaseInitConfiguration.cs
@@ -17,6 +17,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public List<ftQueueGR> QueuesGR { get; set; }
         public List<ftQueueIT> QueuesIT { get; set; }
         public List<ftQueueME> QueuesME { get; set; }
+        public List<ftQueuePL> QueuesPL { get; set; }
         public List<ftSignaturCreationUnitAT> SignaturCreationUnitsAT { get; set; }
         public List<ftSignaturCreationUnitBE> SignaturCreationUnitsBE { get; set; }
         public List<ftSignaturCreationUnitDE> SignaturCreationUnitsDE { get; set; }
@@ -25,6 +26,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public List<ftSignaturCreationUnitGR> SignaturCreationUnitsGR { get; set; }
         public List<ftSignaturCreationUnitIT> SignaturCreationUnitsIT { get; set; }
         public List<ftSignaturCreationUnitME> SignaturCreationUnitsME { get; set; }
+        public List<ftSignaturCreationUnitPL> SignaturCreationUnitsPL { get; set; }
         public MasterDataConfiguration MasterData { get; set; }
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.v2/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.v2/JournalProcessor.cs
@@ -162,6 +162,7 @@ public class JournalProcessor
             QueueGRList = await configurationRepository.GetQueueGRListAsync().ConfigureAwait(false),
             QueueITList = await configurationRepository.GetQueueITListAsync().ConfigureAwait(false),
             QueueMEList = await configurationRepository.GetQueueMEListAsync().ConfigureAwait(false),
+            QueuePLList = await configurationRepository.GetQueuePLListAsync().ConfigureAwait(false),
             QueuePTList = GetConfigurationFromDictionary<ftQueuePT>("init_ftQueuePT"),
             SignaturCreationUnitATList = await configurationRepository.GetSignaturCreationUnitATListAsync().ConfigureAwait(false),
             SignaturCreationUnitBEList = await configurationRepository.GetSignaturCreationUnitBEListAsync().ConfigureAwait(false),
@@ -171,6 +172,7 @@ public class JournalProcessor
             SignaturCreationUnitGRList = await configurationRepository.GetSignaturCreationUnitGRListAsync().ConfigureAwait(false),
             SignaturCreationUnitITList = await configurationRepository.GetSignaturCreationUnitITListAsync().ConfigureAwait(false),
             SignaturCreationUnitMEList = await configurationRepository.GetSignaturCreationUnitMEListAsync().ConfigureAwait(false),
+            SignaturCreationUnitPLList = await configurationRepository.GetSignaturCreationUnitPLListAsync().ConfigureAwait(false),
             SignaturCreationUnitPTList = GetConfigurationFromDictionary<ftSignaturCreationUnitPT>("init_ftSignaturCreationUnitPT"),
         };
     }

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/DatabaseMigrator.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/DatabaseMigrator.cs
@@ -40,6 +40,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage
                 new Migration_005_JournalES(_tableServiceClient, queueConfiguration),
                 new Migration_006_GR(_tableServiceClient, queueConfiguration),
                 new Migration_007_BE(_tableServiceClient, queueConfiguration),
+                new Migration_008_PL(_tableServiceClient, queueConfiguration),
             };
         }
 

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Migrations/Migration_008_PL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Migrations/Migration_008_PL.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Migrations
+{
+    public class Migration_008_PL : IAzureTableStorageMigration
+    {
+        private readonly TableServiceClient _tableServiceClient;
+        private readonly QueueConfiguration _queueConfiguration;
+
+        public Migration_008_PL(TableServiceClient tableServiceClient, QueueConfiguration queueConfiguration)
+        {
+            _tableServiceClient = tableServiceClient;
+            _queueConfiguration = queueConfiguration;
+        }
+
+        public int Version => 8;
+
+        public async Task ExecuteAsync()
+        {
+            await _tableServiceClient.CreateTableIfNotExistsAsync(GetTableName(AzureTableStorageQueuePLRepository.TABLE_NAME));
+            await _tableServiceClient.CreateTableIfNotExistsAsync(GetTableName(AzureTableStorageSignaturCreationUnitPLRepository.TABLE_NAME));
+        }
+
+        private string GetTableName(string entityName) => $"x{_queueConfiguration.QueueId.ToString().Replace("-", "")}{entityName}";
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageConfigurationRepository.cs
@@ -20,6 +20,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         private readonly AzureTableStorageQueueGRRepository _queueGRRepository;
         private readonly AzureTableStorageQueueITRepository _queueITRepository;
         private readonly AzureTableStorageQueueMERepository _queueMERepository;
+        private readonly AzureTableStorageQueuePLRepository _queuePLRepository;
         private readonly AzureTableStorageSignaturCreationUnitATRepository _signaturCreationUnitATRepository;
         private readonly AzureTableStorageSignaturCreationUnitBERepository _signaturCreationUnitBERepository;
         private readonly AzureTableStorageSignaturCreationUnitDERepository _signaturCreationUnitDERepository;
@@ -28,6 +29,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         private readonly AzureTableStorageSignaturCreationUnitGRRepository _signaturCreationUnitGRRepository;
         private readonly AzureTableStorageSignaturCreationUnitITRepository _signaturCreationUnitITRepository;
         private readonly AzureTableStorageSignaturCreationUnitMERepository _signaturCreationUnitMERepository;
+        private readonly AzureTableStorageSignaturCreationUnitPLRepository _signaturCreationUnitPLRepository;
 
         public AzureTableStorageConfigurationRepository() { }
 
@@ -44,6 +46,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
             _queueGRRepository = new AzureTableStorageQueueGRRepository(queueConfig, tableServiceClient);
             _queueITRepository = new AzureTableStorageQueueITRepository(queueConfig, tableServiceClient);
             _queueMERepository = new AzureTableStorageQueueMERepository(queueConfig, tableServiceClient);
+            _queuePLRepository = new AzureTableStorageQueuePLRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitATRepository = new AzureTableStorageSignaturCreationUnitATRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitBERepository = new AzureTableStorageSignaturCreationUnitBERepository(queueConfig, tableServiceClient);
             _signaturCreationUnitDERepository = new AzureTableStorageSignaturCreationUnitDERepository(queueConfig, tableServiceClient);
@@ -52,6 +55,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
             _signaturCreationUnitGRRepository = new AzureTableStorageSignaturCreationUnitGRRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitITRepository = new AzureTableStorageSignaturCreationUnitITRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitMERepository = new AzureTableStorageSignaturCreationUnitMERepository(queueConfig, tableServiceClient);
+            _signaturCreationUnitPLRepository = new AzureTableStorageSignaturCreationUnitPLRepository(queueConfig, tableServiceClient);
         }
 
         public async Task<ftCashBox> GetCashBoxAsync(Guid cashBoxId) => await _cashBoxRepository.GetAsync(cashBoxId).ConfigureAwait(false);
@@ -98,6 +102,10 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         public async Task<IEnumerable<ftQueueME>> GetQueueMEListAsync() => await _queueMERepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateQueueMEAsync(ftQueueME queue) => await _queueMERepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
 
+        public async Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => await _queuePLRepository.GetAsync(queuePLId).ConfigureAwait(false);
+        public async Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => await _queuePLRepository.GetAsync().ConfigureAwait(false);
+        public async Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => await _queuePLRepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -122,6 +130,10 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         public async Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid id) => await _signaturCreationUnitGRRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => await _signaturCreationUnitGRRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => await _signaturCreationUnitGRRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
+
+        public async Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid id) => await _signaturCreationUnitPLRepository.GetAsync(id).ConfigureAwait(false);
+        public async Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => await _signaturCreationUnitPLRepository.GetAsync().ConfigureAwait(false);
+        public async Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => await _signaturCreationUnitPLRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
 
         public async Task<ftSignaturCreationUnitIT> GetSignaturCreationUnitITAsync(Guid id) => await _signaturCreationUnitITRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitIT>> GetSignaturCreationUnitITListAsync() => await _signaturCreationUnitITRepository.GetAsync().ConfigureAwait(false);

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageQueuePLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageQueuePLRepository.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration
+{
+    public class AzureTableStorageQueuePLRepository : BaseAzureTableStorageRepository<Guid, AzureTableStorageFtQueuePL, ftQueuePL>
+    {
+        public AzureTableStorageQueuePLRepository(QueueConfiguration queueConfig, TableServiceClient tableServiceClient)
+            : base(queueConfig, tableServiceClient, TABLE_NAME) { }
+
+        public const string TABLE_NAME = "QueuePL";
+
+        protected override void EntityUpdated(ftQueuePL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftQueuePL entity) => entity.ftQueuePLId;
+
+        public async Task InsertOrUpdateAsync(ftQueuePL storageEntity)
+        {
+            EntityUpdated(storageEntity);
+            var entity = MapToAzureEntity(storageEntity);
+            await _tableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+        }
+
+        protected override AzureTableStorageFtQueuePL MapToAzureEntity(ftQueuePL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new AzureTableStorageFtQueuePL
+            {
+                PartitionKey = src.ftQueuePLId.ToString(),
+                RowKey = src.ftQueuePLId.ToString(),
+                ftQueuePLId = src.ftQueuePLId,
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                CashBoxIdentification = src.CashBoxIdentification,
+                SSCDFailCount = src.SSCDFailCount,
+                SSCDFailMoment = src.SSCDFailMoment?.ToUniversalTime(),
+                SSCDFailQueueItemId = src.SSCDFailQueueItemId,
+                UsedFailedCount = src.UsedFailedCount,
+                UsedFailedMomentMin = src.UsedFailedMomentMin?.ToUniversalTime(),
+                UsedFailedMomentMax = src.UsedFailedMomentMax?.ToUniversalTime(),
+                UsedFailedQueueItemId = src.UsedFailedQueueItemId,
+                TimeStamp = src.TimeStamp,
+            };
+        }
+
+        protected override ftQueuePL MapToStorageEntity(AzureTableStorageFtQueuePL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new ftQueuePL
+            {
+                ftQueuePLId = src.ftQueuePLId,
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                CashBoxIdentification = src.CashBoxIdentification,
+                SSCDFailCount = src.SSCDFailCount,
+                SSCDFailMoment = src.SSCDFailMoment,
+                SSCDFailQueueItemId = src.SSCDFailQueueItemId,
+                UsedFailedCount = src.UsedFailedCount,
+                UsedFailedMomentMin = src.UsedFailedMomentMin,
+                UsedFailedMomentMax = src.UsedFailedMomentMax,
+                UsedFailedQueueItemId = src.UsedFailedQueueItemId,
+                TimeStamp = src.TimeStamp,
+            };
+        }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageSignaturCreationUnitPLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageSignaturCreationUnitPLRepository.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration
+{
+    public class AzureTableStorageSignaturCreationUnitPLRepository : BaseAzureTableStorageRepository<Guid, AzureTableStorageFtSignaturCreationUnitPL, ftSignaturCreationUnitPL>
+    {
+        public AzureTableStorageSignaturCreationUnitPLRepository(QueueConfiguration queueConfig, TableServiceClient tableServiceClient)
+            : base(queueConfig, tableServiceClient, TABLE_NAME) { }
+
+        public const string TABLE_NAME = "SignaturCreationUnitPL";
+
+        protected override void EntityUpdated(ftSignaturCreationUnitPL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftSignaturCreationUnitPL entity) => entity.ftSignaturCreationUnitPLId;
+
+        public async Task InsertOrUpdateAsync(ftSignaturCreationUnitPL storageEntity)
+        {
+            EntityUpdated(storageEntity);
+            var entity = MapToAzureEntity(storageEntity);
+            await _tableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+        }
+
+        protected override AzureTableStorageFtSignaturCreationUnitPL MapToAzureEntity(ftSignaturCreationUnitPL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new AzureTableStorageFtSignaturCreationUnitPL
+            {
+                PartitionKey = src.ftSignaturCreationUnitPLId.ToString(),
+                RowKey = src.ftSignaturCreationUnitPLId.ToString(),
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                Url = src.Url,
+                InfoJson = src.InfoJson,
+                TimeStamp = src.TimeStamp
+            };
+        }
+
+        protected override ftSignaturCreationUnitPL MapToStorageEntity(AzureTableStorageFtSignaturCreationUnitPL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new ftSignaturCreationUnitPL
+            {
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                Url = src.Url,
+                InfoJson = src.InfoJson,
+                TimeStamp = src.TimeStamp
+            };
+        }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtQueuePL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtQueuePL.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration
+{
+    public class AzureTableStorageFtQueuePL : BaseTableEntity
+    {
+        public Guid ftQueuePLId { get; set; }
+        public Guid? ftSignaturCreationUnitPLId { get; set; }
+        public string CashBoxIdentification { get; set; }
+
+        public int SSCDFailCount { get; set; }
+        public DateTime? SSCDFailMoment { get; set; }
+        public Guid? SSCDFailQueueItemId { get; set; }
+
+        public int UsedFailedCount { get; set; }
+        public DateTime? UsedFailedMomentMin { get; set; }
+        public DateTime? UsedFailedMomentMax { get; set; }
+        public Guid? UsedFailedQueueItemId { get; set; }
+
+        public long TimeStamp { get; set; }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtSignaturCreationUnitPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtSignaturCreationUnitPL.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration
+{
+    public class AzureTableStorageFtSignaturCreationUnitPL : BaseTableEntity
+    {
+        public Guid ftSignaturCreationUnitPLId { get; set; }
+        public string Url { get; set; }
+        public string InfoJson { get; set; }
+        public long TimeStamp { get; set; }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
@@ -31,6 +31,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 QueuesGR = ParseParameter<List<ftQueueGR>>(configuration, "init_ftQueueGR") ?? new List<ftQueueGR>(),
                 QueuesIT = ParseParameter<List<ftQueueIT>>(configuration, "init_ftQueueIT") ?? new List<ftQueueIT>(),
                 QueuesME = ParseParameter<List<ftQueueME>>(configuration, "init_ftQueueME") ?? new List<ftQueueME>(),
+                QueuesPL = ParseParameter<List<ftQueuePL>>(configuration, "init_ftQueuePL") ?? new List<ftQueuePL>(),
                 CashBox = ParseParameter<ftCashBox>(configuration, "init_ftCashBox"),
                 SignaturCreationUnitsAT = ParseParameter<List<ftSignaturCreationUnitAT>>(configuration, "init_ftSignaturCreationUnitAT") ?? new List<ftSignaturCreationUnitAT>(),
                 SignaturCreationUnitsBE = ParseParameter<List<ftSignaturCreationUnitBE>>(configuration, "init_ftSignaturCreationUnitBE") ?? new List<ftSignaturCreationUnitBE>(),
@@ -40,6 +41,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 SignaturCreationUnitsGR = ParseParameter<List<ftSignaturCreationUnitGR>>(configuration, "init_ftSignaturCreationUnitGR") ?? new List<ftSignaturCreationUnitGR>(),
                 SignaturCreationUnitsME = ParseParameter<List<ftSignaturCreationUnitME>>(configuration, "init_ftSignaturCreationUnitME") ?? new List<ftSignaturCreationUnitME>(),
                 SignaturCreationUnitsIT = ParseParameter<List<ftSignaturCreationUnitIT>>(configuration, "init_ftSignaturCreationUnitIT") ?? new List<ftSignaturCreationUnitIT>(),
+                SignaturCreationUnitsPL = ParseParameter<List<ftSignaturCreationUnitPL>>(configuration, "init_ftSignaturCreationUnitPL") ?? new List<ftSignaturCreationUnitPL>(),
                 MasterData = ParseParameter<MasterDataConfiguration>(configuration, "init_masterData")
             };
         }
@@ -146,6 +148,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 InitQueueGRAsync(config.QueuesGR, configurationRepository),
                 InitQueueMEAsync(config.QueuesME, configurationRepository),
                 InitQueueITAsync(config.QueuesIT, configurationRepository),
+                InitQueuePLAsync(config.QueuesPL, configurationRepository),
                 InitSignaturCreationUnitATAsync(config.SignaturCreationUnitsAT, configurationRepository),
                 InitSignaturCreationUnitBEAsync(config.SignaturCreationUnitsBE, configurationRepository),
                 InitSignaturCreationUnitFRAsync(config.SignaturCreationUnitsFR, configurationRepository),
@@ -154,6 +157,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 InitSignaturCreationUnitGRAsync(config.SignaturCreationUnitsGR, configurationRepository),
                 InitSignaturCreationUnitITAsync(config.SignaturCreationUnitsIT, configurationRepository, enforceUpdateUserDefinedConfig),
                 InitSignaturCreationUnitMEAsync(config.SignaturCreationUnitsME, configurationRepository),
+                InitSignaturCreationUnitPLAsync(config.SignaturCreationUnitsPL, configurationRepository),
             };
             await Task.WhenAll(tasks);
         }
@@ -339,6 +343,17 @@ namespace fiskaltrust.Middleware.Storage.Base
                 }
             }
         }
+        private async Task InitQueuePLAsync(List<ftQueuePL> queuesPL, IConfigurationRepository configurationRepository)
+        {
+            foreach (var item in queuesPL)
+            {
+                var dbQueuePl = await configurationRepository.GetQueuePLAsync(item.ftQueuePLId).ConfigureAwait(false);
+                if (dbQueuePl == null)
+                {
+                    await configurationRepository.InsertOrUpdateQueuePLAsync(item).ConfigureAwait(false);
+                }
+            }
+        }
         private async Task InitQueueMEAsync(List<ftQueueME> queuesME, IConfigurationRepository configurationRepository)
         {
             foreach (var item in queuesME)
@@ -516,6 +531,18 @@ namespace fiskaltrust.Middleware.Storage.Base
                 if (scu == null)
                 {
                     await configurationRepository.InsertOrUpdateSignaturCreationUnitGRAsync(item).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task InitSignaturCreationUnitPLAsync(List<ftSignaturCreationUnitPL> signaturCreationUnitsPL, IConfigurationRepository configurationRepository)
+        {
+            foreach (var item in signaturCreationUnitsPL)
+            {
+                var scu = await configurationRepository.GetSignaturCreationUnitPLAsync(item.ftSignaturCreationUnitPLId).ConfigureAwait(false);
+                if (scu == null)
+                {
+                    await configurationRepository.InsertOrUpdateSignaturCreationUnitPLAsync(item).ConfigureAwait(false);
                 }
             }
         }

--- a/queue/src/fiskaltrust.Middleware.Storage.EF/Repositories/EfConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.EF/Repositories/EfConfigurationRepository.cs
@@ -81,6 +81,10 @@ namespace fiskaltrust.Middleware.Storage.EF.Repositories
         public Task<IEnumerable<ftQueueGR>> GetQueueGRListAsync() => throw new NotImplementedException();
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queueGR) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid id) => throw new NotImplementedException();
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queuePL) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -113,6 +117,10 @@ namespace fiskaltrust.Middleware.Storage.EF.Repositories
         public Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid id) => throw new NotImplementedException();
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid id) => throw new NotImplementedException();
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemoryQueuePLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemoryQueuePLRepository.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.InMemory.Repositories.Configuration
+{
+    public class InMemoryQueuePLRepository : AbstractInMemoryRepository<Guid, ftQueuePL>
+    {
+        public InMemoryQueuePLRepository() : base(new List<ftQueuePL>()) { }
+
+        public InMemoryQueuePLRepository(IEnumerable<ftQueuePL> data) : base(data) { }
+
+        protected override void EntityUpdated(ftQueuePL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftQueuePL entity) => entity.ftQueuePLId;
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemorySignaturCreationUnitPLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemorySignaturCreationUnitPLRepository.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.InMemory.Repositories.Configuration
+{
+    public class InMemorySignaturCreationUnitPLRepository : AbstractInMemoryRepository<Guid, ftSignaturCreationUnitPL>
+    {
+        public InMemorySignaturCreationUnitPLRepository() : base(new List<ftSignaturCreationUnitPL>()) { }
+
+        public InMemorySignaturCreationUnitPLRepository(IEnumerable<ftSignaturCreationUnitPL> data) : base(data) { }
+
+        protected override void EntityUpdated(ftSignaturCreationUnitPL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftSignaturCreationUnitPL entity) => entity.ftSignaturCreationUnitPLId;
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
@@ -74,6 +74,8 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _queueFRRepository = new InMemoryQueueFRRepository(queuesFR);
             _queueITRepository = new InMemoryQueueITRepository(queuesIT);
             _queueMERepository = new InMemoryQueueMERepository(queuesME);
+            _queuePLRepository = new InMemoryQueuePLRepository();
+            _signaturCreationUnitPLRepository = new InMemorySignaturCreationUnitPLRepository();
             _signaturCreationUnitATRepository = new InMemorySignaturCreationUnitATRepository(signatureCreateUnitsAT);
             _signaturCreationUnitDERepository = new InMemorySignaturCreationUnitDERepository(signatureCreateUnitsDE);
             _signaturCreationUnitFRRepository = new InMemorySignaturCreationUnitFRRepository(signatureCreateUnitsFR);

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
@@ -19,6 +19,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         private readonly AbstractInMemoryRepository<Guid, ftQueueME> _queueMERepository;
         private readonly AbstractInMemoryRepository<Guid, ftQueueBE> _queueBERepository;
         private readonly AbstractInMemoryRepository<Guid, ftQueueGR> _queueGRRepository;
+        private readonly AbstractInMemoryRepository<Guid, ftQueuePL> _queuePLRepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitAT> _signaturCreationUnitATRepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitBE> _signaturCreationUnitBERepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitGR> _signaturCreationUnitGRRepository;
@@ -27,6 +28,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         private readonly InMemorySignaturCreationUnitFRRepository _signaturCreationUnitFRRepository;
         private readonly InMemorySignaturCreationUnitITRepository _signaturCreationUnitITRepository;
         private readonly InMemorySignaturCreationUnitMERepository _signaturCreationUnitMERepository;
+        private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitPL> _signaturCreationUnitPLRepository;
 
         public InMemoryConfigurationRepository()
         {
@@ -40,6 +42,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _queueMERepository = new InMemoryQueueMERepository();
             _queueBERepository = new InMemoryQueueBERepository();
             _queueGRRepository = new InMemoryQueueGRRepository();
+            _queuePLRepository = new InMemoryQueuePLRepository();
             _signaturCreationUnitATRepository = new InMemorySignaturCreationUnitATRepository();
             _signaturCreationUnitBERepository = new InMemorySignaturCreationUnitBERepository();
             _signaturCreationUnitGRRepository = new InMemorySignaturCreationUnitGRRepository();
@@ -48,6 +51,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _signaturCreationUnitFRRepository = new InMemorySignaturCreationUnitFRRepository();
             _signaturCreationUnitITRepository = new InMemorySignaturCreationUnitITRepository();
             _signaturCreationUnitMERepository = new InMemorySignaturCreationUnitMERepository();
+            _signaturCreationUnitPLRepository = new InMemorySignaturCreationUnitPLRepository();
         }
 
         public InMemoryConfigurationRepository(IEnumerable<ftCashBox> cashBoxes = null,
@@ -117,6 +121,10 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         public Task<ftQueueES> GetQueueESAsync(Guid queueESId) => _queueESRepository.GetAsync(queueESId);
         public Task InsertOrUpdateQueueESAsync(ftQueueES queue) => _queueESRepository.InsertOrUpdateAsync(queue);
 
+        public async Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => await _queuePLRepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
+        public async Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => await _queuePLRepository.GetAsync().ConfigureAwait(false);
+        public async Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => await _queuePLRepository.GetAsync(queuePLId).ConfigureAwait(false);
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -148,6 +156,10 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         public async Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => await _signaturCreationUnitGRRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => await _signaturCreationUnitGRRepository.GetAsync().ConfigureAwait(false);
         public async Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid signaturCreationUnitGRId) => await _signaturCreationUnitGRRepository.GetAsync(signaturCreationUnitGRId).ConfigureAwait(false);
+
+        public async Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => await _signaturCreationUnitPLRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
+        public async Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => await _signaturCreationUnitPLRepository.GetAsync().ConfigureAwait(false);
+        public async Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => await _signaturCreationUnitPLRepository.GetAsync(signaturCreationUnitPLId).ConfigureAwait(false);
 
         public Task<IEnumerable<ftSignaturCreationUnitES>> GetSignaturCreationUnitESListAsync() => _signaturCreationUnitESRepository.GetAsync();
         public async Task InsertOrUpdateSignaturCreationUnitESAsync(ftSignaturCreationUnitES scu) => await _signaturCreationUnitESRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);

--- a/queue/src/fiskaltrust.Middleware.Storage.MySQL/Repositories/MySQLConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.MySQL/Repositories/MySQLConfigurationRepository.cs
@@ -97,6 +97,12 @@ namespace fiskaltrust.Middleware.Storage.MySQL.Repositories
 
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queue) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
 
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
@@ -142,6 +148,12 @@ namespace fiskaltrust.Middleware.Storage.MySQL.Repositories
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
 
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/queue/src/fiskaltrust.Middleware.Storage.SQLite/Repositories/SQLiteConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.SQLite/Repositories/SQLiteConfigurationRepository.cs
@@ -97,6 +97,12 @@ namespace fiskaltrust.Middleware.Storage.SQLite.Repositories
 
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queue) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
 
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
@@ -142,6 +148,12 @@ namespace fiskaltrust.Middleware.Storage.SQLite.Repositories
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
 
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/storage/src/fiskaltrust.storage/Models/ftQueuePL.cs
+++ b/storage/src/fiskaltrust.storage/Models/ftQueuePL.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace fiskaltrust.storage.V0
+{
+    public class ftQueuePL
+    {
+        public Guid ftQueuePLId { get; set; }
+
+        public Guid? ftSignaturCreationUnitPLId { get; set; }
+
+        public string CashBoxIdentification { get; set; }
+
+        public int SSCDFailCount { get; set; }
+
+        public DateTime? SSCDFailMoment { get; set; }
+
+        public Guid? SSCDFailQueueItemId { get; set; }
+
+        public int UsedFailedCount { get; set; }
+
+        public DateTime? UsedFailedMomentMin { get; set; }
+
+        public DateTime? UsedFailedMomentMax { get; set; }
+
+        public Guid? UsedFailedQueueItemId { get; set; }
+
+        public long TimeStamp { get; set; }
+    }
+}

--- a/storage/src/fiskaltrust.storage/Models/ftSignaturCreationUnitPL.cs
+++ b/storage/src/fiskaltrust.storage/Models/ftSignaturCreationUnitPL.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace fiskaltrust.storage.V0
+{
+    public class ftSignaturCreationUnitPL
+    {
+        public Guid ftSignaturCreationUnitPLId { get; set; }
+
+        public long TimeStamp { get; set; }
+
+        public string Url { get; set; }
+
+        public string InfoJson { get; set; }
+    }
+}

--- a/storage/src/fiskaltrust.storage/Repositories/IConfigurationRepository.cs
+++ b/storage/src/fiskaltrust.storage/Repositories/IConfigurationRepository.cs
@@ -14,6 +14,7 @@ namespace fiskaltrust.storage.V0
         Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu);
         Task InsertOrUpdateSignaturCreationUnitITAsync(ftSignaturCreationUnitIT scu);
         Task InsertOrUpdateSignaturCreationUnitMEAsync(ftSignaturCreationUnitME scu);
+        Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu);
         Task InsertOrUpdateQueueATAsync(ftQueueAT queue);
         Task InsertOrUpdateQueueBEAsync(ftQueueBE queue);
         Task InsertOrUpdateQueueDEAsync(ftQueueDE queue);
@@ -23,5 +24,6 @@ namespace fiskaltrust.storage.V0
         Task InsertOrUpdateQueueGRAsync(ftQueueGR queue);
         Task InsertOrUpdateQueueITAsync(ftQueueIT queue);
         Task InsertOrUpdateQueueMEAsync(ftQueueME queue);
+        Task InsertOrUpdateQueuePLAsync(ftQueuePL queue);
     }
 }

--- a/storage/src/fiskaltrust.storage/Repositories/IReadOnlyConfigurationRepository.cs
+++ b/storage/src/fiskaltrust.storage/Repositories/IReadOnlyConfigurationRepository.cs
@@ -33,6 +33,9 @@ namespace fiskaltrust.storage.V0
         Task<IEnumerable<ftSignaturCreationUnitME>> GetSignaturCreationUnitMEListAsync();
         Task<ftSignaturCreationUnitME> GetSignaturCreationUnitMEAsync(Guid signaturCreationUnitDEId);
 
+        Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync();
+        Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId);
+
         Task<IEnumerable<ftQueue>> GetQueueListAsync();
         Task<ftQueue> GetQueueAsync(Guid queueId);
 
@@ -62,5 +65,8 @@ namespace fiskaltrust.storage.V0
 
         Task<IEnumerable<ftQueueME>> GetQueueMEListAsync();
         Task<ftQueueME> GetQueueMEAsync(Guid queueMEId);
+
+        Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync();
+        Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId);
     }
 }


### PR DESCRIPTION
## Summary

Storage groundwork for Poland per [market-pl#2](https://github.com/fiskaltrust/market-pl/issues/2) (section 3), mirroring how GR/ES landed:

- **`fiskaltrust.storage`**: `ftQueuePL` (GR shape minus `LastHash`/`LastSignature` — in PL the certified device owns numbering and signatures, so there is no queue-side chain to persist; the `SSCDFail*`/`UsedFailed*` failure-tracking fields stay because reserve-printer failover is a core PL requirement) and `ftSignaturCreationUnitPL` (`Url` + `InfoJson`, ES shape — `InfoJson` gives the reserve-printer/device metadata a home without another schema change). New `IConfigurationRepository`/`IReadOnlyConfigurationRepository` members.
- **AzureTableStorage** (feeds the v2 `AzureStorageProvider`): `AzureTableStorageQueuePLRepository`, `AzureTableStorageSignaturCreationUnitPLRepository`, table entities, `Migration_008_PL`, registration in `DatabaseMigrator`. Unlike the GR SCU mapper, the PL SCU mapper maps all fields (`Url`, `InfoJson`).
- **InMemory**: full implementation — this is what the upcoming QueuePL acceptance tests will run on.
- **SQLite / MySQL / EF**: `NotImplementedException` stubs, exactly as for ES/GR/BE (v2 markets are AzureTableStorage-backed).
- **`BaseStorageBootStrapper`**: `init_ftQueuePL` / `init_ftSignaturCreationUnitPL` parsing + persistence, wired into `PersistConfigurationParallelAsync` (the v2 `AzureStorageProvider` path). Left out of the sequential v1 `PersistConfigurationAsync`, which only covers v1 markets.

## Design note for review

`ftSignaturCreationUnitPL` is included although market-pl#2 only names `ftQueuePL` — every market has an SCU entity, and the PL failover story (primary + reserve printer address) needs a portal-configurable home. If you prefer SCU-package-config-only, the entity and its wiring are easy to drop.

## Test plan

- All touched projects build with 0 errors (fiskaltrust.storage, Contracts, Storage.Base, AzureTableStorage, InMemory, SQLite, MySQL, EF, Localization.v2)
- `Storage.InMemory.AcceptanceTest`: 175/175 passed (net6.0)
- `Storage.SQLite.AcceptanceTest`: 178/178 passed (net6.0)
- `BaseStorageBootStrapper` tests (QueueFR.UnitTest): 3/3 passed
- net461 targets not run locally (macOS) — covered by CI

Part of the PL middleware track (interface: fiskaltrust/middleware-interface-dotnet#105). Next up: `scu-pl` (Abstraction + InMemory) and `QueuePL`.

**Tracked in** fiskaltrust/market-pl#49 (sub-issue of fiskaltrust/market-pl#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
