### PR TITLE
fix(CustomRTServer): Map customer fiscal code and VAT number in CustomRTServer

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueIT/Factories/SignaturItemFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueIT/Factories/SignaturItemFactory.cs
@@ -73,7 +73,7 @@ namespace fiskaltrust.Middleware.Localization.QueueIT.Factories
             }
             if (!string.IsNullOrEmpty(customerIdentification))
             {
-                stringBuilder.AppendLine($"Codice Fiscale: {customerIdentification}");
+                stringBuilder.AppendLine($"Cod. Fisc./P.IVA: {customerIdentification}");
             }
             if (!string.IsNullOrEmpty(shaMetadata))
             {

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
@@ -27,6 +27,7 @@ public static class CustomRTServerMapping
             refCashUuid = "ND";
         }
         (var totalAmount, var vatAmount, var items) = GenerateItemDataForReceiptRequest(receiptRequest, queueIdentification.LastZNumber + 1, queueIdentification.LastDocNumber + 1);
+        (var fiscalcode, var vatcode) = GetCustomerDataForReceiptRequest(receiptRequest);
         var fiscalDocument = new FDocument
         {
             document = new DocumentData
@@ -37,8 +38,8 @@ public static class CustomRTServerMapping
                 docnumber = queueIdentification.LastDocNumber + 1,
                 docznumber = queueIdentification.LastZNumber + 1,
                 amount = ConvertToFullAmountInt(totalAmount),
-                fiscalcode = "",
-                vatcode = "",
+                fiscalcode = fiscalcode,
+                vatcode = vatcode,
                 fiscaloperator = "",
                 businessname = null,
                 prevSignature = queueIdentification.LastSignature,
@@ -77,6 +78,7 @@ public static class CustomRTServerMapping
             refCashUuid = "ND";
         }
         (var totalAmount, var vatAmount, var items) = GenerateItemDataForReceiptRequest(receiptRequest, queueIdentification.LastZNumber + 1, queueIdentification.LastDocNumber + 1);
+        (var fiscalcode, var vatcode) = GetCustomerDataForReceiptRequest(receiptRequest);
 
         var fiscalDocument = new FDocument
         {
@@ -88,8 +90,8 @@ public static class CustomRTServerMapping
                 docnumber = queueIdentification.LastDocNumber + 1,
                 docznumber = queueIdentification.LastZNumber + 1,
                 amount = ConvertToFullAmountInt(totalAmount),
-                fiscalcode = "",
-                vatcode = "",
+                fiscalcode = fiscalcode,
+                vatcode = vatcode,
                 fiscaloperator = "",
                 businessname = null,
                 prevSignature = queueIdentification.LastSignature,
@@ -130,8 +132,9 @@ public static class CustomRTServerMapping
         document.docnumber = queueIdentification.LastDocNumber + 1;
         document.docznumber = queueIdentification.LastZNumber + 1;
         document.amount = ConvertToFullAmountInt(totalAmount);
-        document.fiscalcode = "";
-        document.vatcode = "";
+        // The lottery code and the customer identification are not mutually exclusive here: both are sent
+        // on the same document, so this also applies to the DocumentDataLottery branch above.
+        (document.fiscalcode, document.vatcode) = GetCustomerDataForReceiptRequest(receiptRequest);
         document.fiscaloperator = "";
         document.businessname = null;
         document.prevSignature = queueIdentification.LastSignature;
@@ -168,6 +171,26 @@ public static class CustomRTServerMapping
         qrCode.signature = GlobalTools.CreateHMAC(Convert.FromBase64String(key), qrCode.shaMetadata);
         return qrCode;
     }
+
+    /// <summary>
+    /// Reads the customer identification from cbCustomer. By convention across the IT SCUs
+    /// (cf. CustomRTPrinterSCU) Customer.CustomerId carries the codice fiscale and
+    /// Customer.CustomerVATId the partita IVA, so each one maps to its own document field.
+    /// Both values are forwarded as-is: validating their shape is handled separately.
+    /// </summary>
+    public static (string fiscalcode, string vatcode) GetCustomerDataForReceiptRequest(ReceiptRequest receiptRequest)
+    {
+        var customer = receiptRequest.GetCustomer();
+        return (Normalize(customer?.CustomerId), NormalizeVatId(customer?.CustomerVATId));
+    }
+
+    private static string NormalizeVatId(string? vatId)
+    {
+        var vat = Normalize(vatId);
+        return vat.StartsWith("IT", StringComparison.Ordinal) ? vat.Substring(2) : vat;
+    }
+
+    private static string Normalize(string? value) => value?.Trim().ToUpperInvariant() ?? "";
 
     public static bool InverseAmount(ReceiptRequest receiptRequest, ChargeItem chargeItem) => receiptRequest.IsRefund() || receiptRequest.IsVoid() || chargeItem.IsRefund() || chargeItem.IsVoid();
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
@@ -337,7 +337,9 @@ public sealed class CustomRTServerSCU : LegacySCU
             RTDocType = docType,
             RTServerSHAMetadata = commercialDocument.qrData.shaMetadata,
             RTCodiceLotteria = (fiscalDocument.document as DocumentDataLottery)?.lottery_client_code ?? "",
