### PR TITLE
Detect the provider channel's 228 as a duplicate-UID rejection

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Processors/InvoiceCounterReservation.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Processors/InvoiceCounterReservation.cs
@@ -17,16 +17,25 @@ internal static class InvoiceCounterReservation
 {
     /// <summary>
     /// myDATA validation error 233 — "UID: {uid} has already been sent" (myDATA API
-    /// v1.0.10 §7.2, the only duplicate-transmission code in the error table; the
-    /// check runs on the provider channel, which is how this SCU submits). The UID is
-    /// AADE's hash over the invoice identity (issuer VAT, issue date, branch, invoice
-    /// type, series, aa), so a 233 proves an invoice identical to this reservation —
-    /// including its (series, aa) — is already filed. The queue is the single writer
-    /// of its own series (handwritten numbering into the own series and series/aa
-    /// overrides are both rejected), so that can only mean the counter is behind AADE:
-    /// the reserved number is consumed.
+    /// v1.0.10 §7.2). The UID is AADE's hash over the invoice identity (issuer VAT,
+    /// issue date, branch, invoice type, series, aa), so a 233 proves an invoice
+    /// identical to this reservation — including its (series, aa) — is already filed.
+    /// The queue is the single writer of its own series (handwritten numbering into
+    /// the own series and series/aa overrides are both rejected), so that can only
+    /// mean the counter is behind AADE: the reserved number is consumed.
     /// </summary>
     private const string DuplicateAaAadeErrorCode = "233";
+
+    /// <summary>
+    /// myDATA validation error 228 — "{Field} is invalid" with Field ∈ {UID,
+    /// InvoiceType} (myDATA API v1.0.10 §7.2). The provider channel — which is how
+    /// this SCU submits — reports the duplicate UID under this code instead of 233,
+    /// observed live as "The UID: {uid} is invalid . It has already been sent for
+    /// another invoice (MARK:{mark} , AUTHENTICATION_CODE:{code})". Because 228 also
+    /// covers the InvoiceType variant (and a UID that is merely malformed), it only
+    /// counts as a duplicate when the message names the UID as already sent.
+    /// </summary>
+    private const string InvalidFieldAadeErrorCode = "228";
 
     public static async Task<ProcessCommandResponse> InvokeWithCounterAsync(
         ProcessCommandRequest request,
@@ -72,7 +81,7 @@ internal static class InvoiceCounterReservation
 
         var response = await SubmitWithSegmentAsync(request, reservedSeries, reservedAa, sscdCall);
 
-        if (IsDuplicateAaError(response.ReceiptResponse))
+        if (TryGetDuplicateAaError(response.ReceiptResponse, out var duplicateErrorCode))
         {
             // "Number consumed, advance": AADE proved an invoice identical to this
             // reservation is already filed, so move the persisted counter past the
@@ -80,23 +89,23 @@ internal static class InvoiceCounterReservation
             // resubmission; the POS retry loop is the retry mechanism), but the next
             // attempt reserves a fresh number instead of re-reserving the same one
             // forever. This heals the retry after the commit write below failed
-            // (identical resubmission, same UID → 233) and same-day re-issues caused
-            // by a too-low queue-start seed (see InvoiceCounterMigration). Handwritten
-            // documents never get here — they returned above, before the reservation.
-            // Their numbering is caller-owned, so a handwritten 233 is the caller's
-            // duplicate to fix and must never move the queue's counter.
+            // (identical resubmission, same UID → 228/233) and same-day re-issues
+            // caused by a too-low queue-start seed (see InvoiceCounterMigration).
+            // Handwritten documents never get here — they returned above, before the
+            // reservation. Their numbering is caller-owned, so a handwritten duplicate
+            // is the caller's problem to fix and must never move the queue's counter.
             queueGR.InvoiceNumerator = reservedAa;
             await configRepo.InsertOrUpdateQueueGRAsync(queueGR);
             // Two sinks on purpose: the action journal is the durable per-queue audit
             // trail, the structured warning is what OpenTelemetry/AppInsights pick up
             // for alerting across queues.
             await queueStorageProvider.CreateActionJournalAsync(
-                $"AADE rejected aa {reservedAa} in series '{reservedSeries}' as a duplicate (233) — the invoice counter was behind AADE. The counter advanced to {reservedAa}; the next submission reserves aa {reservedAa + 1}.",
+                $"AADE rejected aa {reservedAa} in series '{reservedSeries}' as a duplicate ({duplicateErrorCode}) — the invoice counter was behind AADE. The counter advanced to {reservedAa}; the next submission reserves aa {reservedAa + 1}.",
                 $"{response.ReceiptResponse.ftState:X}",
                 response.ReceiptResponse.ftQueueItemID);
             logger.LogWarning(
-                "AADE rejected aa {RejectedAa} in series '{InvoiceSeries}' as a duplicate (233) for queue {QueueId} (queue item {QueueItemId}) — the invoice counter was behind AADE. Advanced InvoiceNumerator to {InvoiceNumerator}; the next submission reserves aa {NextAa}.",
-                reservedAa, reservedSeries, request.queue.ftQueueId, response.ReceiptResponse.ftQueueItemID, queueGR.InvoiceNumerator, queueGR.InvoiceNumerator + 1);
+                "AADE rejected aa {RejectedAa} in series '{InvoiceSeries}' as a duplicate ({DuplicateErrorCode}) for queue {QueueId} (queue item {QueueItemId}) — the invoice counter was behind AADE. Advanced InvoiceNumerator to {InvoiceNumerator}; the next submission reserves aa {NextAa}.",
+                reservedAa, reservedSeries, duplicateErrorCode, request.queue.ftQueueId, response.ReceiptResponse.ftQueueItemID, queueGR.InvoiceNumerator, queueGR.InvoiceNumerator + 1);
             return new ProcessCommandResponse(response.ReceiptResponse, []);
         }
 
@@ -117,8 +126,8 @@ internal static class InvoiceCounterReservation
             queueGR.LastInvoiceMark = mark;
             // Accepted-risk window (shared with the ES processors): if this write fails
             // after AADE filed the invoice, the aa is consumed at AADE while the counter
-            // stays behind — the retry re-reserves it, AADE answers 233 once, and the
-            // duplicate-aa advance above moves the counter past it.
+            // stays behind — the retry re-reserves it, AADE answers 228/233 once, and
+            // the duplicate-aa advance above moves the counter past it.
             await configRepo.InsertOrUpdateQueueGRAsync(queueGR);
         }
 
