### PR TITLE
Add scu-pl foundation: SCU.PL.Abstraction + SCU.PL.InMemory

### DIFF
--- a/scu-pl/Directory.Build.props
+++ b/scu-pl/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <PropertyGroup>
+    <Version>1.3.0-local</Version>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
+    <Authors>fiskaltrust</Authors>
+    <Company>fiskaltrust</Company>
+    <Copyright>Copyright 2022</Copyright>
+    <PackageTags>fiskaltrust signing</PackageTags>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <AssemblyCompany>fiskaltrust</AssemblyCompany>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Deterministic>true</Deterministic>
+    <LangVersion>12.0</LangVersion>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;NU5104</WarningsNotAsErrors>
+  </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Condition="Exists('version.json')">
+            <PrivateAssets>all</PrivateAssets>
+            <Version>3.9.50</Version>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/scu-pl/fiskaltrust.Middleware.SCU.PL.sln
+++ b/scu-pl/fiskaltrust.Middleware.SCU.PL.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.Abstraction", "src\fiskaltrust.Middleware.SCU.PL.Abstraction\fiskaltrust.Middleware.SCU.PL.Abstraction.csproj", "{06041BEC-3297-4274-8996-B5973CDBD2DC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.InMemory", "src\fiskaltrust.Middleware.SCU.PL.InMemory\fiskaltrust.Middleware.SCU.PL.InMemory.csproj", "{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.UnitTest", "test\fiskaltrust.Middleware.SCU.PL.UnitTest\fiskaltrust.Middleware.SCU.PL.UnitTest.csproj", "{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/SignatureTypePL.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/SignatureTypePL.cs
@@ -1,0 +1,23 @@
+using System;
+using fiskaltrust.ifPOS.v2.Cases;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+
+public enum SignatureTypePL : long
+{
+    FiscalDocumentNumber = 0x504C_2000_0000_0101,
+    DeviceSerialNumber = 0x504C_2000_0000_0102,
+    UniqueDeviceNumber = 0x504C_2000_0000_0103,
+    ZReportNumber = 0x504C_2000_0000_0104,
+    EReceiptReference = 0x504C_2000_0000_0105,
+    StoredNotFiscalized = 0x504C_2000_0000_0106,
+}
+
+public static class SignatureTypePLExt
+{
+    public static T As<T>(this SignatureTypePL self) where T : Enum, IConvertible => (T) Enum.ToObject(typeof(T), self);
+
+    public static bool IsType(this SignatureType self, SignatureTypePL signatureTypePL) => ((long) self & 0xFFFF) == ((long) signatureTypePL & 0xFFFF);
+    public static SignatureType WithType(this SignatureType self, SignatureTypePL state) => (SignatureType) ((ulong) self & 0xFFFF_FFFF_FFFF_0000 | (ulong) state & 0xFFFF);
+    public static SignatureTypePL Type(this SignatureType self) => (SignatureTypePL) ((long) self & 0xFFFF);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/StatePL.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/StatePL.cs
@@ -1,0 +1,14 @@
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+
+/// <summary>
+/// PL-localized ftState values. The middle three nibbles (0x0000_0FFF_0000_0000) carry the
+/// PL-local flags; the lowest flag nibble bit marks "fiscal device unreachable" — in Poland a
+/// non-working register legally means no sale (Art. 111(3) VAT Act), so callers must be able
+/// to distinguish this failure from any other error.
+/// </summary>
+public enum StatePL : ulong
+{
+    Success = 0x504C_2000_0000_0000,
+    Error = 0x504C_2000_EEEE_EEEE,
+    DeviceUnreachableError = 0x504C_2001_EEEE_EEEE,
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Exceptions/PLSSCDExceptions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Exceptions/PLSSCDExceptions.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+
+/// <summary>Base type for all failures raised by Polish SCUs.</summary>
+public class PLSSCDException : Exception
+{
+    public PLSSCDException(string message) : base(message) { }
+    public PLSSCDException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// The fiscal register could not be reached (offline printer, network failure, printer farm
+/// endpoint down). In Poland no working register legally means no sale (Art. 111(3) VAT Act),
+/// so this failure carries its own ftState flag — see <c>StatePL.DeviceUnreachableError</c>.
+/// </summary>
+public class PLDeviceUnreachableException : PLSSCDException
+{
+    public PLDeviceUnreachableException(string message) : base(message) { }
+    public PLDeviceUnreachableException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>The register rejected an operation with a device error code.</summary>
+public class PLDeviceErrorException : PLSSCDException
+{
+    public int ErrorCode { get; }
+
+    public PLDeviceErrorException(int errorCode, string message) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+}
+
+/// <summary>A request violates a PL constraint before any device communication happens.</summary>
+public class PLValidationException : PLSSCDException
+{
+    public PLValidationException(string message) : base(message) { }
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLAmountExtensions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLAmountExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+/// <summary>
+/// Polish fiscal devices exchange monetary amounts as integer grosze (1 PLN = 100 gr).
+/// </summary>
+public static class PLAmountExtensions
+{
+    public static long ToGrosze(this decimal amountPln) => (long)Math.Round(amountPln * 100m, 0, MidpointRounding.AwayFromZero);
+
+    public static decimal GroszeToPln(this long amountGrosze) => amountGrosze / 100m;
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLReceiptResponseExtensions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLReceiptResponseExtensions.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+/// <summary>
+/// The single place where PL SCUs enrich a ReceiptResponse with device-owned identity:
+/// ftCashBoxIdentification carries the numer unikatowy and ftReceiptIdentification is completed
+/// with the fiscal document number issued by the register.
+/// </summary>
+public static class PLReceiptResponseExtensions
+{
+    public static void AddSignatureItem(this ReceiptResponse response, SignatureTypePL signatureType, string caption, string data)
+        => response.ftSignatures.Add(new SignatureItem
+        {
+            ftSignatureFormat = SignatureFormat.Text,
+            ftSignatureType = (SignatureType)(ulong)(long)signatureType,
+            Caption = caption,
+            Data = data,
+        });
+
+    public static void EnrichWithDeviceIdentification(this ReceiptResponse response, PLDeviceInfo deviceInfo)
+    {
+        if (!string.IsNullOrEmpty(deviceInfo.UniqueDeviceNumber))
+        {
+            response.ftCashBoxIdentification = deviceInfo.UniqueDeviceNumber;
+            response.AddSignatureItem(SignatureTypePL.UniqueDeviceNumber, "Numer unikatowy", deviceInfo.UniqueDeviceNumber);
+        }
+
+        if (!string.IsNullOrEmpty(deviceInfo.DeviceSerialNumber))
+        {
+            response.AddSignatureItem(SignatureTypePL.DeviceSerialNumber, "Numer fabryczny", deviceInfo.DeviceSerialNumber);
+        }
+    }
+
+    public static void EnrichWithFiscalDocumentNumber(this ReceiptResponse response, long fiscalDocumentNumber)
+    {
+        var number = fiscalDocumentNumber.ToString(CultureInfo.InvariantCulture);
+        response.ftReceiptIdentification += number;
+        response.AddSignatureItem(SignatureTypePL.FiscalDocumentNumber, "Numer dokumentu fiskalnego", number);
+    }
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLStateMapper.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLStateMapper.cs
@@ -1,0 +1,20 @@
+using System;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+public static class PLStateMapper
+{
+    /// <summary>
+    /// Maps an SCU failure to the PL-localized ftState. Device-unreachable failures get their own
+    /// local flag so queues and monitoring can distinguish "no register — no legal sale" from
+    /// ordinary errors.
+    /// </summary>
+    public static State Map(Exception exception) => exception switch
+    {
+        PLDeviceUnreachableException => (State)StatePL.DeviceUnreachableError,
+        _ => (State)StatePL.Error,
+    };
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLDeviceInfo.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLDeviceInfo.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2.pl;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+/// <summary>
+/// The fiscalization state of the connected Polish register. Fiscalizing a device is a
+/// certified-technician (serwis) act and can never be triggered through the middleware.
+/// </summary>
+public enum PLFiscalizationState
+{
+    Unknown = 0,
+    NonFiscal = 1,
+    Fiscalized = 2,
+    ReadOnly = 3,
+}
+
+/// <summary>
+/// A single slot of the PTU VAT rate table programmed on the register. A slot either carries a
+/// percentage rate or is marked tax-exempt (zwolniona, "zw.").
+/// </summary>
+public class PLVatRateTableEntry
+{
+    /// <summary>The PTU slot letter ("A" to "G").</summary>
+    public string PtuSlot { get; set; } = "";
+
+    /// <summary>The VAT rate in percent (e.g. 23 for the standard rate), or null if the slot is exempt.</summary>
+    public decimal? VatRatePercent { get; set; }
+
+    /// <summary>True if the slot is programmed as tax-exempt (zwolniona, "zw.").</summary>
+    public bool IsExempt { get; set; }
+}
+
+/// <summary>
+/// Typed state of the Polish register as reported by the device. In Poland the certified register
+/// owns the compliance state; this model travels as the json-serialized <c>InfoData</c> blob of
+/// <see cref="PLSSCDInfo"/>. Software registers (kasy wirtualne) have no numer fabryczny — for them
+/// <see cref="DeviceSerialNumber"/> stays null and <see cref="UniqueDeviceNumber"/> identifies the register.
+/// </summary>
+public class PLDeviceInfo
+{
+    /// <summary>The manufacturing serial number (numer fabryczny); null for software registers.</summary>
+    public string? DeviceSerialNumber { get; set; }
+
+    /// <summary>The unique number assigned from the MF pool (numer unikatowy), printed on every fiscal document.</summary>
+    public string? UniqueDeviceNumber { get; set; }
+
+    /// <summary>The registration number assigned during fiscalization (numer ewidencyjny), identifying the register in the CRK.</summary>
+    public string? RegistrationNumber { get; set; }
+
+    public PLFiscalizationState FiscalizationState { get; set; }
+
+    /// <summary>The PTU VAT rate table (slots A–G) currently programmed on the register.</summary>
+    public List<PLVatRateTableEntry> VatRateTable { get; set; } = new();
+
+    /// <summary>Whether the register can currently reach the CRK (Central Repository of Cash Registers).</summary>
+    public bool? CrkReachable { get; set; }
+
+    /// <summary>The moment of the last successful transmission to the CRK, as reported by the register.</summary>
+    public DateTime? CrkLastTransmission { get; set; }
+
+    /// <summary>Whether the register supports issuing e-receipts (e-paragony).</summary>
+    public bool? EReceiptCapable { get; set; }
+
+    /// <summary>The number of the current daily (Z) report period.</summary>
+    public int? CurrentZReportNumber { get; set; }
+
+    public PLSSCDInfo ToPLSSCDInfo() => new()
+    {
+        InfoData = JsonSerializer.Serialize(this)
+    };
+
+    public static PLDeviceInfo? FromPLSSCDInfo(PLSSCDInfo info)
+        => info.InfoData is null ? null : JsonSerializer.Deserialize<PLDeviceInfo>(info.InfoData);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLFiscalCommand.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLFiscalCommand.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+/// <summary>
+/// The device-neutral fiscal operations a Polish SCU must be able to perform. Device SCUs
+/// (e.g. Posnet) map these to their protocol frames; the command set follows the receipt flow
+/// trinit → trline → trpayment → trend plus the report and status operations.
+/// </summary>
+public enum PLFiscalCommandType
+{
+    GetStatus,
+    GetDeviceInfo,
+    BeginReceipt,
+    AddReceiptLine,
+    AddPayment,
+    EndReceipt,
+    CancelReceipt,
+    DailyReport,
+    PeriodicReport,
+}
+
+/// <summary>
+/// A single device-neutral fiscal command. Deliberately loosely typed while the Posnet protocol
+/// implementation (market-pl#3) settles the field glossary; device SCUs translate
+/// <see cref="Parameters"/> into their protocol-specific representation.
+/// </summary>
+public class PLFiscalCommand
+{
+    public PLFiscalCommandType CommandType { get; set; }
+
+    public Dictionary<string, string> Parameters { get; set; } = new();
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/PtuSlotResolver.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/PtuSlotResolver.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction;
+
+/// <summary>The statutory Polish VAT rates the ftChargeItemCase VAT nibble maps to.</summary>
+public static class PLVatRates
+{
+    public const decimal Normal = 23m;
+    public const decimal Reduced1 = 8m;
+    public const decimal Reduced2 = 5m;
+    public const decimal Zero = 0m;
+}
+
+/// <summary>
+/// Resolves the PTU slot for a charge item against the VAT rate table reported by the register.
+/// The slot letters are never hardcoded: which slot carries which rate (and which slot is the
+/// exempt "zw." one) is owned by the device — only the case→rate mapping is statutory.
+/// </summary>
+public class PtuSlotResolver
+{
+    private readonly IReadOnlyList<PLVatRateTableEntry> _vatRateTable;
+
+    public PtuSlotResolver(IEnumerable<PLVatRateTableEntry> deviceVatRateTable)
+    {
+        _vatRateTable = deviceVatRateTable.ToList();
+    }
+
+    public PLVatRateTableEntry Resolve(ChargeItemCase chargeItemCase) => chargeItemCase.Vat() switch
+    {
+        ChargeItemCase.NormalVatRate => ResolveByRate(PLVatRates.Normal),
+        ChargeItemCase.DiscountedVatRate1 => ResolveByRate(PLVatRates.Reduced1),
+        ChargeItemCase.DiscountedVatRate2 => ResolveByRate(PLVatRates.Reduced2),
+        ChargeItemCase.ZeroVatRate => ResolveByRate(PLVatRates.Zero),
+        ChargeItemCase.NotTaxable => ResolveExempt(),
+        var vat => throw new PLValidationException($"The VAT case {vat} of ftChargeItemCase 0x{(ulong)chargeItemCase:X} has no Polish PTU mapping."),
+    };
+
+    public PLVatRateTableEntry ResolveByRate(decimal vatRatePercent)
+        => _vatRateTable.FirstOrDefault(x => !x.IsExempt && x.VatRatePercent == vatRatePercent)
+            ?? throw new PLValidationException($"The VAT rate table of the register does not contain a PTU slot for {vatRatePercent}%.");
+
+    public PLVatRateTableEntry ResolveExempt()
+        => _vatRateTable.FirstOrDefault(x => x.IsExempt)
+            ?? throw new PLValidationException("The VAT rate table of the register does not contain a tax-exempt (zw.) PTU slot.");
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/fiskaltrust.Middleware.SCU.PL.Abstraction.csproj
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/fiskaltrust.Middleware.SCU.PL.Abstraction.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Shared abstractions for the fiskaltrust Middleware SCUs for Poland: PTU slot resolution, PL signature types and states, device info, amount helpers and the SCU exception hierarchy.</Description>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+        <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+        <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
+    </ItemGroup>
+
+    <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup Label="FilesToCopy">
+        <Content Include="..\..\LICENSES\**" Pack="true" PackagePath="LICENSES" LinkBase="LICENSES">
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.InMemory;
+
+/// <summary>
+/// A deterministic, hardware-free IPLSSCD implementation that mimics the behavior of a Polish
+/// online register: it owns the fiscal document numbering and the daily (Z) report counter and
+/// enriches responses with the device identity — enough to run QueuePL acceptance tests without
+/// a printer. Validation hooks let tests inject device behaviors (e.g. tax-class blocking).
+/// </summary>
+public class InMemorySCU : IPLSSCD
+{
+    private readonly PLDeviceInfo _deviceInfo;
+    private readonly List<Action<ProcessRequest>> _validators;
+    private readonly object _syncRoot = new();
+    private long _fiscalDocumentNumber;
+
+    public InMemorySCU(PLDeviceInfo? deviceInfo = null, IEnumerable<Action<ProcessRequest>>? validators = null, long fiscalDocumentNumberSeed = 0)
+    {
+        _deviceInfo = deviceInfo ?? CreateDefaultDeviceInfo();
+        _deviceInfo.CurrentZReportNumber ??= 0;
+        _validators = validators?.ToList() ?? new List<Action<ProcessRequest>>();
+        _fiscalDocumentNumber = fiscalDocumentNumberSeed;
+    }
+
+    public static PLDeviceInfo CreateDefaultDeviceInfo() => new()
+    {
+        DeviceSerialNumber = "INM1234567",
+        UniqueDeviceNumber = "ZAS0000000001",
+        RegistrationNumber = "0000000001",
+        FiscalizationState = PLFiscalizationState.Fiscalized,
+        VatRateTable = new List<PLVatRateTableEntry>
+        {
+            new() { PtuSlot = "A", VatRatePercent = 23m },
+            new() { PtuSlot = "B", VatRatePercent = 8m },
+            new() { PtuSlot = "C", VatRatePercent = 5m },
+            new() { PtuSlot = "D", VatRatePercent = 0m },
+            new() { PtuSlot = "G", IsExempt = true },
+        },
+        CrkReachable = true,
+        CrkLastTransmission = null,
+        EReceiptCapable = true,
+        CurrentZReportNumber = 0,
+    };
+
+    public Task<EchoResponse> EchoAsync(EchoRequest echoRequest)
+        => Task.FromResult(new EchoResponse { Message = echoRequest.Message });
+
+    public Task<PLSSCDInfo> GetInfoAsync()
+        => Task.FromResult(_deviceInfo.ToPLSSCDInfo());
+
+    public Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request)
+    {
+        foreach (var validator in _validators)
+        {
+            validator(request);
+        }
+
+        var receiptCase = request.ReceiptRequest.ftReceiptCase;
+        var response = request.ReceiptResponse;
+
+        if (receiptCase.IsType(ReceiptCaseType.Invoice))
+        {
+            throw new PLValidationException("Invoice cases (0x1xxx) must not reach a Polish SCU — QueuePL persists them without fiscalization.");
+        }
+
+        response.EnrichWithDeviceIdentification(_deviceInfo);
+
+        if (receiptCase.IsType(ReceiptCaseType.Receipt))
+        {
+            long fiscalDocumentNumber;
+            lock (_syncRoot)
+            {
+                fiscalDocumentNumber = ++_fiscalDocumentNumber;
+            }
+            response.EnrichWithFiscalDocumentNumber(fiscalDocumentNumber);
+        }
+        else if (receiptCase.IsType(ReceiptCaseType.DailyOperations) && IsZReportCase(receiptCase))
+        {
+            int zReportNumber;
+            lock (_syncRoot)
+            {
+                zReportNumber = (_deviceInfo.CurrentZReportNumber ?? 0) + 1;
+                _deviceInfo.CurrentZReportNumber = zReportNumber;
+            }
+            response.AddSignatureItem(Abstraction.Cases.SignatureTypePL.ZReportNumber, "Numer raportu dobowego", zReportNumber.ToString());
+        }
+
+        return Task.FromResult(new ProcessResponse { ReceiptResponse = response });
+    }
+
+    private static bool IsZReportCase(ReceiptCase receiptCase)
+        => receiptCase.IsCase(ReceiptCase.DailyClosing0x2011)
+            || receiptCase.IsCase(ReceiptCase.MonthlyClosing0x2012)
+            || receiptCase.IsCase(ReceiptCase.YearlyClosing0x2013);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
@@ -75,7 +75,7 @@ public class InMemorySCU : IPLSSCD
 
         response.EnrichWithDeviceIdentification(_deviceInfo);
 
-        if (receiptCase.IsType(ReceiptCaseType.Receipt))
+        if (IsFiscalReceiptCase(receiptCase))
         {
             long fiscalDocumentNumber;
             lock (_syncRoot)
@@ -84,8 +84,10 @@ public class InMemorySCU : IPLSSCD
             }
             response.EnrichWithFiscalDocumentNumber(fiscalDocumentNumber);
         }
-        else if (receiptCase.IsType(ReceiptCaseType.DailyOperations) && IsZReportCase(receiptCase))
+        else if (receiptCase.IsCase(ReceiptCase.DailyClosing0x2011))
         {
+            // Only the daily closing advances the Z counter — monthly/yearly closings are
+            // periodic reports over already-closed days and do not create a new Z report.
             int zReportNumber;
             lock (_syncRoot)
             {
@@ -98,8 +100,14 @@ public class InMemorySCU : IPLSSCD
         return Task.FromResult(new ProcessResponse { ReceiptResponse = response });
     }
 
-    private static bool IsZReportCase(ReceiptCase receiptCase)
-        => receiptCase.IsCase(ReceiptCase.DailyClosing0x2011)
-            || receiptCase.IsCase(ReceiptCase.MonthlyClosing0x2012)
-            || receiptCase.IsCase(ReceiptCase.YearlyClosing0x2013);
+    /// <summary>
+    /// Only the fiscal sale documents consume a fiscal document number on the register —
+    /// non-fiscal receipt cases (payment transfer, sale without fiscalization obligation,
+    /// delivery note, table check, pro forma) do not.
+    /// </summary>
+    private static bool IsFiscalReceiptCase(ReceiptCase receiptCase)
+        => receiptCase.IsType(ReceiptCaseType.Receipt)
+            && (receiptCase.IsCase(ReceiptCase.UnknownReceipt0x0000)
+                || receiptCase.IsCase(ReceiptCase.PointOfSaleReceipt0x0001)
+                || receiptCase.IsCase(ReceiptCase.ECommerce0x0004));
 }

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/fiskaltrust.Middleware.SCU.PL.InMemory.csproj
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/fiskaltrust.Middleware.SCU.PL.InMemory.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>The fiskaltrust Middleware implementation of the InMemory SCU for Poland.</Description>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+        <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+        <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\fiskaltrust.Middleware.SCU.PL.Abstraction\fiskaltrust.Middleware.SCU.PL.Abstraction.csproj" />
+    </ItemGroup>
+
+    <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup Label="FilesToCopy">
+        <Content Include="..\..\LICENSES\**" Pack="true" PackagePath="LICENSES" LinkBase="LICENSES">
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/AbstractionHelperTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/AbstractionHelperTests.cs
@@ -1,0 +1,82 @@
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class PLAmountExtensionsTests
+{
+    [Theory]
+    [InlineData("12.34", 1234L)]
+    [InlineData("0.005", 1L)]
+    [InlineData("-1.005", -101L)]
+    [InlineData("23", 2300L)]
+    public void ToGrosze_ShouldRoundAwayFromZero(string amount, long expected)
+        => decimal.Parse(amount, System.Globalization.CultureInfo.InvariantCulture).ToGrosze().Should().Be(expected);
+
+    [Fact]
+    public void GroszeToPln_ShouldRoundTrip()
+        => 1234L.GroszeToPln().Should().Be(12.34m);
+}
+
+public class PLDeviceInfoTests
+{
+    [Fact]
+    public void ToPLSSCDInfo_ShouldRoundTripThroughInfoData()
+    {
+        var deviceInfo = new PLDeviceInfo
+        {
+            DeviceSerialNumber = "ABC1234567",
+            UniqueDeviceNumber = "ZAS1234567890",
+            RegistrationNumber = "1234567890",
+            FiscalizationState = PLFiscalizationState.Fiscalized,
+            VatRateTable = new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } },
+            CrkReachable = true,
+            EReceiptCapable = true,
+            CurrentZReportNumber = 42,
+        };
+
+        var info = deviceInfo.ToPLSSCDInfo();
+        info.InfoData.Should().NotBeNullOrEmpty();
+
+        var roundTripped = PLDeviceInfo.FromPLSSCDInfo(info);
+        roundTripped.Should().BeEquivalentTo(deviceInfo);
+    }
+
+    [Fact]
+    public void FromPLSSCDInfo_ShouldReturnNull_WhenInfoDataIsNull()
+        => PLDeviceInfo.FromPLSSCDInfo(new ifPOS.v2.pl.PLSSCDInfo()).Should().BeNull();
+}
+
+public class PLStateMapperTests
+{
+    [Fact]
+    public void Map_ShouldFlagDeviceUnreachable()
+        => PLStateMapper.Map(new PLDeviceUnreachableException("printer offline"))
+            .Should().Be((State)0x504C_2001_EEEE_EEEE);
+
+    [Fact]
+    public void Map_ShouldReturnPlainError_ForOtherFailures()
+        => PLStateMapper.Map(new PLDeviceErrorException(2005, "no transaction mode"))
+            .Should().Be((State)0x504C_2000_EEEE_EEEE);
+}
+
+public class SignatureTypePLTests
+{
+    [Fact]
+    public void SignatureTypes_ShouldCarryThePLCountryCode()
+    {
+        foreach (SignatureTypePL type in Enum.GetValues(typeof(SignatureTypePL)))
+        {
+            ((SignatureType)(ulong)(long)type).Country().Should().Be("PL");
+        }
+    }
+
+    [Fact]
+    public void IsType_ShouldMatchOnTheLowestNibbles()
+        => ((SignatureType)0x504C_2000_0000_0104UL).IsType(SignatureTypePL.ZReportNumber).Should().BeTrue();
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
@@ -1,0 +1,128 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using fiskaltrust.Middleware.SCU.PL.InMemory;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class InMemorySCUTests
+{
+    private static ProcessRequest CreateRequest(ulong receiptCase) => new()
+    {
+        ReceiptRequest = new ReceiptRequest
+        {
+            cbReceiptReference = "pl-test",
+            ftReceiptCase = (ReceiptCase)receiptCase,
+        },
+        ReceiptResponse = new ReceiptResponse
+        {
+            ftCashBoxID = Guid.NewGuid(),
+            ftReceiptIdentification = "ft1#",
+        },
+    };
+
+    private const ulong CashSale = 0x504C_2000_0000_0001;
+    private const ulong DailyClosing = 0x504C_2000_0000_2011;
+    private const ulong ZeroReceipt = 0x504C_2000_0000_2000;
+    private const ulong Invoice = 0x504C_2000_0000_1001;
+
+    [Fact]
+    public async Task EchoAsync_ShouldMirrorMessage()
+    {
+        var scu = new InMemorySCU();
+        (await scu.EchoAsync(new EchoRequest { Message = "test" })).Message.Should().Be("test");
+    }
+
+    [Fact]
+    public async Task GetInfoAsync_ShouldExposeTypedDeviceInfo_ThroughInfoData()
+    {
+        var scu = new InMemorySCU();
+
+        var info = await scu.GetInfoAsync();
+        var deviceInfo = PLDeviceInfo.FromPLSSCDInfo(info);
+
+        deviceInfo.Should().NotBeNull();
+        deviceInfo!.FiscalizationState.Should().Be(PLFiscalizationState.Fiscalized);
+        deviceInfo.UniqueDeviceNumber.Should().NotBeNullOrEmpty();
+        deviceInfo.VatRateTable.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNumberReceiptsDeterministically()
+    {
+        var scu = new InMemorySCU();
+
+        var first = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+        var second = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        first.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#1");
+        second.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#2");
+        second.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.FiscalDocumentNumber) && x.Data == "2");
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldSetCashBoxIdentification_ToUniqueDeviceNumber()
+    {
+        var deviceInfo = InMemorySCU.CreateDefaultDeviceInfo();
+        var scu = new InMemorySCU(deviceInfo);
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        result.ReceiptResponse.ftCashBoxIdentification.Should().Be(deviceInfo.UniqueDeviceNumber);
+        result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.UniqueDeviceNumber));
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldIncrementZCounter_OnDailyClosing()
+    {
+        var scu = new InMemorySCU();
+
+        await scu.ProcessReceiptAsync(CreateRequest(DailyClosing));
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+
+        info!.CurrentZReportNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotNumberZeroReceipts()
+    {
+        var scu = new InMemorySCU();
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(ZeroReceipt));
+
+        result.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#");
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+        info!.CurrentZReportNumber.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldRejectInvoiceCases()
+    {
+        var scu = new InMemorySCU();
+
+        var act = () => scu.ProcessReceiptAsync(CreateRequest(Invoice));
+
+        await act.Should().ThrowAsync<PLValidationException>();
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldRunValidationHooks()
+    {
+        var seen = new List<string?>();
+        var scu = new InMemorySCU(validators: new Action<ProcessRequest>[]
+        {
+            request => seen.Add(request.ReceiptRequest.cbReceiptReference),
+            request => throw new PLValidationException("blocked by hook"),
+        });
+
+        var act = () => scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        await act.Should().ThrowAsync<PLValidationException>().WithMessage("blocked by hook");
+        seen.Should().ContainSingle().Which.Should().Be("pl-test");
+    }
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
@@ -101,6 +101,29 @@ public class InMemorySCUTests
     }
 
     [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotNumberNonFiscalReceiptCases()
+    {
+        var scu = new InMemorySCU();
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(0x504C_2000_0000_0003));
+
+        result.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#");
+        var next = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+        next.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#1");
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotAdvanceZCounter_OnMonthlyClosing()
+    {
+        var scu = new InMemorySCU();
+
+        await scu.ProcessReceiptAsync(CreateRequest(0x504C_2000_0000_2012));
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+
+        info!.CurrentZReportNumber.Should().Be(0);
+    }
+
+    [Fact]
     public async Task ProcessReceiptAsync_ShouldRejectInvoiceCases()
     {
         var scu = new InMemorySCU();

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/PtuSlotResolverTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/PtuSlotResolverTests.cs
@@ -1,0 +1,78 @@
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class PtuSlotResolverTests
+{
+    private static List<PLVatRateTableEntry> DefaultTable() => new()
+    {
+        new() { PtuSlot = "A", VatRatePercent = 23m },
+        new() { PtuSlot = "B", VatRatePercent = 8m },
+        new() { PtuSlot = "C", VatRatePercent = 5m },
+        new() { PtuSlot = "D", VatRatePercent = 0m },
+        new() { PtuSlot = "G", IsExempt = true },
+    };
+
+    [Theory]
+    [InlineData(ChargeItemCase.NormalVatRate, "A")]
+    [InlineData(ChargeItemCase.DiscountedVatRate1, "B")]
+    [InlineData(ChargeItemCase.DiscountedVatRate2, "C")]
+    [InlineData(ChargeItemCase.ZeroVatRate, "D")]
+    [InlineData(ChargeItemCase.NotTaxable, "G")]
+    public void Resolve_ShouldMapVatCase_ToDefaultSlots(ChargeItemCase vatCase, string expectedSlot)
+    {
+        var resolver = new PtuSlotResolver(DefaultTable());
+        var chargeItemCase = ((ChargeItemCase)0x504C_2000_0000_0000).WithVat(vatCase);
+
+        resolver.Resolve(chargeItemCase).PtuSlot.Should().Be(expectedSlot);
+    }
+
+    [Fact]
+    public void Resolve_ShouldFollowTheDeviceTable_NotHardcodedLetters()
+    {
+        // A register may have 23% programmed on a different slot — the device owns the assignment.
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry>
+        {
+            new() { PtuSlot = "B", VatRatePercent = 23m },
+            new() { PtuSlot = "E", IsExempt = true },
+        });
+
+        resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.NormalVatRate)).PtuSlot.Should().Be("B");
+        resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.NotTaxable)).PtuSlot.Should().Be("E");
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_WhenRateNotProgrammedOnDevice()
+    {
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } });
+
+        var act = () => resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.DiscountedVatRate1));
+
+        act.Should().Throw<PLValidationException>().WithMessage("*8%*");
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_ForVatCasesWithoutPolishMapping()
+    {
+        var resolver = new PtuSlotResolver(DefaultTable());
+
+        var act = () => resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.ParkingVatRate));
+
+        act.Should().Throw<PLValidationException>();
+    }
+
+    [Fact]
+    public void ResolveExempt_ShouldThrow_WhenNoExemptSlotExists()
+    {
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } });
+
+        var act = () => resolver.ResolveExempt();
+
+        act.Should().Throw<PLValidationException>().WithMessage("*zw.*");
+    }
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/fiskaltrust.Middleware.SCU.PL.UnitTest.csproj
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/fiskaltrust.Middleware.SCU.PL.UnitTest.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <LangVersion>Latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\fiskaltrust.Middleware.SCU.PL.InMemory\fiskaltrust.Middleware.SCU.PL.InMemory.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

The scu-pl market folder per [market-pl#50](https://github.com/fiskaltrust/market-pl/issues/50) (part of [market-pl#2](https://github.com/fiskaltrust/market-pl/issues/2), section 4), mirroring the scu-pt project shape:

**`fiskaltrust.Middleware.SCU.PL.Abstraction`**
- `PtuSlotResolver` — PTU slots resolved **at runtime against the device's VAT rate table**, never hardcoded (only the statutory case→rate mapping is fixed: Normal→23%, Discounted1→8%, Discounted2→5%, Zero→0%, NotTaxable→zw.)
- `SignatureTypePL` (0x504C_2000_0000_0101…0106: FiscalDocumentNumber, DeviceSerialNumber, UniqueDeviceNumber, ZReportNumber, EReceiptReference, StoredNotFiscalized) + `StatePL` with the **device-unreachable local flag** (no working register = no legal sale, Art. 111(3) VAT Act — queues/monitoring must distinguish this)
- `PLDeviceInfo` — the typed device state (fiscalization state, PTU table, CRK status, Z counter, numer fabryczny/unikatowy/ewidencyjny), serialized into `PLSSCDInfo.InfoData` per the generic-contract decision in middleware-interface-dotnet#105
- `PLFiscalCommand`, grosze/PLN helpers, SCU exception hierarchy → ftState mapping, and the single response-enrichment helper (`ftCashBoxIdentification` = numer unikatowy; `ftReceiptIdentification` += fiscal document number)

**`fiskaltrust.Middleware.SCU.PL.InMemory`** — deterministic `IPLSSCD` (fiscal document numbering, Z-report counter, validation hooks for device-behavior injection) so QueuePL acceptance tests run without hardware.

## Dependency note

Pins `fiskaltrust.interface **1.3.79-rc1-26216-90828**` — the exact CI package from the green master build of middleware-interface-dotnet#108 (exact pin because `TreatWarningsAsErrors` turns NU1603 into an error, same reason scu-pt pins `1.3.78-rc1-25294-86170`). The package still needs to be pushed to the middleware feed (staged with Stefan); until then only local builds against the build drop work.

## Test plan

- Solution builds with **0 warnings / 0 errors** (warnings-as-errors active)
- **28/28 unit tests pass**: PTU resolution incl. non-default slot layouts + missing-rate/missing-zw. failures, grosze rounding, InfoData round-trip, state mapping, signature-type country codes, InMemory numbering determinism, Z counter, invoice-case rejection, validation hooks

Note: no scu-pl CI workflow was added — scu-pt and scu-gr have none either (v2 SCUs are packaged via the slash-command flow).

**Tracked in** fiskaltrust/market-pl#50 (sub-issue of fiskaltrust/market-pl#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)