-            RTCustomerID = "",
+            RTCustomerID = string.IsNullOrEmpty(fiscalDocument.document.fiscalcode)
+                ? fiscalDocument.document.vatcode
+                : fiscalDocument.document.fiscalcode,
             RTReferenceZNumber = fiscalDocument.document.referenceClosurenumber,
             RTReferenceDocNumber = fiscalDocument.document.referenceDocnumber,
             RTReferenceDocMoment = string.IsNullOrEmpty(fiscalDocument.document.referenceDtime) ? null : DateTime.Parse(fiscalDocument.document.referenceDtime)

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
@@ -225,5 +226,167 @@ public class CustomRTServerSCUTests : IDisposable
 
         fiscalDocument.document.Should().NotBeOfType<DocumentDataLottery>();
         commercialDocument.fiscalData.Should().NotContain("lottery_client_code");
+    }
+
+    private static QueueIdentification CreateQueueIdentification() => new QueueIdentification
+    {
+        CashUuId = _cashBoxId,
+        CashHmacKey = Convert.ToBase64String(new byte[] { 1, 2, 3, 4 })
+    };
+
+    private static ReceiptRequest CreateReceiptRequest(string cbCustomer = null, string lotteryCode = null) => new ReceiptRequest
+    {
+        ftReceiptCase = (long) ITReceiptCases.PointOfSaleReceipt0x0001,
+        cbReceiptMoment = DateTime.UtcNow,
+        cbChargeItems = Array.Empty<ChargeItem>(),
+        cbPayItems = Array.Empty<PayItem>(),
+        cbCustomer = cbCustomer,
+        ftReceiptCaseData = lotteryCode is null
+            ? null
+            : JsonConvert.SerializeObject(new ReceiptCaseLotteryData
+            {
+                servizi_lotteriadegliscontrini_gov_it = new servizi_lotteriadegliscontrini_gov_it { codicelotteria = lotteryCode }
+            })
+    };
+
+    private static ReceiptResponse CreateReceiptResponse() => new ReceiptResponse
+    {
+        ftQueueID = _queueId.ToString(),
+        ftCashBoxIdentification = _cashBoxId,
+        ftState = 0x4954_2000_0000_0000,
+        ftSignatures = Array.Empty<SignaturItem>()
+    };
+
+    [Fact]
+    public void GenerateFiscalDocument_WithCustomerVATId_MapsPartitaIvaToVatCode()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerVATId":"01606720215"}""");
+
+        (var commercialDocument, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
+        fiscalDocument.document.fiscalcode.Should().BeEmpty();
+        commercialDocument.fiscalData.Should().Contain("\"vatcode\":\"01606720215\"");
+    }
+
+    [Fact]
+    public void GenerateFiscalDocument_WithCustomerId_MapsCodiceFiscaleToFiscalCode()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U"}""");
+
+        (var commercialDocument, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        fiscalDocument.document.fiscalcode.Should().Be("RSSMRA80A01H501U");
+        fiscalDocument.document.vatcode.Should().BeEmpty();
+        commercialDocument.fiscalData.Should().Contain("\"fiscalcode\":\"RSSMRA80A01H501U\"");
+    }
+
+    [Fact]
+    public void GenerateFiscalDocument_WithBothCustomerIdAndVATId_MapsBothFields()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        using var scope = new AssertionScope();
+        fiscalDocument.document.fiscalcode.Should().Be("RSSMRA80A01H501U");
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
+    }
+
+    [Theory]
+    [InlineData("IT01606720215")]
+    [InlineData("it01606720215")]
+    [InlineData("  IT01606720215  ")]
+    public void GenerateFiscalDocument_WithCountryPrefixedCustomerVATId_StripsPrefix(string customerVATId)
+    {
+        var receiptRequest = CreateReceiptRequest($$"""{"CustomerVATId":"{{customerVATId}}"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
+    }
+
+    // Shape validation of partita IVA / codice fiscale is out of scope here: whatever the PoS sends is
+    // forwarded to the RT server, apart from trimming, upper-casing and stripping the IT country prefix.
+    [Theory]
+    [InlineData("12345", "12345")]                   // too short
+    [InlineData("016067202151", "016067202151")]     // too long
+    [InlineData("IT12345", "12345")]                 // too short once the prefix is stripped
+    [InlineData("0160672021a", "0160672021A")]       // right length, not all digits
+    public void GenerateFiscalDocument_DoesNotValidateCustomerVATIdShape(string customerVATId, string expected)
+    {
+        var receiptRequest = CreateReceiptRequest($$"""{"CustomerVATId":"{{customerVATId}}"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        fiscalDocument.document.vatcode.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("RSSMRA80A01H501", "RSSMRA80A01H501")]        // too short
+    [InlineData("RSSMRA80A01H501UU", "RSSMRA80A01H501UU")]    // too long
+    [InlineData("  rssmra80a01h501u  ", "RSSMRA80A01H501U")]  // trimmed and upper-cased, not validated
+    public void GenerateFiscalDocument_DoesNotValidateCustomerIdShape(string customerId, string expected)
+    {
+        var receiptRequest = CreateReceiptRequest($$"""{"CustomerId":"{{customerId}}"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        fiscalDocument.document.fiscalcode.Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not json at all")]
+    [InlineData("""{"CustomerName":"Mario Rossi"}""")]
+    public void GenerateFiscalDocument_WithoutCustomerIdentification_LeavesCustomerFieldsEmpty(string cbCustomer)
+    {
+        var receiptRequest = CreateReceiptRequest(cbCustomer);
+
+        (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        using var scope = new AssertionScope();
+        fiscalDocument.document.fiscalcode.Should().BeEmpty();
+        fiscalDocument.document.vatcode.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GenerateFiscalDocument_WithLotteryCodeAndCustomer_MapsBothOnTheSameDocument()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerVATId":"01606720215"}""", lotteryCode: "ABCD1234");
+
+        (var commercialDocument, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
+
+        using var scope = new AssertionScope();
+        fiscalDocument.document.Should().BeOfType<DocumentDataLottery>();
+        ((DocumentDataLottery) fiscalDocument.document).lottery_client_code.Should().Be("ABCD1234");
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
+        commercialDocument.fiscalData.Should().Contain("\"lottery_client_code\":\"ABCD1234\"");
+        commercialDocument.fiscalData.Should().Contain("\"vatcode\":\"01606720215\"");
+    }
+
+    [Fact]
+    public void CreateResoDocument_WithCustomer_MapsCustomerFields()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.CreateResoDocument(receiptRequest, CreateQueueIdentification(), CreateReceiptResponse());
+
+        using var scope = new AssertionScope();
+        fiscalDocument.document.fiscalcode.Should().Be("RSSMRA80A01H501U");
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
+    }
+
+    [Fact]
+    public void CreateAnnuloDocument_WithCustomer_MapsCustomerFields()
+    {
+        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+
+        (_, var fiscalDocument) = CustomRTServerMapping.CreateAnnuloDocument(receiptRequest, CreateQueueIdentification(), CreateReceiptResponse());
+
+        using var scope = new AssertionScope();
+        fiscalDocument.document.fiscalcode.Should().Be("RSSMRA80A01H501U");
+        fiscalDocument.document.vatcode.Should().Be("01606720215");
     }
 }


### PR DESCRIPTION
## Description

CustomRTServer never read cbCustomer: document.fiscalcode and document.vatcode were hardcoded to empty strings in all three mapper paths, and the RTCustomerID signature was hardcoded to empty as well. The customer identification therefore never reached the RT server nor the receipt footer.

Map it following the convention already used by CustomRTPrinter, where Customer.CustomerId carries the codice fiscale and Customer.CustomerVATId the partita IVA, so each one maps to its own document field. Unlike Epson, the lottery code and the customer identification are not mutually exclusive here: both are sent on the same document.

Values are forwarded as-is apart from trimming, upper-casing and stripping the IT country prefix from the partita IVA, matching what EpsonCommandFactory does. Validating their shape is left for a follow-up.

Derive RTCustomerID from the mapped document (codice fiscale first, partita IVA as fallback) so the footer prints it, and relabel that footer line to "Cod. Fisc./P.IVA:" since it can now carry either of the two.

Fixes #736 