@@ -189,8 +198,9 @@ internal static class InvoiceCounterReservation
         return response;
     }
 
-    private static bool IsDuplicateAaError(ReceiptResponse response)
+    private static bool TryGetDuplicateAaError(ReceiptResponse response, out string duplicateErrorCode)
     {
+        duplicateErrorCode = string.Empty;
         if (!response.ftState.IsState(State.Error))
         {
             return false;
@@ -199,8 +209,8 @@ internal static class InvoiceCounterReservation
         // serialized AADEEErrorResponse: {"AADEError":"...","Errors":[{"message":"...",
         // "code":"..."}]}. The property names duplicate scu-gr's AADEEErrorResponse and
         // the xsd-generated ErrorType — if either side drifts, the advance silently
-        // stops triggering and a 233 fails the receipt without moving the counter,
-        // exactly as it did before the heal existed.
+        // stops triggering and a duplicate fails the receipt without moving the
+        // counter, exactly as it did before the heal existed.
         foreach (var signature in response.ftSignatures ?? [])
         {
             if (!string.Equals(signature.Caption, "FAILURE", StringComparison.Ordinal) || string.IsNullOrEmpty(signature.Data))
@@ -218,11 +228,30 @@ internal static class InvoiceCounterReservation
                 }
                 foreach (var error in errors.EnumerateArray())
                 {
-                    if (error.ValueKind == JsonValueKind.Object
-                        && error.TryGetProperty("code", out var code)
-                        && code.ValueKind == JsonValueKind.String
-                        && string.Equals(code.GetString(), DuplicateAaAadeErrorCode, StringComparison.Ordinal))
+                    if (error.ValueKind != JsonValueKind.Object
+                        || !error.TryGetProperty("code", out var code)
+                        || code.ValueKind != JsonValueKind.String)
                     {
+                        continue;
+                    }
+                    if (string.Equals(code.GetString(), DuplicateAaAadeErrorCode, StringComparison.Ordinal))
+                    {
+                        duplicateErrorCode = DuplicateAaAadeErrorCode;
+                        return true;
+                    }
+                    // 228 is ambiguous ("{Field} is invalid", Field ∈ {UID, InvoiceType})
+                    // — only its duplicate-UID variant proves a consumed number, so the
+                    // message must name the UID as already sent. Anything else stays a
+                    // regular failure: advancing there would burn numbers for a request
+                    // that keeps failing.
+                    if (string.Equals(code.GetString(), InvalidFieldAadeErrorCode, StringComparison.Ordinal)
+                        && error.TryGetProperty("message", out var message)
+                        && message.ValueKind == JsonValueKind.String
+                        && message.GetString() is { } messageText
+                        && messageText.Contains("UID", StringComparison.OrdinalIgnoreCase)
+                        && messageText.Contains("already been sent", StringComparison.OrdinalIgnoreCase))
+                    {
+                        duplicateErrorCode = InvalidFieldAadeErrorCode;
                         return true;
                     }
                 }

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueGR.UnitTest/Processors/InvoiceCounterReservationTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueGR.UnitTest/Processors/InvoiceCounterReservationTests.cs
@@ -214,9 +214,92 @@ public class InvoiceCounterReservationTests
     }
 
     [Fact]
+    public async Task DuplicateUid228FromProviderChannel_AdvancesTheCounter()
+    {
+        // The provider channel — which is how this SCU submits — reports the duplicate
+        // UID as validation error 228 instead of 233. This is the byte-for-byte payload
+        // observed in production; it must trigger the same "number consumed, advance".
+        var queue = TestHelpers.CreateQueue();
+        var queueGR = new ftQueueGR
+        {
+            ftQueueGRId = queue.ftQueueId,
+            CashBoxIdentification = "CB-A",
+            InvoiceSeries = "CB-A",
+            InvoiceNumerator = 41,
+        };
+        var configRepoMock = SetupConfigRepoMock(queueGR);
+        var scuCalls = 0;
+        var grSSCDMock = new Mock<IGRSSCD>();
+        grSSCDMock.Setup(x => x.ProcessReceiptAsync(It.IsAny<ProcessRequest>(), It.IsAny<List<(ReceiptRequest, ReceiptResponse)>>()))
+            .ReturnsAsync((ProcessRequest req, List<(ReceiptRequest, ReceiptResponse)> _) =>
+            {
+                scuCalls++;
+                req.ReceiptResponse.SetReceiptResponseError(
+                    "{\"AADEError\":\"ValidationError\",\"Errors\":[{\"message\":\"The UID: E983749569A44D1417B39328DED86B6E84AF6B59 is invalid . It has already been sent for another invoice (MARK:400001966030681 , AUTHENTICATION_CODE:6485235B15AB2E465F94C28BF5471F8A3795D688)\",\"code\":\"228\"}]}");
+                return new ProcessResponse { ReceiptResponse = req.ReceiptResponse };
+            });
+        var storageProviderMock = new Mock<IQueueStorageProvider>();
+
+        var processor = new ReceiptCommandProcessorGR(
+            grSSCDMock.Object,
+            storageProviderMock.Object,
+            new AsyncLazy<IConfigurationRepository>(() => Task.FromResult(configRepoMock.Object)),
+            Mock.Of<ILogger>());
+
+        var result = await processor.PointOfSaleReceipt0x0001Async(BuildRequest(queue, ReceiptCase.PointOfSaleReceipt0x0001));
+
+        scuCalls.Should().Be(1); // no resubmission within the call — same as 233
+        result.receiptResponse.ftState.IsState(State.Error).Should().BeTrue();
+        result.receiptResponse.ftReceiptIdentification.Should().Be("ft1#");
+        queueGR.InvoiceNumerator.Should().Be(42);
+        configRepoMock.Verify(x => x.InsertOrUpdateQueueGRAsync(It.Is<ftQueueGR>(q => q.InvoiceNumerator == 42)), Times.Once);
+        storageProviderMock.Verify(x => x.CreateActionJournalAsync(It.Is<string>(m => m.Contains("228")), It.IsAny<string>(), It.IsAny<Guid?>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Error228ForOtherFields_DoesNotAdvanceTheCounter()
+    {
+        // 228 is "{Field} is invalid" with Field ∈ {UID, InvoiceType} — only the
+        // duplicate-UID variant ("already been sent") proves a consumed number. Any
+        // other 228 is a problem with the receipt itself and must not move the counter.
+        var queue = TestHelpers.CreateQueue();
+        var queueGR = new ftQueueGR
+        {
+            ftQueueGRId = queue.ftQueueId,
+            CashBoxIdentification = "CB-A",
+            InvoiceSeries = "CB-A",
+            InvoiceNumerator = 41,
+        };
+        var configRepoMock = SetupConfigRepoMock(queueGR);
+        var grSSCDMock = new Mock<IGRSSCD>();
+        grSSCDMock.Setup(x => x.ProcessReceiptAsync(It.IsAny<ProcessRequest>(), It.IsAny<List<(ReceiptRequest, ReceiptResponse)>>()))
+            .ReturnsAsync((ProcessRequest req, List<(ReceiptRequest, ReceiptResponse)> _) =>
+            {
+                req.ReceiptResponse.SetReceiptResponseError(
+                    "{\"AADEError\":\"ValidationError\",\"Errors\":[{\"message\":\"The INVOICE TYPE: 11.5 is invalid\",\"code\":\"228\"}]}");
+                return new ProcessResponse { ReceiptResponse = req.ReceiptResponse };
+            });
+        var storageProviderMock = new Mock<IQueueStorageProvider>();
+
+        var processor = new ReceiptCommandProcessorGR(
+            grSSCDMock.Object,
+            storageProviderMock.Object,
+            new AsyncLazy<IConfigurationRepository>(() => Task.FromResult(configRepoMock.Object)),
+            Mock.Of<ILogger>());
+
+        var result = await processor.PointOfSaleReceipt0x0001Async(BuildRequest(queue, ReceiptCase.PointOfSaleReceipt0x0001));
+
+        result.receiptResponse.ftState.IsState(State.Error).Should().BeTrue();
+        queueGR.InvoiceNumerator.Should().Be(41);
+        configRepoMock.Verify(x => x.InsertOrUpdateQueueGRAsync(It.IsAny<ftQueueGR>()), Times.Never);
+        storageProviderMock.Verify(x => x.CreateActionJournalAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid?>()), Times.Never);
+    }
+
+    [Fact]
     public async Task NonDuplicateAadeError_DoesNotAdvanceTheCounter()
     {
-        // Only 233 is proof that the number is consumed at AADE. Any other rejection is
+        // Only a duplicate-UID rejection (233, or 228's already-sent variant) is proof
+        // that the number is consumed at AADE. Any other rejection is
         // a problem with the receipt itself — advancing there would burn numbers for a
         // request that keeps failing.
         var queue = TestHelpers.CreateQueue();


### PR DESCRIPTION
## What

The duplicate-aa advance shipped with #741 matches AADE validation error **233** ("UID has already been sent"). The provider channel — which is how this SCU submits — reports the same condition as **228** ("{Field} is invalid"), observed byte-for-byte in production:

```
The UID: E983749569A44D1417B39328DED86B6E84AF6B59 is invalid . It has already been sent for another invoice (MARK:400001966030681 , AUTHENTICATION_CODE:...)
```

So live duplicates sailed past the detection: the counter never advanced and every same-day submission kept re-reserving the burned number.

This extends `InvoiceCounterReservation`'s detection to 228 — guarded by the message naming the **UID** as **already been sent**, because 228 also covers the InvoiceType variant and a merely malformed UID (myDATA v1.0.10, p. 65), which must stay regular, non-advancing failures. The action journal and structured warning now carry whichever code actually triggered the advance.

## Reviewer notes

- No behavioral change beyond the added match: same advance-once, no resubmission, handwritten documents still excluded.
- Tests: the live 228 payload advances the counter and journals with the code; a non-UID 228 ("The INVOICE TYPE: 11.5 is invalid") does not advance. Full QueueGR unit suite passes (93/93).

🤖 Generated with [Claude Code](https://claude.com/claude-code)