### PR TITLE
Add market PL to Test.Launcher.v2 with committed sample requests

### DIFF
--- a/queue/fiskaltrust.Middleware.sln
+++ b/queue/fiskaltrust.Middleware.sln
@@ -148,6 +148,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Middleware.Loca
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Middleware.Localization.QueuePT.AcceptanceTest", "test\fiskaltrust.Middleware.Localization.QueuePT.AcceptanceTest\fiskaltrust.Middleware.Localization.QueuePT.AcceptanceTest.csproj", "{CDDBA508-0669-026C-E379-9DE95EAAE1E8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Middleware.Localization.QueuePL", "src\fiskaltrust.Middleware.Localization.QueuePL\fiskaltrust.Middleware.Localization.QueuePL.csproj", "{E27C2D31-80BB-4278-A938-A2DA3C859F36}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Middleware.Localization.QueuePL.UnitTest", "test\fiskaltrust.Middleware.Localization.QueuePL.UnitTest\fiskaltrust.Middleware.Localization.QueuePL.UnitTest.csproj", "{5140AFD5-D555-4EEA-980B-F4C7E768C231}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest", "test\fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest\fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.csproj", "{CB31B1CF-5416-41CA-8347-695F7557E7FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -830,6 +836,42 @@ Global
 		{CDDBA508-0669-026C-E379-9DE95EAAE1E8}.Release|x64.Build.0 = Release|Any CPU
 		{CDDBA508-0669-026C-E379-9DE95EAAE1E8}.Release|x86.ActiveCfg = Release|Any CPU
 		{CDDBA508-0669-026C-E379-9DE95EAAE1E8}.Release|x86.Build.0 = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|x64.Build.0 = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Debug|x86.Build.0 = Debug|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|x64.ActiveCfg = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|x64.Build.0 = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|x86.ActiveCfg = Release|Any CPU
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36}.Release|x86.Build.0 = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|x64.Build.0 = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Debug|x86.Build.0 = Debug|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|x64.ActiveCfg = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|x64.Build.0 = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|x86.ActiveCfg = Release|Any CPU
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231}.Release|x86.Build.0 = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|x64.Build.0 = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Debug|x86.Build.0 = Debug|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|x64.ActiveCfg = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|x64.Build.0 = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|x86.ActiveCfg = Release|Any CPU
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -898,6 +940,9 @@ Global
 		{99B81AF4-7155-4734-09A5-D793DD150397} = {095CBF40-606D-4CC5-91E3-D009C271BC16}
 		{05278E6D-1E14-7BE6-C514-E4478F99BA1A} = {16BF88B4-3302-49F5-A5FA-5DA96DD03F0E}
 		{CDDBA508-0669-026C-E379-9DE95EAAE1E8} = {16BF88B4-3302-49F5-A5FA-5DA96DD03F0E}
+		{E27C2D31-80BB-4278-A938-A2DA3C859F36} = {08381205-3409-4468-92EB-ACA65F8D82FB}
+		{5140AFD5-D555-4EEA-980B-F4C7E768C231} = {EAEEF28B-F372-48C1-8F9B-45CEB95159A2}
+		{CB31B1CF-5416-41CA-8347-695F7557E7FB} = {EAEEF28B-F372-48C1-8F9B-45CEB95159A2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E8BEA609-BD83-4165-A14A-D010D2CC87AD}

--- a/queue/src/fiskaltrust.Middleware.Contracts/Models/StorageBaseInitConfiguration.cs
+++ b/queue/src/fiskaltrust.Middleware.Contracts/Models/StorageBaseInitConfiguration.cs
@@ -17,6 +17,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public List<ftQueueGR> QueuesGR { get; set; }
         public List<ftQueueIT> QueuesIT { get; set; }
         public List<ftQueueME> QueuesME { get; set; }
+        public List<ftQueuePL> QueuesPL { get; set; }
         public List<ftSignaturCreationUnitAT> SignaturCreationUnitsAT { get; set; }
         public List<ftSignaturCreationUnitBE> SignaturCreationUnitsBE { get; set; }
         public List<ftSignaturCreationUnitDE> SignaturCreationUnitsDE { get; set; }
@@ -25,6 +26,7 @@ namespace fiskaltrust.Middleware.Contracts.Models
         public List<ftSignaturCreationUnitGR> SignaturCreationUnitsGR { get; set; }
         public List<ftSignaturCreationUnitIT> SignaturCreationUnitsIT { get; set; }
         public List<ftSignaturCreationUnitME> SignaturCreationUnitsME { get; set; }
+        public List<ftSignaturCreationUnitPL> SignaturCreationUnitsPL { get; set; }
         public MasterDataConfiguration MasterData { get; set; }
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Factories/SignaturItemFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Factories/SignaturItemFactory.cs
@@ -1,0 +1,42 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.Localization.QueuePL.Models;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Factories;
+
+public static class SignaturItemFactory
+{
+    public static SignatureItem CreateInitialOperationSignature(ftQueue queue)
+    {
+        return new SignatureItem()
+        {
+            ftSignatureFormat = SignatureFormat.Text,
+            ftSignatureType = SignatureTypePL.InitialOperationReceipt.As<SignatureType>(),
+            Caption = $"Initial-operation receipt",
+            Data = $"Queue-ID: {queue.ftQueueId}"
+        };
+    }
+
+    public static SignatureItem CreateOutOfOperationSignature(ftQueue queue)
+    {
+        return new SignatureItem()
+        {
+            ftSignatureType = SignatureTypePL.OutOfOperationReceipt.As<SignatureType>(),
+            ftSignatureFormat = SignatureFormat.Text,
+            Caption = $"Out-of-operation receipt",
+            Data = $"Queue-ID: {queue.ftQueueId}"
+        };
+    }
+
+    public static SignatureItem CreateStoredNotFiscalizedSignature()
+    {
+        return new SignatureItem()
+        {
+            ftSignatureFormat = SignatureFormat.Text,
+            ftSignatureType = SignatureTypePL.StoredNotFiscalized.As<SignatureType>(),
+            Caption = "Stored, not fiscalized",
+            Data = "The invoice was persisted by the middleware but not transmitted to KSeF. Configure an SCU.PL.KSeF to fiscalize invoice cases."
+        };
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Factories/ftActionJournalFactory.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Factories/ftActionJournalFactory.cs
@@ -1,0 +1,68 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.Middleware.Localization.QueuePL.Models;
+using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.storage.V0;
+using Newtonsoft.Json;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Factories;
+
+public static class ftActionJournalFactory
+{
+    public static ftActionJournal CreateDailyClosingActionJournal(ftQueue queue, ReceiptRequest request, ReceiptResponse receiptResponse)
+    {
+        var ftReceiptCaseHex = request.ftReceiptCase.ToString("X");
+        return CreateActionJournal(receiptResponse.ftQueueID, ftReceiptCaseHex, receiptResponse.ftQueueItemID, $"Daily-Closing receipt was processed.", JsonConvert.SerializeObject(new { ftReceiptNumerator = queue.ftReceiptNumerator + 1 }));
+    }
+
+    public static ftActionJournal CreateMonthlyClosingActionJournal(ftQueue queue, ReceiptRequest request, ReceiptResponse receiptResponse)
+    {
+        var ftReceiptCaseHex = request.ftReceiptCase.ToString("X");
+        return CreateActionJournal(receiptResponse.ftQueueID, ftReceiptCaseHex, receiptResponse.ftQueueItemID, $"Monthly-Closing receipt was processed.", JsonConvert.SerializeObject(new { ftReceiptNumerator = queue.ftReceiptNumerator + 1 }));
+    }
+
+    public static ftActionJournal CreateInitialOperationActionJournal(ReceiptRequest request, ReceiptResponse receiptResponse)
+    {
+        var notification = new ActivateQueuePL
+        {
+            CashBoxId = request.ftCashBoxID!.Value,
+            QueueId = receiptResponse.ftQueueID,
+            Moment = DateTime.UtcNow,
+            IsStartReceipt = true,
+            Version = "V0",
+        };
+        return CreateActionJournal(receiptResponse.ftQueueID, $"{request.ftReceiptCase:X}-{nameof(ActivateQueuePL)}", receiptResponse.ftQueueItemID, $"Initial-Operation receipt. Queue-ID: {receiptResponse.ftQueueID}", JsonConvert.SerializeObject(notification));
+    }
+
+    public static ftActionJournal CreateWrongStateForInitialOperationActionJournal(ftQueue queue, ReceiptRequest request, ReceiptResponse receiptResponse, string message)
+    {
+        return CreateActionJournal(receiptResponse.ftQueueID, $"{request.ftReceiptCase:X}", receiptResponse.ftQueueItemID, message, "");
+    }
+
+    public static ftActionJournal CreateOutOfOperationActionJournal(ReceiptRequest request, ReceiptResponse receiptResponse)
+    {
+        var notification = new DeactivateQueuePL
+        {
+            CashBoxId = request.ftCashBoxID!.Value,
+            QueueId = receiptResponse.ftQueueID,
+            Moment = DateTime.UtcNow,
+            IsStopReceipt = true,
+            Version = "V0"
+        };
+        return CreateActionJournal(receiptResponse.ftQueueID, $"{request.ftReceiptCase:X}-{nameof(DeactivateQueuePL)}", receiptResponse.ftQueueItemID, $"Out-of-Operation receipt. Queue-ID: {receiptResponse.ftQueueID}", JsonConvert.SerializeObject(notification));
+    }
+
+    private static ftActionJournal CreateActionJournal(Guid queueId, string type, Guid queueItemId, string message, string data, int priority = -1)
+    {
+        return new ftActionJournal
+        {
+            ftActionJournalId = Guid.NewGuid(),
+            ftQueueId = queueId,
+            ftQueueItemId = queueItemId,
+            Type = type,
+            Moment = DateTime.UtcNow,
+            Message = message,
+            Priority = priority,
+            DataJson = data
+        };
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/ActivateQueuePL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/ActivateQueuePL.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Models;
+
+public class ActivateQueuePL
+{
+    public Guid CashBoxId { get; set; }
+    public Guid QueueId { get; set; }
+    public DateTime Moment { get; set; }
+    public bool IsStartReceipt { get; set; }
+    public string Version { get; set; } = "V0";
+}
+
+public class DeactivateQueuePL
+{
+    public Guid CashBoxId { get; set; }
+    public Guid QueueId { get; set; }
+    public DateTime Moment { get; set; }
+    public bool IsStopReceipt { get; set; }
+    public string Version { get; set; } = "V0";
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/Cases/SignatureTypePL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/Cases/SignatureTypePL.cs
@@ -1,0 +1,21 @@
+using System;
+using fiskaltrust.ifPOS.v2.Cases;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Models;
+
+public enum SignatureTypePL : long
+{
+    InitialOperationReceipt = 0x504C_2000_0000_0003,
+    OutOfOperationReceipt = 0x504C_2000_0000_0003,
+    /// <summary>Invoice cases (0x1xxx) are persisted but not fiscalized until an SCU.PL.KSeF is configured — value shared with SCU.PL.Abstraction.</summary>
+    StoredNotFiscalized = 0x504C_2000_0000_0106,
+}
+
+public static class SignatureTypePLExt
+{
+    public static T As<T>(this SignatureTypePL self) where T : Enum, IConvertible => (T) Enum.ToObject(typeof(T), self);
+
+    public static bool IsType(this SignatureType self, SignatureTypePL signatureTypePL) => ((long) self & 0xFFFF) == ((long) signatureTypePL & 0xFFFF);
+    public static SignatureType WithType(this SignatureType self, SignatureTypePL state) => (SignatureType) ((ulong) self & 0xFFFF_FFFF_FFFF_0000 | (ulong) state & 0xFFFF);
+    public static SignatureTypePL Type(this SignatureType self) => (SignatureTypePL) ((long) self & 0xFFFF);
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/PLSSCDInfoHelper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Models/PLSSCDInfoHelper.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2.pl;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Models;
+
+/// <summary>
+/// Reads the device state out of the generic <see cref="PLSSCDInfo.InfoData"/> blob. The blob's
+/// contract is the <c>PLDeviceInfo</c> model of <c>fiskaltrust.Middleware.SCU.PL.Abstraction</c>;
+/// the queue only needs the fiscalization state, so it parses that single property instead of
+/// referencing the SCU package.
+/// </summary>
+internal static class PLSSCDInfoHelper
+{
+    /// <summary>PLFiscalizationState.Fiscalized in SCU.PL.Abstraction.</summary>
+    private const int Fiscalized = 2;
+
+    public static bool IsFiscalized(PLSSCDInfo? info)
+    {
+        if (info?.InfoData is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(info.InfoData);
+            return document.RootElement.TryGetProperty("FiscalizationState", out var state)
+                && state.ValueKind == JsonValueKind.Number
+                && state.GetInt32() == Fiscalized;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/DailyOperationsCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/DailyOperationsCommandProcessorPL.cs
@@ -1,0 +1,46 @@
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.QueuePL.Factories;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+/// <summary>
+/// Daily operations map to register operations: the zero receipt reads the device status, the
+/// daily closing triggers the legally required daily (Z) report, monthly/yearly closings trigger
+/// the periodic report. All of them go through the SCU — the register owns the report counters.
+/// </summary>
+public class DailyOperationsCommandProcessorPL(IPLSSCD sscd) : IDailyOperationsCommandProcessor
+{
+    private readonly IPLSSCD _sscd = sscd;
+
+    public async Task<ProcessCommandResponse> ZeroReceipt0x2000Async(ProcessCommandRequest request) => await SubmitAsync(request);
+
+    public async Task<ProcessCommandResponse> OneReceipt0x2001Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> ShiftClosing0x2010Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> DailyClosing0x2011Async(ProcessCommandRequest request)
+    {
+        var response = await SubmitAsync(request);
+        return new ProcessCommandResponse(response.receiptResponse, [ftActionJournalFactory.CreateDailyClosingActionJournal(request.queue, request.ReceiptRequest, request.ReceiptResponse)]);
+    }
+
+    public async Task<ProcessCommandResponse> MonthlyClosing0x2012Async(ProcessCommandRequest request)
+    {
+        var response = await SubmitAsync(request);
+        return new ProcessCommandResponse(response.receiptResponse, [ftActionJournalFactory.CreateMonthlyClosingActionJournal(request.queue, request.ReceiptRequest, request.ReceiptResponse)]);
+    }
+
+    public async Task<ProcessCommandResponse> YearlyClosing0x2013Async(ProcessCommandRequest request) => await SubmitAsync(request);
+
+    private async Task<ProcessCommandResponse> SubmitAsync(ProcessCommandRequest request)
+    {
+        var response = await _sscd.ProcessReceiptAsync(new ProcessRequest
+        {
+            ReceiptRequest = request.ReceiptRequest,
+            ReceiptResponse = request.ReceiptResponse,
+        });
+        return new ProcessCommandResponse(response.ReceiptResponse, new List<ftActionJournal>());
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/InvoiceCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/InvoiceCommandProcessorPL.cs
@@ -1,0 +1,28 @@
+using fiskaltrust.Middleware.Localization.QueuePL.Factories;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+/// <summary>
+/// Invoice cases are deliberately NOT sent to the register — invoices are fiscalized via KSeF,
+/// not via the cash register. Until an SCU.PL.KSeF is configured the request/response pair is
+/// persisted as a queue item (done by the shared SignProcessor) and marked with an informational
+/// "stored, not fiscalized" signature. Switching to a KSeF processor later is a configuration
+/// change, not a breaking one.
+/// </summary>
+public class InvoiceCommandProcessorPL : IInvoiceCommandProcessor
+{
+    public Task<ProcessCommandResponse> InvoiceUnknown0x1000Async(ProcessCommandRequest request)
+    {
+        request.ReceiptResponse.AddSignatureItem(SignaturItemFactory.CreateStoredNotFiscalizedSignature());
+        return Task.FromResult(new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>()));
+    }
+
+    public Task<ProcessCommandResponse> InvoiceB2C0x1001Async(ProcessCommandRequest request) => InvoiceUnknown0x1000Async(request);
+
+    public Task<ProcessCommandResponse> InvoiceB2B0x1002Async(ProcessCommandRequest request) => InvoiceUnknown0x1000Async(request);
+
+    public Task<ProcessCommandResponse> InvoiceB2G0x1003Async(ProcessCommandRequest request) => InvoiceUnknown0x1000Async(request);
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/JournalProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/JournalProcessorPL.cs
@@ -1,0 +1,25 @@
+using System.Net.Mime;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+/// <summary>
+/// PL-specific journal exports. The international raw exports (0x…0000–0x…0002) are handled by
+/// the shared JournalProcessor; the first PL journal type will be JPK_FA (invoice records,
+/// Art. 193a Tax Ordinance on-demand structure) — tracked in fiskaltrust/market-pl#53.
+/// </summary>
+public class JournalProcessorPL : IJournalProcessor
+{
+    public (ContentType, IAsyncEnumerable<byte[]>) ProcessAsync(JournalRequest request)
+    {
+        return (new ContentType(MediaTypeNames.Application.Xml), ProcessJpkAsync(request));
+    }
+
+    private static async IAsyncEnumerable<byte[]> ProcessJpkAsync(JournalRequest request)
+    {
+        await Task.CompletedTask;
+        yield return Array.Empty<byte>();
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/LifecycleCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/LifecycleCommandProcessorPL.cs
@@ -1,0 +1,52 @@
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.QueuePL.Factories;
+using fiskaltrust.Middleware.Localization.QueuePL.Models;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.Localization.v2.Storage;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+/// <summary>
+/// Registers/deregisters the queue. There is no device-fiscalization command: fiscalizing a Polish
+/// register is a certified-technician (serwis) act, so the initial-operation receipt only verifies
+/// via GetInfo that the connected register reports itself as fiscalized.
+/// </summary>
+public class LifecycleCommandProcessorPL(IPLSSCD sscd, ILocalizedQueueStorageProvider localizedQueueStorageProvider) : ILifecycleCommandProcessor
+{
+    private readonly IPLSSCD _sscd = sscd;
+    private readonly ILocalizedQueueStorageProvider _localizedQueueStorageProvider = localizedQueueStorageProvider;
+
+    public async Task<ProcessCommandResponse> InitialOperationReceipt0x4001Async(ProcessCommandRequest request)
+    {
+        var (queue, receiptRequest, receiptResponse) = request;
+
+        var info = await _sscd.GetInfoAsync();
+        if (!PLSSCDInfoHelper.IsFiscalized(info))
+        {
+            var message = $"The connected register does not report FiscalizationState 'Fiscalized'. A Polish register must be fiscalized by an authorized serwis before the queue can start operating.";
+            receiptResponse.SetReceiptResponseError(message);
+            return new ProcessCommandResponse(receiptResponse, [ftActionJournalFactory.CreateWrongStateForInitialOperationActionJournal(queue, receiptRequest, receiptResponse, message)]);
+        }
+
+        var actionJournal = ftActionJournalFactory.CreateInitialOperationActionJournal(receiptRequest, receiptResponse);
+        await _localizedQueueStorageProvider.ActivateQueueAsync();
+        receiptResponse.AddSignatureItem(SignaturItemFactory.CreateInitialOperationSignature(queue));
+        return new ProcessCommandResponse(receiptResponse, [actionJournal]);
+    }
+
+    public async Task<ProcessCommandResponse> OutOfOperationReceipt0x4002Async(ProcessCommandRequest request)
+    {
+        var (queue, receiptRequest, receiptResponse) = request;
+        await _localizedQueueStorageProvider.DeactivateQueueAsync();
+        var actionJournal = ftActionJournalFactory.CreateOutOfOperationActionJournal(receiptRequest, receiptResponse);
+        receiptResponse.AddSignatureItem(SignaturItemFactory.CreateOutOfOperationSignature(queue));
+        receiptResponse.MarkAsDisabled();
+        return new ProcessCommandResponse(receiptResponse, [actionJournal]);
+    }
+
+    public async Task<ProcessCommandResponse> InitSCUSwitch0x4011Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> FinishSCUSwitch0x4012Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/PLFallBackOperations.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/PLFallBackOperations.cs
@@ -1,0 +1,12 @@
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+public static class PLFallBackOperations
+{
+    public static async Task<ProcessCommandResponse> NoOp(ProcessCommandRequest request) => await Task.FromResult(new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>())).ConfigureAwait(false);
+
+    public static Task<ProcessCommandResponse> NotSupported(ProcessCommandRequest request, string name) => throw new NotSupportedException($"The ftReceiptCase {name} - 0x{request.ReceiptRequest.ftReceiptCase.Case():x} is not supported in the QueuePL implementation.");
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ProtocolCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ProtocolCommandProcessorPL.cs
@@ -1,0 +1,25 @@
+using fiskaltrust.Middleware.Localization.v2;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+public class ProtocolCommandProcessorPL : IProtocolCommandProcessor
+{
+    public async Task<ProcessCommandResponse> ProtocolUnspecified0x3000Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> ProtocolTechnicalEvent0x3001Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> ProtocolAccountingEvent0x3002Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public Task<ProcessCommandResponse> InternalUsageMaterialConsumption0x3003Async(ProcessCommandRequest request) => PLFallBackOperations.NotSupported(request, "InternalUsageMaterialConsumption");
+
+    public async Task<ProcessCommandResponse> Order0x3004Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    public async Task<ProcessCommandResponse> Pay0x3005Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+
+    /// <summary>
+    /// Copies are served queue-side by replaying the stored response of the referenced receipt
+    /// (avoids a dependency on the register's e-journal). The replay wiring lands together with
+    /// the reference-resolution work; until then the case is acknowledged as a no-op.
+    /// </summary>
+    public async Task<ProcessCommandResponse> CopyReceiptPrintExistingReceipt0x3010Async(ProcessCommandRequest request) => await PLFallBackOperations.NoOp(request);
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ReceiptCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ReceiptCommandProcessorPL.cs
@@ -1,8 +1,11 @@
+using System.Text.Json;
 using fiskaltrust.ifPOS.v2;
 using fiskaltrust.ifPOS.v2.Cases;
 using fiskaltrust.ifPOS.v2.pl;
 using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Helpers;
 using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.Localization.v2.Models;
 using fiskaltrust.storage.V0;
 
 namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
@@ -40,9 +43,9 @@ public class ReceiptCommandProcessorPL(IPLSSCD sscd) : IReceiptCommandProcessor
             return new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>());
         }
 
-        if (request.ReceiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.ReceiverIsBusiness) && string.IsNullOrEmpty(request.ReceiptRequest.cbCustomer?.ToString()))
+        if (request.ReceiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.ReceiverIsBusiness) && string.IsNullOrWhiteSpace(GetCustomerVatId(request.ReceiptRequest)))
         {
-            request.ReceiptResponse.SetReceiptResponseError("A NIP receipt (paragon z NIP) requires the buyer's NIP in cbCustomer. Until 2026-12-31 such receipts up to 450 PLN act as simplified invoices.");
+            request.ReceiptResponse.SetReceiptResponseError("A NIP receipt (paragon z NIP) requires the buyer's NIP as CustomerVATId in cbCustomer. Until 2026-12-31 such receipts up to 450 PLN act as simplified invoices.");
             return new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>());
         }
 
@@ -56,9 +59,29 @@ public class ReceiptCommandProcessorPL(IPLSSCD sscd) : IReceiptCommandProcessor
 
     private static bool HasMixedSaleAndReturn(ReceiptRequest request)
     {
+        // Discounts/extras and voids are position modifiers, not return positions — only a
+        // genuinely negative sale line makes the document a return.
         var chargeItems = request.cbChargeItems ?? new List<ChargeItem>();
-        var hasPositive = chargeItems.Any(x => x.Amount > 0);
-        var hasNegative = chargeItems.Any(x => x.Amount < 0);
-        return hasPositive && hasNegative;
+        var hasSalePosition = chargeItems.Any(x => x.Amount > 0 && !x.IsDiscountOrExtra() && !x.IsVoid());
+        var hasReturnPosition = chargeItems.Any(x => x.Amount < 0 && !x.IsDiscountOrExtra() && !x.IsVoid());
+        return hasSalePosition && hasReturnPosition;
+    }
+
+    private static string? GetCustomerVatId(ReceiptRequest request)
+    {
+        var cbCustomer = request.cbCustomer?.ToString();
+        if (string.IsNullOrWhiteSpace(cbCustomer))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<MiddlewareCustomer>(cbCustomer, new JsonSerializerOptions { PropertyNameCaseInsensitive = true })?.CustomerVATId;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ReceiptCommandProcessorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Processors/ReceiptCommandProcessorPL.cs
@@ -1,0 +1,64 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Processors;
+
+/// <summary>
+/// Passes receipts through to the register SCU after validating the protocol constraints the
+/// device would reject anyway. Tax-class immutability (item name ↔ PTU slot) is enforced by the
+/// register's product database and therefore stays device-side.
+/// </summary>
+public class ReceiptCommandProcessorPL(IPLSSCD sscd) : IReceiptCommandProcessor
+{
+    private readonly IPLSSCD _sscd = sscd;
+
+    public async Task<ProcessCommandResponse> UnknownReceipt0x0000Async(ProcessCommandRequest request) => await PointOfSaleReceipt0x0001Async(request);
+
+    public Task<ProcessCommandResponse> PointOfSaleReceipt0x0001Async(ProcessCommandRequest request) => SubmitAsync(request);
+
+    public Task<ProcessCommandResponse> PaymentTransfer0x0002Async(ProcessCommandRequest request) => PLFallBackOperations.NoOp(request);
+
+    public Task<ProcessCommandResponse> PointOfSaleReceiptWithoutObligation0x0003Async(ProcessCommandRequest request) => PLFallBackOperations.NoOp(request);
+
+    public Task<ProcessCommandResponse> ECommerce0x0004Async(ProcessCommandRequest request) => SubmitAsync(request);
+
+    public Task<ProcessCommandResponse> DeliveryNote0x0005Async(ProcessCommandRequest request) => PLFallBackOperations.NotSupported(request, "DeliveryNote");
+
+    public Task<ProcessCommandResponse> TableCheck0x0006Async(ProcessCommandRequest request) => PLFallBackOperations.NotSupported(request, "TableCheck");
+
+    public Task<ProcessCommandResponse> ProForma0x0007Async(ProcessCommandRequest request) => PLFallBackOperations.NotSupported(request, "ProForma");
+
+    private async Task<ProcessCommandResponse> SubmitAsync(ProcessCommandRequest request)
+    {
+        if (HasMixedSaleAndReturn(request.ReceiptRequest))
+        {
+            request.ReceiptResponse.SetReceiptResponseError("A Polish fiscal document must not mix sale and return positions — the register protocol processes returns as separate non-fiscal documents. Send the return as its own receipt (flag Refund, 0x0100_0000).");
+            return new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>());
+        }
+
+        if (request.ReceiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.ReceiverIsBusiness) && string.IsNullOrEmpty(request.ReceiptRequest.cbCustomer?.ToString()))
+        {
+            request.ReceiptResponse.SetReceiptResponseError("A NIP receipt (paragon z NIP) requires the buyer's NIP in cbCustomer. Until 2026-12-31 such receipts up to 450 PLN act as simplified invoices.");
+            return new ProcessCommandResponse(request.ReceiptResponse, new List<ftActionJournal>());
+        }
+
+        var response = await _sscd.ProcessReceiptAsync(new ProcessRequest
+        {
+            ReceiptRequest = request.ReceiptRequest,
+            ReceiptResponse = request.ReceiptResponse,
+        });
+        return new ProcessCommandResponse(response.ReceiptResponse, new List<ftActionJournal>());
+    }
+
+    private static bool HasMixedSaleAndReturn(ReceiptRequest request)
+    {
+        var chargeItems = request.cbChargeItems ?? new List<ChargeItem>();
+        var hasPositive = chargeItems.Any(x => x.Amount > 0);
+        var hasNegative = chargeItems.Any(x => x.Amount < 0);
+        return hasPositive && hasNegative;
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/QueuePLBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/QueuePLBootstrapper.cs
@@ -26,14 +26,24 @@ public class QueuePLBootstrapper : IV2QueueBootstrapper
         var queueStorageProvider = new QueueStorageProvider(id, storageProvider);
         var queueItemRepository = storageProvider.CreateMiddlewareQueueItemRepository();
 
+        // PL launches with enforcing validation: there are no legacy integrations to stay
+        // compatible with, and the queue currency rule (PLN, rfcs/0705-queue-single-currency)
+        // must reject rather than log. A configured ValidationLevel still takes precedence.
+        var validationConfig = ValidationConfiguration.FromConfiguration(configuration);
+        if (validationConfig.ValidationLevel is null)
+        {
+            validationConfig = new ValidationConfiguration { ValidationLevel = ValidationLevel.Error, ValidationsInSignatures = validationConfig.ValidationsInSignatures };
+        }
+
         var signProcessorPL = new ReceiptProcessor(
             loggerFactory.CreateLogger<ReceiptProcessor>(),
-            new ReceiptReferenceProvider(queueItemRepository),
+            new Validation.ReceiptValidatorPL(new ReceiptReferenceProvider(queueItemRepository)),
             new LifecycleCommandProcessorPL(plSSCD, queueStorageProvider),
             new ReceiptCommandProcessorPL(plSSCD),
             new DailyOperationsCommandProcessorPL(plSSCD),
             new InvoiceCommandProcessorPL(),
-            new ProtocolCommandProcessorPL());
+            new ProtocolCommandProcessorPL(),
+            validationConfig);
         var signProcessor = new SignProcessor(loggerFactory.CreateLogger<SignProcessor>(), queueStorageProvider, signProcessorPL.ProcessAsync, cashBoxIdentification, middlewareConfiguration);
         var journalProcessor = new JournalProcessor(storageProvider, new JournalProcessorPL(), configuration, loggerFactory.CreateLogger<JournalProcessor>());
         _queue = new Queue(signProcessor, journalProcessor, loggerFactory)

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/QueuePLBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/QueuePLBootstrapper.cs
@@ -1,0 +1,60 @@
+using System.IO.Pipelines;
+using System.Net.Mime;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.QueuePL.Processors;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Configuration;
+using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.Localization.v2.Storage;
+using Microsoft.Extensions.Logging;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL;
+
+public class QueuePLBootstrapper : IV2QueueBootstrapper
+{
+    private readonly Queue _queue;
+
+    public QueuePLBootstrapper(Guid id, ILoggerFactory loggerFactory, Dictionary<string, object> configuration, IPLSSCD plSSCD)
+        : this(id, loggerFactory, configuration, plSSCD, new AzureStorageProvider(loggerFactory, id, configuration)) { }
+
+    public QueuePLBootstrapper(Guid id, ILoggerFactory loggerFactory, Dictionary<string, object> configuration, IPLSSCD plSSCD, IStorageProvider storageProvider)
+    {
+        var middlewareConfiguration = MiddlewareConfigurationFactory.CreateMiddlewareConfiguration(id, configuration);
+        var cashBoxIdentification = new AsyncLazy<string>(async () => (await (await storageProvider.CreateConfigurationRepository()).GetQueuePLAsync(id)).CashBoxIdentification);
+
+        var queueStorageProvider = new QueueStorageProvider(id, storageProvider);
+        var queueItemRepository = storageProvider.CreateMiddlewareQueueItemRepository();
+
+        var signProcessorPL = new ReceiptProcessor(
+            loggerFactory.CreateLogger<ReceiptProcessor>(),
+            new ReceiptReferenceProvider(queueItemRepository),
+            new LifecycleCommandProcessorPL(plSSCD, queueStorageProvider),
+            new ReceiptCommandProcessorPL(plSSCD),
+            new DailyOperationsCommandProcessorPL(plSSCD),
+            new InvoiceCommandProcessorPL(),
+            new ProtocolCommandProcessorPL());
+        var signProcessor = new SignProcessor(loggerFactory.CreateLogger<SignProcessor>(), queueStorageProvider, signProcessorPL.ProcessAsync, cashBoxIdentification, middlewareConfiguration);
+        var journalProcessor = new JournalProcessor(storageProvider, new JournalProcessorPL(), configuration, loggerFactory.CreateLogger<JournalProcessor>());
+        _queue = new Queue(signProcessor, journalProcessor, loggerFactory)
+        {
+            Id = id,
+            Configuration = configuration,
+        };
+    }
+
+    public Func<string, Task<string>> RegisterForSign()
+    {
+        return _queue.RegisterForSign();
+    }
+
+    public Func<string, Task<string>> RegisterForEcho()
+    {
+        return _queue.RegisterForEcho();
+    }
+
+    public Func<string, Task<(ContentType contentType, PipeReader reader)>> RegisterForJournal()
+    {
+        return _queue.RegisterForJournal();
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Validation/ReceiptValidatorPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/Validation/ReceiptValidatorPL.cs
@@ -1,0 +1,42 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.Middleware.Localization.v2.Validation;
+using FluentValidation;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.Validation;
+
+/// <summary>
+/// PL market validations. The queue currency for Poland is PLN (rfcs/0705-queue-single-currency):
+/// a queue totalizes in exactly one currency, so every receipt — and every charge/pay item on it —
+/// must carry PLN. Currency defaults to EUR in the data format, so PosCreators must set it explicitly.
+/// </summary>
+public class ReceiptValidationsPL : AbstractValidator<ReceiptRequest>
+{
+    public ReceiptValidationsPL()
+    {
+        RuleFor(x => x.Currency)
+            .Equal(Currency.PLN)
+            .WithMessage(request => $"Expected currency PLN for this queue but received '{request.Currency}'.")
+            .WithErrorCode("CurrencyMustMatchMarket");
+
+        RuleForEach(x => x.cbChargeItems)
+            .Must((request, chargeItem) => chargeItem.Currency == request.Currency)
+            .WithMessage((request, chargeItem) => $"Charge item '{chargeItem.Description}' has currency '{chargeItem.Currency}' but the receipt currency is '{request.Currency}'.")
+            .WithErrorCode("CurrencyMustMatchMarket");
+
+        RuleForEach(x => x.cbPayItems)
+            .Must((request, payItem) => payItem.Currency == request.Currency)
+            .WithMessage((request, payItem) => $"Pay item '{payItem.Description}' has currency '{payItem.Currency}' but the receipt currency is '{request.Currency}'.")
+            .WithErrorCode("CurrencyMustMatchMarket");
+    }
+}
+
+public class ReceiptValidatorPL : MarketValidator
+{
+    public ReceiptValidatorPL(ReceiptReferenceProvider receiptReferenceProvider) : base(receiptReferenceProvider) { }
+
+    protected override IEnumerable<IValidator<ReceiptRequest>> GetMarketValidators(ReceiptResponse? response = null, object? numberSeries = null)
+    {
+        yield return new ReceiptValidationsPL();
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePL/fiskaltrust.Middleware.Localization.QueuePL.csproj
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePL/fiskaltrust.Middleware.Localization.QueuePL.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <LangVersion>Latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.4" />
+        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Update="fiskaltrust.interface" Version="1.3.79-rc1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\fiskaltrust.Middleware.Localization.v2\fiskaltrust.Middleware.Localization.v2.csproj" />
+        <ProjectReference Include="..\fiskaltrust.Middleware.Storage.AzureTableStorage\fiskaltrust.Middleware.Storage.AzureTableStorage.csproj" />
+        <ProjectReference Include="..\fiskaltrust.Middleware.Storage\fiskaltrust.Middleware.Storage.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="fiskaltrust.Middleware.Localization.QueuePL.UnitTest" />
+        <InternalsVisibleTo Include="fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest" />
+    </ItemGroup>
+
+</Project>

--- a/queue/src/fiskaltrust.Middleware.Localization.v2/JournalProcessor.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.v2/JournalProcessor.cs
@@ -162,6 +162,7 @@ public class JournalProcessor
             QueueGRList = await configurationRepository.GetQueueGRListAsync().ConfigureAwait(false),
             QueueITList = await configurationRepository.GetQueueITListAsync().ConfigureAwait(false),
             QueueMEList = await configurationRepository.GetQueueMEListAsync().ConfigureAwait(false),
+            QueuePLList = await configurationRepository.GetQueuePLListAsync().ConfigureAwait(false),
             QueuePTList = GetConfigurationFromDictionary<ftQueuePT>("init_ftQueuePT"),
             SignaturCreationUnitATList = await configurationRepository.GetSignaturCreationUnitATListAsync().ConfigureAwait(false),
             SignaturCreationUnitBEList = await configurationRepository.GetSignaturCreationUnitBEListAsync().ConfigureAwait(false),
@@ -171,6 +172,7 @@ public class JournalProcessor
             SignaturCreationUnitGRList = await configurationRepository.GetSignaturCreationUnitGRListAsync().ConfigureAwait(false),
             SignaturCreationUnitITList = await configurationRepository.GetSignaturCreationUnitITListAsync().ConfigureAwait(false),
             SignaturCreationUnitMEList = await configurationRepository.GetSignaturCreationUnitMEListAsync().ConfigureAwait(false),
+            SignaturCreationUnitPLList = await configurationRepository.GetSignaturCreationUnitPLListAsync().ConfigureAwait(false),
             SignaturCreationUnitPTList = GetConfigurationFromDictionary<ftSignaturCreationUnitPT>("init_ftSignaturCreationUnitPT"),
         };
     }

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/DatabaseMigrator.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/DatabaseMigrator.cs
@@ -40,6 +40,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage
                 new Migration_005_JournalES(_tableServiceClient, queueConfiguration),
                 new Migration_006_GR(_tableServiceClient, queueConfiguration),
                 new Migration_007_BE(_tableServiceClient, queueConfiguration),
+                new Migration_008_PL(_tableServiceClient, queueConfiguration),
             };
         }
 

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Migrations/Migration_008_PL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Migrations/Migration_008_PL.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Migrations
+{
+    public class Migration_008_PL : IAzureTableStorageMigration
+    {
+        private readonly TableServiceClient _tableServiceClient;
+        private readonly QueueConfiguration _queueConfiguration;
+
+        public Migration_008_PL(TableServiceClient tableServiceClient, QueueConfiguration queueConfiguration)
+        {
+            _tableServiceClient = tableServiceClient;
+            _queueConfiguration = queueConfiguration;
+        }
+
+        public int Version => 8;
+
+        public async Task ExecuteAsync()
+        {
+            await _tableServiceClient.CreateTableIfNotExistsAsync(GetTableName(AzureTableStorageQueuePLRepository.TABLE_NAME));
+            await _tableServiceClient.CreateTableIfNotExistsAsync(GetTableName(AzureTableStorageSignaturCreationUnitPLRepository.TABLE_NAME));
+        }
+
+        private string GetTableName(string entityName) => $"x{_queueConfiguration.QueueId.ToString().Replace("-", "")}{entityName}";
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/AzureTableStorageConfigurationRepository.cs
@@ -20,6 +20,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         private readonly AzureTableStorageQueueGRRepository _queueGRRepository;
         private readonly AzureTableStorageQueueITRepository _queueITRepository;
         private readonly AzureTableStorageQueueMERepository _queueMERepository;
+        private readonly AzureTableStorageQueuePLRepository _queuePLRepository;
         private readonly AzureTableStorageSignaturCreationUnitATRepository _signaturCreationUnitATRepository;
         private readonly AzureTableStorageSignaturCreationUnitBERepository _signaturCreationUnitBERepository;
         private readonly AzureTableStorageSignaturCreationUnitDERepository _signaturCreationUnitDERepository;
@@ -28,6 +29,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         private readonly AzureTableStorageSignaturCreationUnitGRRepository _signaturCreationUnitGRRepository;
         private readonly AzureTableStorageSignaturCreationUnitITRepository _signaturCreationUnitITRepository;
         private readonly AzureTableStorageSignaturCreationUnitMERepository _signaturCreationUnitMERepository;
+        private readonly AzureTableStorageSignaturCreationUnitPLRepository _signaturCreationUnitPLRepository;
 
         public AzureTableStorageConfigurationRepository() { }
 
@@ -44,6 +46,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
             _queueGRRepository = new AzureTableStorageQueueGRRepository(queueConfig, tableServiceClient);
             _queueITRepository = new AzureTableStorageQueueITRepository(queueConfig, tableServiceClient);
             _queueMERepository = new AzureTableStorageQueueMERepository(queueConfig, tableServiceClient);
+            _queuePLRepository = new AzureTableStorageQueuePLRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitATRepository = new AzureTableStorageSignaturCreationUnitATRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitBERepository = new AzureTableStorageSignaturCreationUnitBERepository(queueConfig, tableServiceClient);
             _signaturCreationUnitDERepository = new AzureTableStorageSignaturCreationUnitDERepository(queueConfig, tableServiceClient);
@@ -52,6 +55,7 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
             _signaturCreationUnitGRRepository = new AzureTableStorageSignaturCreationUnitGRRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitITRepository = new AzureTableStorageSignaturCreationUnitITRepository(queueConfig, tableServiceClient);
             _signaturCreationUnitMERepository = new AzureTableStorageSignaturCreationUnitMERepository(queueConfig, tableServiceClient);
+            _signaturCreationUnitPLRepository = new AzureTableStorageSignaturCreationUnitPLRepository(queueConfig, tableServiceClient);
         }
 
         public async Task<ftCashBox> GetCashBoxAsync(Guid cashBoxId) => await _cashBoxRepository.GetAsync(cashBoxId).ConfigureAwait(false);
@@ -98,6 +102,10 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         public async Task<IEnumerable<ftQueueME>> GetQueueMEListAsync() => await _queueMERepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateQueueMEAsync(ftQueueME queue) => await _queueMERepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
 
+        public async Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => await _queuePLRepository.GetAsync(queuePLId).ConfigureAwait(false);
+        public async Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => await _queuePLRepository.GetAsync().ConfigureAwait(false);
+        public async Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => await _queuePLRepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -122,6 +130,10 @@ namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories
         public async Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid id) => await _signaturCreationUnitGRRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => await _signaturCreationUnitGRRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => await _signaturCreationUnitGRRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
+
+        public async Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid id) => await _signaturCreationUnitPLRepository.GetAsync(id).ConfigureAwait(false);
+        public async Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => await _signaturCreationUnitPLRepository.GetAsync().ConfigureAwait(false);
+        public async Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => await _signaturCreationUnitPLRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
 
         public async Task<ftSignaturCreationUnitIT> GetSignaturCreationUnitITAsync(Guid id) => await _signaturCreationUnitITRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitIT>> GetSignaturCreationUnitITListAsync() => await _signaturCreationUnitITRepository.GetAsync().ConfigureAwait(false);

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageQueuePLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageQueuePLRepository.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration
+{
+    public class AzureTableStorageQueuePLRepository : BaseAzureTableStorageRepository<Guid, AzureTableStorageFtQueuePL, ftQueuePL>
+    {
+        public AzureTableStorageQueuePLRepository(QueueConfiguration queueConfig, TableServiceClient tableServiceClient)
+            : base(queueConfig, tableServiceClient, TABLE_NAME) { }
+
+        public const string TABLE_NAME = "QueuePL";
+
+        protected override void EntityUpdated(ftQueuePL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftQueuePL entity) => entity.ftQueuePLId;
+
+        public async Task InsertOrUpdateAsync(ftQueuePL storageEntity)
+        {
+            EntityUpdated(storageEntity);
+            var entity = MapToAzureEntity(storageEntity);
+            await _tableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+        }
+
+        protected override AzureTableStorageFtQueuePL MapToAzureEntity(ftQueuePL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new AzureTableStorageFtQueuePL
+            {
+                PartitionKey = src.ftQueuePLId.ToString(),
+                RowKey = src.ftQueuePLId.ToString(),
+                ftQueuePLId = src.ftQueuePLId,
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                CashBoxIdentification = src.CashBoxIdentification,
+                SSCDFailCount = src.SSCDFailCount,
+                SSCDFailMoment = src.SSCDFailMoment?.ToUniversalTime(),
+                SSCDFailQueueItemId = src.SSCDFailQueueItemId,
+                UsedFailedCount = src.UsedFailedCount,
+                UsedFailedMomentMin = src.UsedFailedMomentMin?.ToUniversalTime(),
+                UsedFailedMomentMax = src.UsedFailedMomentMax?.ToUniversalTime(),
+                UsedFailedQueueItemId = src.UsedFailedQueueItemId,
+                TimeStamp = src.TimeStamp,
+            };
+        }
+
+        protected override ftQueuePL MapToStorageEntity(AzureTableStorageFtQueuePL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new ftQueuePL
+            {
+                ftQueuePLId = src.ftQueuePLId,
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                CashBoxIdentification = src.CashBoxIdentification,
+                SSCDFailCount = src.SSCDFailCount,
+                SSCDFailMoment = src.SSCDFailMoment,
+                SSCDFailQueueItemId = src.SSCDFailQueueItemId,
+                UsedFailedCount = src.UsedFailedCount,
+                UsedFailedMomentMin = src.UsedFailedMomentMin,
+                UsedFailedMomentMax = src.UsedFailedMomentMax,
+                UsedFailedQueueItemId = src.UsedFailedQueueItemId,
+                TimeStamp = src.TimeStamp,
+            };
+        }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageSignaturCreationUnitPLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/Repositories/Configuration/AzureTableStorageSignaturCreationUnitPLRepository.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Threading.Tasks;
+using Azure.Data.Tables;
+using fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.Repositories.Configuration
+{
+    public class AzureTableStorageSignaturCreationUnitPLRepository : BaseAzureTableStorageRepository<Guid, AzureTableStorageFtSignaturCreationUnitPL, ftSignaturCreationUnitPL>
+    {
+        public AzureTableStorageSignaturCreationUnitPLRepository(QueueConfiguration queueConfig, TableServiceClient tableServiceClient)
+            : base(queueConfig, tableServiceClient, TABLE_NAME) { }
+
+        public const string TABLE_NAME = "SignaturCreationUnitPL";
+
+        protected override void EntityUpdated(ftSignaturCreationUnitPL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftSignaturCreationUnitPL entity) => entity.ftSignaturCreationUnitPLId;
+
+        public async Task InsertOrUpdateAsync(ftSignaturCreationUnitPL storageEntity)
+        {
+            EntityUpdated(storageEntity);
+            var entity = MapToAzureEntity(storageEntity);
+            await _tableClient.UpsertEntityAsync(entity, TableUpdateMode.Replace);
+        }
+
+        protected override AzureTableStorageFtSignaturCreationUnitPL MapToAzureEntity(ftSignaturCreationUnitPL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new AzureTableStorageFtSignaturCreationUnitPL
+            {
+                PartitionKey = src.ftSignaturCreationUnitPLId.ToString(),
+                RowKey = src.ftSignaturCreationUnitPLId.ToString(),
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                Url = src.Url,
+                InfoJson = src.InfoJson,
+                TimeStamp = src.TimeStamp
+            };
+        }
+
+        protected override ftSignaturCreationUnitPL MapToStorageEntity(AzureTableStorageFtSignaturCreationUnitPL src)
+        {
+            if (src == null)
+            {
+                return null;
+            }
+
+            return new ftSignaturCreationUnitPL
+            {
+                ftSignaturCreationUnitPLId = src.ftSignaturCreationUnitPLId,
+                Url = src.Url,
+                InfoJson = src.InfoJson,
+                TimeStamp = src.TimeStamp
+            };
+        }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtQueuePL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtQueuePL.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration
+{
+    public class AzureTableStorageFtQueuePL : BaseTableEntity
+    {
+        public Guid ftQueuePLId { get; set; }
+        public Guid? ftSignaturCreationUnitPLId { get; set; }
+        public string CashBoxIdentification { get; set; }
+
+        public int SSCDFailCount { get; set; }
+        public DateTime? SSCDFailMoment { get; set; }
+        public Guid? SSCDFailQueueItemId { get; set; }
+
+        public int UsedFailedCount { get; set; }
+        public DateTime? UsedFailedMomentMin { get; set; }
+        public DateTime? UsedFailedMomentMax { get; set; }
+        public Guid? UsedFailedQueueItemId { get; set; }
+
+        public long TimeStamp { get; set; }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtSignaturCreationUnitPL.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.AzureTableStorage/TableEntities/Configuration/AzureTableStorageFtSignaturCreationUnitPL.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace fiskaltrust.Middleware.Storage.AzureTableStorage.TableEntities.Configuration
+{
+    public class AzureTableStorageFtSignaturCreationUnitPL : BaseTableEntity
+    {
+        public Guid ftSignaturCreationUnitPLId { get; set; }
+        public string Url { get; set; }
+        public string InfoJson { get; set; }
+        public long TimeStamp { get; set; }
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
@@ -174,11 +174,13 @@ namespace fiskaltrust.Middleware.Storage.Base
             await InitQueueFRAsync(config.QueuesFR, configurationRepository).ConfigureAwait(false);
             await InitQueueITAsync(config.QueuesIT, configurationRepository).ConfigureAwait(false);
             await InitQueueMEAsync(config.QueuesME, configurationRepository).ConfigureAwait(false);
+            await InitQueuePLAsync(config.QueuesPL, configurationRepository).ConfigureAwait(false);
             await InitSignaturCreationUnitATAsync(config.SignaturCreationUnitsAT, configurationRepository).ConfigureAwait(false);
             await InitSignaturCreationUnitFRAsync(config.SignaturCreationUnitsFR, configurationRepository).ConfigureAwait(false);
             await InitSignaturCreationUnitDEAsync(config.SignaturCreationUnitsDE, configurationRepository, enforceUpdateUserDefinedConfig).ConfigureAwait(false);
             await InitSignaturCreationUnitITAsync(config.SignaturCreationUnitsIT, configurationRepository, enforceUpdateUserDefinedConfig).ConfigureAwait(false);
             await InitSignaturCreationUnitMEAsync(config.SignaturCreationUnitsME, configurationRepository).ConfigureAwait(false);
+            await InitSignaturCreationUnitPLAsync(config.SignaturCreationUnitsPL, configurationRepository).ConfigureAwait(false);
         }
 
         private T ParseParameter<T>(Dictionary<string, object> config, string key) where T : new()

--- a/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.Base/BaseStorageBootStrapper.cs
@@ -31,6 +31,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 QueuesGR = ParseParameter<List<ftQueueGR>>(configuration, "init_ftQueueGR") ?? new List<ftQueueGR>(),
                 QueuesIT = ParseParameter<List<ftQueueIT>>(configuration, "init_ftQueueIT") ?? new List<ftQueueIT>(),
                 QueuesME = ParseParameter<List<ftQueueME>>(configuration, "init_ftQueueME") ?? new List<ftQueueME>(),
+                QueuesPL = ParseParameter<List<ftQueuePL>>(configuration, "init_ftQueuePL") ?? new List<ftQueuePL>(),
                 CashBox = ParseParameter<ftCashBox>(configuration, "init_ftCashBox"),
                 SignaturCreationUnitsAT = ParseParameter<List<ftSignaturCreationUnitAT>>(configuration, "init_ftSignaturCreationUnitAT") ?? new List<ftSignaturCreationUnitAT>(),
                 SignaturCreationUnitsBE = ParseParameter<List<ftSignaturCreationUnitBE>>(configuration, "init_ftSignaturCreationUnitBE") ?? new List<ftSignaturCreationUnitBE>(),
@@ -40,6 +41,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 SignaturCreationUnitsGR = ParseParameter<List<ftSignaturCreationUnitGR>>(configuration, "init_ftSignaturCreationUnitGR") ?? new List<ftSignaturCreationUnitGR>(),
                 SignaturCreationUnitsME = ParseParameter<List<ftSignaturCreationUnitME>>(configuration, "init_ftSignaturCreationUnitME") ?? new List<ftSignaturCreationUnitME>(),
                 SignaturCreationUnitsIT = ParseParameter<List<ftSignaturCreationUnitIT>>(configuration, "init_ftSignaturCreationUnitIT") ?? new List<ftSignaturCreationUnitIT>(),
+                SignaturCreationUnitsPL = ParseParameter<List<ftSignaturCreationUnitPL>>(configuration, "init_ftSignaturCreationUnitPL") ?? new List<ftSignaturCreationUnitPL>(),
                 MasterData = ParseParameter<MasterDataConfiguration>(configuration, "init_masterData")
             };
         }
@@ -146,6 +148,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 InitQueueGRAsync(config.QueuesGR, configurationRepository),
                 InitQueueMEAsync(config.QueuesME, configurationRepository),
                 InitQueueITAsync(config.QueuesIT, configurationRepository),
+                InitQueuePLAsync(config.QueuesPL, configurationRepository),
                 InitSignaturCreationUnitATAsync(config.SignaturCreationUnitsAT, configurationRepository),
                 InitSignaturCreationUnitBEAsync(config.SignaturCreationUnitsBE, configurationRepository),
                 InitSignaturCreationUnitFRAsync(config.SignaturCreationUnitsFR, configurationRepository),
@@ -154,6 +157,7 @@ namespace fiskaltrust.Middleware.Storage.Base
                 InitSignaturCreationUnitGRAsync(config.SignaturCreationUnitsGR, configurationRepository),
                 InitSignaturCreationUnitITAsync(config.SignaturCreationUnitsIT, configurationRepository, enforceUpdateUserDefinedConfig),
                 InitSignaturCreationUnitMEAsync(config.SignaturCreationUnitsME, configurationRepository),
+                InitSignaturCreationUnitPLAsync(config.SignaturCreationUnitsPL, configurationRepository),
             };
             await Task.WhenAll(tasks);
         }
@@ -339,6 +343,17 @@ namespace fiskaltrust.Middleware.Storage.Base
                 }
             }
         }
+        private async Task InitQueuePLAsync(List<ftQueuePL> queuesPL, IConfigurationRepository configurationRepository)
+        {
+            foreach (var item in queuesPL)
+            {
+                var dbQueuePl = await configurationRepository.GetQueuePLAsync(item.ftQueuePLId).ConfigureAwait(false);
+                if (dbQueuePl == null)
+                {
+                    await configurationRepository.InsertOrUpdateQueuePLAsync(item).ConfigureAwait(false);
+                }
+            }
+        }
         private async Task InitQueueMEAsync(List<ftQueueME> queuesME, IConfigurationRepository configurationRepository)
         {
             foreach (var item in queuesME)
@@ -516,6 +531,18 @@ namespace fiskaltrust.Middleware.Storage.Base
                 if (scu == null)
                 {
                     await configurationRepository.InsertOrUpdateSignaturCreationUnitGRAsync(item).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private async Task InitSignaturCreationUnitPLAsync(List<ftSignaturCreationUnitPL> signaturCreationUnitsPL, IConfigurationRepository configurationRepository)
+        {
+            foreach (var item in signaturCreationUnitsPL)
+            {
+                var scu = await configurationRepository.GetSignaturCreationUnitPLAsync(item.ftSignaturCreationUnitPLId).ConfigureAwait(false);
+                if (scu == null)
+                {
+                    await configurationRepository.InsertOrUpdateSignaturCreationUnitPLAsync(item).ConfigureAwait(false);
                 }
             }
         }

--- a/queue/src/fiskaltrust.Middleware.Storage.EF/Repositories/EfConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.EF/Repositories/EfConfigurationRepository.cs
@@ -81,6 +81,10 @@ namespace fiskaltrust.Middleware.Storage.EF.Repositories
         public Task<IEnumerable<ftQueueGR>> GetQueueGRListAsync() => throw new NotImplementedException();
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queueGR) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid id) => throw new NotImplementedException();
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queuePL) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -113,6 +117,10 @@ namespace fiskaltrust.Middleware.Storage.EF.Repositories
         public Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid id) => throw new NotImplementedException();
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid id) => throw new NotImplementedException();
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemoryQueuePLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemoryQueuePLRepository.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.InMemory.Repositories.Configuration
+{
+    public class InMemoryQueuePLRepository : AbstractInMemoryRepository<Guid, ftQueuePL>
+    {
+        public InMemoryQueuePLRepository() : base(new List<ftQueuePL>()) { }
+
+        public InMemoryQueuePLRepository(IEnumerable<ftQueuePL> data) : base(data) { }
+
+        protected override void EntityUpdated(ftQueuePL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftQueuePL entity) => entity.ftQueuePLId;
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemorySignaturCreationUnitPLRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/Configuration/InMemorySignaturCreationUnitPLRepository.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using fiskaltrust.storage.V0;
+
+namespace fiskaltrust.Middleware.Storage.InMemory.Repositories.Configuration
+{
+    public class InMemorySignaturCreationUnitPLRepository : AbstractInMemoryRepository<Guid, ftSignaturCreationUnitPL>
+    {
+        public InMemorySignaturCreationUnitPLRepository() : base(new List<ftSignaturCreationUnitPL>()) { }
+
+        public InMemorySignaturCreationUnitPLRepository(IEnumerable<ftSignaturCreationUnitPL> data) : base(data) { }
+
+        protected override void EntityUpdated(ftSignaturCreationUnitPL entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        protected override Guid GetIdForEntity(ftSignaturCreationUnitPL entity) => entity.ftSignaturCreationUnitPLId;
+    }
+}

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
@@ -74,6 +74,8 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _queueFRRepository = new InMemoryQueueFRRepository(queuesFR);
             _queueITRepository = new InMemoryQueueITRepository(queuesIT);
             _queueMERepository = new InMemoryQueueMERepository(queuesME);
+            _queuePLRepository = new InMemoryQueuePLRepository();
+            _signaturCreationUnitPLRepository = new InMemorySignaturCreationUnitPLRepository();
             _signaturCreationUnitATRepository = new InMemorySignaturCreationUnitATRepository(signatureCreateUnitsAT);
             _signaturCreationUnitDERepository = new InMemorySignaturCreationUnitDERepository(signatureCreateUnitsDE);
             _signaturCreationUnitFRRepository = new InMemorySignaturCreationUnitFRRepository(signatureCreateUnitsFR);

--- a/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.InMemory/Repositories/InMemoryConfigurationRepository.cs
@@ -19,6 +19,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         private readonly AbstractInMemoryRepository<Guid, ftQueueME> _queueMERepository;
         private readonly AbstractInMemoryRepository<Guid, ftQueueBE> _queueBERepository;
         private readonly AbstractInMemoryRepository<Guid, ftQueueGR> _queueGRRepository;
+        private readonly AbstractInMemoryRepository<Guid, ftQueuePL> _queuePLRepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitAT> _signaturCreationUnitATRepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitBE> _signaturCreationUnitBERepository;
         private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitGR> _signaturCreationUnitGRRepository;
@@ -27,6 +28,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         private readonly InMemorySignaturCreationUnitFRRepository _signaturCreationUnitFRRepository;
         private readonly InMemorySignaturCreationUnitITRepository _signaturCreationUnitITRepository;
         private readonly InMemorySignaturCreationUnitMERepository _signaturCreationUnitMERepository;
+        private readonly AbstractInMemoryRepository<Guid, ftSignaturCreationUnitPL> _signaturCreationUnitPLRepository;
 
         public InMemoryConfigurationRepository()
         {
@@ -40,6 +42,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _queueMERepository = new InMemoryQueueMERepository();
             _queueBERepository = new InMemoryQueueBERepository();
             _queueGRRepository = new InMemoryQueueGRRepository();
+            _queuePLRepository = new InMemoryQueuePLRepository();
             _signaturCreationUnitATRepository = new InMemorySignaturCreationUnitATRepository();
             _signaturCreationUnitBERepository = new InMemorySignaturCreationUnitBERepository();
             _signaturCreationUnitGRRepository = new InMemorySignaturCreationUnitGRRepository();
@@ -48,6 +51,7 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
             _signaturCreationUnitFRRepository = new InMemorySignaturCreationUnitFRRepository();
             _signaturCreationUnitITRepository = new InMemorySignaturCreationUnitITRepository();
             _signaturCreationUnitMERepository = new InMemorySignaturCreationUnitMERepository();
+            _signaturCreationUnitPLRepository = new InMemorySignaturCreationUnitPLRepository();
         }
 
         public InMemoryConfigurationRepository(IEnumerable<ftCashBox> cashBoxes = null,
@@ -117,6 +121,10 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         public Task<ftQueueES> GetQueueESAsync(Guid queueESId) => _queueESRepository.GetAsync(queueESId);
         public Task InsertOrUpdateQueueESAsync(ftQueueES queue) => _queueESRepository.InsertOrUpdateAsync(queue);
 
+        public async Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => await _queuePLRepository.InsertOrUpdateAsync(queue).ConfigureAwait(false);
+        public async Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => await _queuePLRepository.GetAsync().ConfigureAwait(false);
+        public async Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => await _queuePLRepository.GetAsync(queuePLId).ConfigureAwait(false);
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
         public async Task InsertOrUpdateSignaturCreationUnitATAsync(ftSignaturCreationUnitAT scu) => await _signaturCreationUnitATRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
@@ -148,6 +156,10 @@ namespace fiskaltrust.Middleware.Storage.InMemory.Repositories
         public async Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => await _signaturCreationUnitGRRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
         public async Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => await _signaturCreationUnitGRRepository.GetAsync().ConfigureAwait(false);
         public async Task<ftSignaturCreationUnitGR> GetSignaturCreationUnitGRAsync(Guid signaturCreationUnitGRId) => await _signaturCreationUnitGRRepository.GetAsync(signaturCreationUnitGRId).ConfigureAwait(false);
+
+        public async Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => await _signaturCreationUnitPLRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);
+        public async Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => await _signaturCreationUnitPLRepository.GetAsync().ConfigureAwait(false);
+        public async Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => await _signaturCreationUnitPLRepository.GetAsync(signaturCreationUnitPLId).ConfigureAwait(false);
 
         public Task<IEnumerable<ftSignaturCreationUnitES>> GetSignaturCreationUnitESListAsync() => _signaturCreationUnitESRepository.GetAsync();
         public async Task InsertOrUpdateSignaturCreationUnitESAsync(ftSignaturCreationUnitES scu) => await _signaturCreationUnitESRepository.InsertOrUpdateAsync(scu).ConfigureAwait(false);

--- a/queue/src/fiskaltrust.Middleware.Storage.MySQL/Repositories/MySQLConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.MySQL/Repositories/MySQLConfigurationRepository.cs
@@ -97,6 +97,12 @@ namespace fiskaltrust.Middleware.Storage.MySQL.Repositories
 
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queue) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
 
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
@@ -142,6 +148,12 @@ namespace fiskaltrust.Middleware.Storage.MySQL.Repositories
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
 
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/queue/src/fiskaltrust.Middleware.Storage.SQLite/Repositories/SQLiteConfigurationRepository.cs
+++ b/queue/src/fiskaltrust.Middleware.Storage.SQLite/Repositories/SQLiteConfigurationRepository.cs
@@ -97,6 +97,12 @@ namespace fiskaltrust.Middleware.Storage.SQLite.Repositories
 
         public Task InsertOrUpdateQueueGRAsync(ftQueueGR queue) => throw new NotImplementedException();
 
+        public Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateQueuePLAsync(ftQueuePL queue) => throw new NotImplementedException();
+
         public async Task<ftSignaturCreationUnitAT> GetSignaturCreationUnitATAsync(Guid id) => await _signaturCreationUnitATRepository.GetAsync(id).ConfigureAwait(false);
 
         public async Task<IEnumerable<ftSignaturCreationUnitAT>> GetSignaturCreationUnitATListAsync() => await _signaturCreationUnitATRepository.GetAsync().ConfigureAwait(false);
@@ -142,6 +148,12 @@ namespace fiskaltrust.Middleware.Storage.SQLite.Repositories
         public Task<IEnumerable<ftSignaturCreationUnitGR>> GetSignaturCreationUnitGRListAsync() => throw new NotImplementedException();
 
         public Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu) => throw new NotImplementedException();
+
+        public Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId) => throw new NotImplementedException();
+
+        public Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync() => throw new NotImplementedException();
+
+        public Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu) => throw new NotImplementedException();
 
         public Task InsertOrUpdateQueueEUAsync(ftQueueEU queue) => throw new NotImplementedException();
         public Task<IEnumerable<ftQueueEU>> GetQueueEUListAsync() => throw new NotImplementedException();

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Helpers/InMemoryLocalizationStorageProvider.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Helpers/InMemoryLocalizationStorageProvider.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using fiskaltrust.Middleware.Abstractions;
+using fiskaltrust.Middleware.Contracts.Repositories;
+using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.Storage.InMemory;
+using fiskaltrust.Middleware.Storage.InMemory.Repositories;
+using fiskaltrust.Middleware.Storage.InMemory.Repositories.MasterData;
+using fiskaltrust.storage.V0;
+using fiskaltrust.storage.V0.MasterData;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.Helpers;
+
+internal sealed class InMemoryLocalizationStorageProvider : IStorageProvider
+{
+    private readonly Task _initialized;
+    private readonly AsyncLazy<IConfigurationRepository> _configurationRepository;
+    private readonly AsyncLazy<IMiddlewareQueueItemRepository> _queueItemRepository;
+    private readonly AsyncLazy<IMiddlewareReceiptJournalRepository> _receiptJournalRepository;
+    private readonly AsyncLazy<IMiddlewareActionJournalRepository> _actionJournalRepository;
+    private readonly AsyncLazy<IMiddlewareJournalESRepository> _journalEsRepository;
+    private readonly AsyncLazy<IMasterDataRepository<AccountMasterData>> _accountMasterDataRepository;
+    private readonly AsyncLazy<IMasterDataRepository<OutletMasterData>> _outletMasterDataRepository;
+    private readonly AsyncLazy<IMasterDataRepository<PosSystemMasterData>> _posSystemMasterDataRepository;
+    private readonly AsyncLazy<IMasterDataRepository<AgencyMasterData>> _agencyMasterDataRepository;
+
+    public InMemoryLocalizationStorageProvider(Guid queueId, Dictionary<string, object> configuration, ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger<IMiddlewareBootstrapper>();
+        var bootstrapper = new InMemoryStorageBootstrapper(queueId, configuration, logger);
+
+        var services = new ServiceCollection();
+        bootstrapper.ConfigureStorageServices(services);
+
+        services.AddSingleton<IMiddlewareJournalESRepository, InMemoryJournalEsRepository>();
+        services.AddSingleton<IJournalESRepository>(sp => sp.GetRequiredService<IMiddlewareJournalESRepository>());
+        services.AddSingleton<IReadOnlyJournalESRepository>(sp => sp.GetRequiredService<IMiddlewareJournalESRepository>());
+
+        var provider = services.BuildServiceProvider();
+
+        _configurationRepository = new AsyncLazy<IConfigurationRepository>(() => Task.FromResult(provider.GetRequiredService<IConfigurationRepository>()));
+        _queueItemRepository = new AsyncLazy<IMiddlewareQueueItemRepository>(() => Task.FromResult(provider.GetRequiredService<IMiddlewareQueueItemRepository>()));
+        _receiptJournalRepository = new AsyncLazy<IMiddlewareReceiptJournalRepository>(() => Task.FromResult(provider.GetRequiredService<IMiddlewareReceiptJournalRepository>()));
+        _actionJournalRepository = new AsyncLazy<IMiddlewareActionJournalRepository>(() => Task.FromResult(provider.GetRequiredService<IMiddlewareActionJournalRepository>()));
+        _journalEsRepository = new AsyncLazy<IMiddlewareJournalESRepository>(() => Task.FromResult(provider.GetRequiredService<IMiddlewareJournalESRepository>()));
+        _accountMasterDataRepository = new AsyncLazy<IMasterDataRepository<AccountMasterData>>(() => Task.FromResult(provider.GetRequiredService<IMasterDataRepository<AccountMasterData>>()));
+        _outletMasterDataRepository = new AsyncLazy<IMasterDataRepository<OutletMasterData>>(() => Task.FromResult(provider.GetRequiredService<IMasterDataRepository<OutletMasterData>>()));
+        _posSystemMasterDataRepository = new AsyncLazy<IMasterDataRepository<PosSystemMasterData>>(() => Task.FromResult(provider.GetRequiredService<IMasterDataRepository<PosSystemMasterData>>()));
+        _agencyMasterDataRepository = new AsyncLazy<IMasterDataRepository<AgencyMasterData>>(() => Task.FromResult(provider.GetRequiredService<IMasterDataRepository<AgencyMasterData>>()));
+
+        _initialized = Task.CompletedTask;
+    }
+
+    public Task Initialized => _initialized;
+
+    public AsyncLazy<IConfigurationRepository> CreateConfigurationRepository() => _configurationRepository;
+
+    public AsyncLazy<IMiddlewareQueueItemRepository> CreateMiddlewareQueueItemRepository() => _queueItemRepository;
+
+    public AsyncLazy<IMiddlewareReceiptJournalRepository> CreateMiddlewareReceiptJournalRepository() => _receiptJournalRepository;
+
+    public AsyncLazy<IMiddlewareActionJournalRepository> CreateMiddlewareActionJournalRepository() => _actionJournalRepository;
+
+    public AsyncLazy<IMiddlewareJournalESRepository> CreateMiddlewareJournalESRepository() => _journalEsRepository;
+
+    public AsyncLazy<IMasterDataRepository<AccountMasterData>> CreateAccountMasterDataRepository() => _accountMasterDataRepository;
+
+    public AsyncLazy<IMasterDataRepository<OutletMasterData>> CreateOutletMasterDataRepository() => _outletMasterDataRepository;
+
+    public AsyncLazy<IMasterDataRepository<PosSystemMasterData>> CreatePosSystemMasterDataRepository() => _posSystemMasterDataRepository;
+
+    public AsyncLazy<IMasterDataRepository<AgencyMasterData>> CreateAgencyMasterDataRepository() => _agencyMasterDataRepository;
+
+    private sealed class InMemoryJournalEsRepository : AbstractInMemoryRepository<Guid, ftJournalES>, IMiddlewareJournalESRepository
+    {
+        public InMemoryJournalEsRepository() : base(new List<ftJournalES>())
+        {
+        }
+
+        protected override Guid GetIdForEntity(ftJournalES entity) => entity.ftJournalESId;
+
+        protected override void EntityUpdated(ftJournalES entity) => entity.TimeStamp = DateTime.UtcNow.Ticks;
+
+        public new Task<IEnumerable<ftJournalES>> GetAsync() => base.GetAsync();
+
+        public new Task<ftJournalES> GetAsync(Guid id) => base.GetAsync(id);
+
+        public new Task InsertAsync(ftJournalES entity) => base.InsertAsync(entity);
+    }
+}

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Helpers/MockPLSSCD.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Helpers/MockPLSSCD.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.Helpers;
+
+/// <summary>
+/// Behaves like a fiscalized Polish register: owns the fiscal document numbering, reports its
+/// identity through the generic InfoData blob (contract: SCU.PL.Abstraction PLDeviceInfo) and
+/// enriches responses with the numer unikatowy and the fiscal document number.
+/// </summary>
+public class MockPLSSCD : IPLSSCD
+{
+    public const string UniqueDeviceNumber = "ZAS0000000001";
+
+    public int ProcessReceiptCalls { get; private set; }
+    private long _fiscalDocumentNumber;
+
+    public Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => Task.FromResult(new EchoResponse { Message = echoRequest.Message });
+
+    public Task<PLSSCDInfo> GetInfoAsync() => Task.FromResult(new PLSSCDInfo
+    {
+        InfoData = JsonSerializer.Serialize(new
+        {
+            DeviceSerialNumber = "MCK1234567",
+            UniqueDeviceNumber,
+            FiscalizationState = 2,
+            VatRateTable = new[]
+            {
+                new { PtuSlot = "A", VatRatePercent = (decimal?)23m, IsExempt = false },
+                new { PtuSlot = "B", VatRatePercent = (decimal?)8m, IsExempt = false },
+                new { PtuSlot = "C", VatRatePercent = (decimal?)5m, IsExempt = false },
+                new { PtuSlot = "D", VatRatePercent = (decimal?)0m, IsExempt = false },
+                new { PtuSlot = "G", VatRatePercent = (decimal?)null, IsExempt = true },
+            },
+            CrkReachable = true,
+            EReceiptCapable = true,
+            CurrentZReportNumber = 0,
+        })
+    });
+
+    public Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request)
+    {
+        ProcessReceiptCalls++;
+        var response = request.ReceiptResponse;
+        response.ftCashBoxIdentification = UniqueDeviceNumber;
+        if (request.ReceiptRequest.ftReceiptCase.IsType(ReceiptCaseType.Receipt))
+        {
+            var number = ++_fiscalDocumentNumber;
+            response.ftReceiptIdentification += number;
+            response.ftSignatures.Add(new SignatureItem
+            {
+                ftSignatureFormat = SignatureFormat.Text,
+                ftSignatureType = (SignatureType)0x504C_2000_0000_0101,
+                Caption = "Numer dokumentu fiskalnego",
+                Data = number.ToString(),
+            });
+        }
+        return Task.FromResult(new ProcessResponse { ReceiptResponse = response });
+    }
+}

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Scenarios/PLScenarioTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Scenarios/PLScenarioTests.cs
@@ -1,0 +1,229 @@
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.Helpers;
+using fiskaltrust.Middleware.Localization.QueuePL.Models;
+using fiskaltrust.storage.V0;
+using fiskaltrust.storage.V0.MasterData;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.Scenarios;
+
+public class PLScenarioTests
+{
+    private readonly Func<string, Task<string>> _signProcessor;
+    private readonly MockPLSSCD _sscd;
+    private readonly Guid _queueId;
+    private readonly Guid _cashBoxId;
+
+    public PLScenarioTests() : this(startQueue: true) { }
+
+    private PLScenarioTests(bool startQueue)
+    {
+        _queueId = Guid.NewGuid();
+        _cashBoxId = Guid.NewGuid();
+        _sscd = new MockPLSSCD();
+
+        var configuration = new Dictionary<string, object>
+        {
+            { "cashboxid", _cashBoxId },
+            { "init_ftCashBox", JsonSerializer.Serialize(new ftCashBox
+                {
+                    ftCashBoxId = _cashBoxId,
+                    TimeStamp = DateTime.UtcNow.Ticks
+                })
+            },
+            { "init_ftQueue", JsonSerializer.Serialize(new List<ftQueue>
+                {
+                    new ftQueue
+                    {
+                        ftQueueId = _queueId,
+                        ftCashBoxId = _cashBoxId,
+                        StartMoment = startQueue ? DateTime.UtcNow : null,
+                        CountryCode = "PL"
+                    }
+                })
+            },
+            { "init_ftQueuePL", JsonSerializer.Serialize(new List<ftQueuePL>
+                {
+                    new ftQueuePL
+                    {
+                        ftQueuePLId = _queueId,
+                        CashBoxIdentification = MockPLSSCD.UniqueDeviceNumber
+                    }
+                })
+            },
+            { "init_ftSignaturCreationUnitPL", JsonSerializer.Serialize(new List<ftSignaturCreationUnitPL>()) },
+            { "init_masterData", JsonSerializer.Serialize(new MasterDataConfiguration
+                {
+                    Account = new AccountMasterData
+                    {
+                        AccountId = Guid.NewGuid(),
+                        AccountName = "fiskaltrust sp. z o.o.",
+                        VatId = "5260250274",
+                        Street = "ul. Przykładowa 1",
+                        Zip = "00-001",
+                        City = "Warszawa",
+                        Country = "PL",
+                        TaxId = "5260250274"
+                    }
+                })
+            }
+        };
+
+        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
+        var storageProvider = new InMemoryLocalizationStorageProvider(_queueId, configuration, loggerFactory);
+        var bootstrapper = new QueuePLBootstrapper(_queueId, loggerFactory, configuration, _sscd, storageProvider);
+        _signProcessor = bootstrapper.RegisterForSign();
+    }
+
+    private async Task<ReceiptResponse> SignAsync(ReceiptRequest request)
+    {
+        var responseJson = await _signProcessor(JsonSerializer.Serialize(request));
+        var response = JsonSerializer.Deserialize<ReceiptResponse>(responseJson);
+        response.Should().NotBeNull();
+        return response!;
+    }
+
+    private ReceiptRequest CreateRequest(ulong receiptCase, List<ChargeItem>? chargeItems = null, List<PayItem>? payItems = null, string? cbCustomer = null)
+    {
+        var request = new ReceiptRequest
+        {
+            ftCashBoxID = _cashBoxId,
+            ftPosSystemId = Guid.NewGuid(),
+            cbTerminalID = "1",
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            cbReceiptMoment = DateTime.UtcNow,
+            ftReceiptCase = (ReceiptCase)receiptCase,
+            cbChargeItems = chargeItems ?? new List<ChargeItem>(),
+            cbPayItems = payItems ?? new List<PayItem>(),
+        };
+        if (cbCustomer is not null)
+        {
+            request.cbCustomer = cbCustomer;
+        }
+        return request;
+    }
+
+    private static List<ChargeItem> Item(decimal amount, decimal vatRate = 23m, ulong vatCase = 0x3) => new()
+    {
+        new ChargeItem
+        {
+            Amount = amount,
+            VATRate = vatRate,
+            Quantity = 1,
+            Description = "Item A",
+            ftChargeItemCase = (ChargeItemCase)(0x504C_2000_0000_0000 | vatCase),
+        }
+    };
+
+    private static List<PayItem> Cash(decimal amount) => new()
+    {
+        new PayItem
+        {
+            Amount = amount,
+            Description = "Cash",
+            ftPayItemCase = (PayItemCase)0x504C_2000_0000_0000,
+        }
+    };
+
+    [Fact]
+    public async Task InitialOperation_ShouldActivateQueue_AgainstFiscalizedDevice()
+    {
+        var harness = new PLScenarioTests(startQueue: false);
+        var response = await harness.SignAsync(harness.CreateRequest(0x504C_2000_0000_4001));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE, response.ftSignatures.FirstOrDefault()?.Data);
+        response.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.InitialOperationReceipt));
+    }
+
+    [Fact]
+    public async Task CashSale_ShouldGetFiscalDocumentNumber_AndDeviceIdentity()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_0001, Item(10m), Cash(10m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        response.ftCashBoxIdentification.Should().Be(MockPLSSCD.UniqueDeviceNumber);
+        response.ftReceiptIdentification.Should().EndWith("1");
+        response.ftSignatures.Should().Contain(x => (ulong)x.ftSignatureType == 0x504C_2000_0000_0101);
+    }
+
+    [Fact]
+    public async Task Return_ShouldPassThrough_AsOwnDocument()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0100_0001, Item(-10m), Cash(-10m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task MixedSaleAndReturn_ShouldFail()
+    {
+        var chargeItems = Item(10m);
+        chargeItems.AddRange(Item(-5m));
+
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_0001, chargeItems, Cash(5m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NipReceipt_ShouldSucceed_WithCustomerNip()
+    {
+        var receiptCase = 0x504C_2000_0000_0001UL | (ulong)ReceiptCaseFlags.ReceiverIsBusiness;
+        var response = await SignAsync(CreateRequest(receiptCase, Item(100m), Cash(100m), cbCustomer: """{"CustomerVATId":"PL5260250274"}"""));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+    }
+
+    [Fact]
+    public async Task NipReceipt_ShouldFail_WithoutCustomerNip()
+    {
+        var receiptCase = 0x504C_2000_0000_0001UL | (ulong)ReceiptCaseFlags.ReceiverIsBusiness;
+        var response = await SignAsync(CreateRequest(receiptCase, Item(100m), Cash(100m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+    }
+
+    [Fact]
+    public async Task ZeroReceipt_ShouldQueryDeviceStatus()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_2000));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(1);
+        response.ftCashBoxIdentification.Should().Be(MockPLSSCD.UniqueDeviceNumber);
+    }
+
+    [Fact]
+    public async Task DailyClosing_ShouldTriggerZReportOnDevice()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_2011));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Invoice_ShouldBeStoredNotFiscalized_WithoutDeviceCall()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_1001, Item(100m), Cash(100m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(0);
+        response.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.StoredNotFiscalized));
+    }
+
+    [Fact]
+    public async Task OutOfOperation_ShouldDisableQueue()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_4002));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+        response.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.OutOfOperationReceipt));
+    }
+}

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Scenarios/PLScenarioTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/Scenarios/PLScenarioTests.cs
@@ -87,7 +87,7 @@ public class PLScenarioTests
         return response!;
     }
 
-    private ReceiptRequest CreateRequest(ulong receiptCase, List<ChargeItem>? chargeItems = null, List<PayItem>? payItems = null, string? cbCustomer = null)
+    private ReceiptRequest CreateRequest(ulong receiptCase, List<ChargeItem>? chargeItems = null, List<PayItem>? payItems = null, string? cbCustomer = null, Currency currency = Currency.PLN)
     {
         var request = new ReceiptRequest
         {
@@ -97,6 +97,7 @@ public class PLScenarioTests
             cbReceiptReference = Guid.NewGuid().ToString(),
             cbReceiptMoment = DateTime.UtcNow,
             ftReceiptCase = (ReceiptCase)receiptCase,
+            Currency = currency,
             cbChargeItems = chargeItems ?? new List<ChargeItem>(),
             cbPayItems = payItems ?? new List<PayItem>(),
         };
@@ -107,7 +108,7 @@ public class PLScenarioTests
         return request;
     }
 
-    private static List<ChargeItem> Item(decimal amount, decimal vatRate = 23m, ulong vatCase = 0x3) => new()
+    private static List<ChargeItem> Item(decimal amount, decimal vatRate = 23m, ulong vatCase = 0x3, Currency currency = Currency.PLN) => new()
     {
         new ChargeItem
         {
@@ -115,6 +116,7 @@ public class PLScenarioTests
             VATRate = vatRate,
             Quantity = 1,
             Description = "Item A",
+            Currency = currency,
             ftChargeItemCase = (ChargeItemCase)(0x504C_2000_0000_0000 | vatCase),
         }
     };
@@ -125,6 +127,7 @@ public class PLScenarioTests
         {
             Amount = amount,
             Description = "Cash",
+            Currency = Currency.PLN,
             ftPayItemCase = (PayItemCase)0x504C_2000_0000_0000,
         }
     };
@@ -153,10 +156,15 @@ public class PLScenarioTests
     [Fact]
     public async Task Return_ShouldPassThrough_AsOwnDocument()
     {
-        var response = await SignAsync(CreateRequest(0x504C_2000_0100_0001, Item(-10m), Cash(-10m)));
+        var sale = CreateRequest(0x504C_2000_0000_0001, Item(10m), Cash(10m));
+        await SignAsync(sale);
 
-        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
-        _sscd.ProcessReceiptCalls.Should().Be(1);
+        var returnRequest = CreateRequest(0x504C_2000_0100_0001, Item(-10m), Cash(-10m));
+        returnRequest.cbPreviousReceiptReference = sale.cbReceiptReference;
+        var response = await SignAsync(returnRequest);
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE, string.Join(" | ", response.ftSignatures.Select(x => $"{x.Caption}: {x.Data}")));
+        _sscd.ProcessReceiptCalls.Should().Be(2);
     }
 
     [Fact]
@@ -216,6 +224,25 @@ public class PLScenarioTests
         ((ulong)response.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
         _sscd.ProcessReceiptCalls.Should().Be(0);
         response.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.StoredNotFiscalized));
+    }
+
+    [Fact]
+    public async Task Receipt_WithoutPlnCurrency_ShouldBeRejected()
+    {
+        // Currency defaults to EUR — the PL queue only totalizes PLN (rfcs/0705-queue-single-currency).
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_0001, Item(10m), Cash(10m), currency: Currency.EUR));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Receipt_WithForeignCurrencyItem_ShouldBeRejected()
+    {
+        var response = await SignAsync(CreateRequest(0x504C_2000_0000_0001, Item(10m, currency: Currency.EUR), Cash(10m)));
+
+        ((ulong)response.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+        _sscd.ProcessReceiptCalls.Should().Be(0);
     }
 
     [Fact]

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.csproj
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest/fiskaltrust.Middleware.Localization.QueuePL.AcceptanceTest.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>Latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="fiskaltrust.interface" Version="1.3.79-rc1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\fiskaltrust.Middleware.Localization.QueuePL\fiskaltrust.Middleware.Localization.QueuePL.csproj" />
+        <ProjectReference Include="..\..\src\fiskaltrust.Middleware.Storage.InMemory\fiskaltrust.Middleware.Storage.InMemory.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/ProcessorTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/ProcessorTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.QueuePL.Models;
+using fiskaltrust.Middleware.Localization.QueuePL.Processors;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.Localization.v2.Storage;
+using fiskaltrust.storage.V0;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.Localization.QueuePL.UnitTest;
+
+internal class FakePLSSCD : IPLSSCD
+{
+    public int ProcessReceiptCalls { get; private set; }
+    public bool Fiscalized { get; set; } = true;
+
+    public Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => Task.FromResult(new EchoResponse { Message = echoRequest.Message });
+
+    public Task<PLSSCDInfo> GetInfoAsync() => Task.FromResult(new PLSSCDInfo
+    {
+        InfoData = JsonSerializer.Serialize(new { FiscalizationState = Fiscalized ? 2 : 1, UniqueDeviceNumber = "ZAS0000000001" })
+    });
+
+    public Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request)
+    {
+        ProcessReceiptCalls++;
+        return Task.FromResult(new ProcessResponse { ReceiptResponse = request.ReceiptResponse });
+    }
+}
+
+internal class FakeLocalizedQueueStorageProvider : ILocalizedQueueStorageProvider
+{
+    public bool Activated { get; private set; }
+    public bool Deactivated { get; private set; }
+
+    public Task ActivateQueueAsync()
+    {
+        Activated = true;
+        return Task.CompletedTask;
+    }
+
+    public Task DeactivateQueueAsync()
+    {
+        Deactivated = true;
+        return Task.CompletedTask;
+    }
+}
+
+public class ProcessorTestsBase
+{
+    internal static ProcessCommandRequest CreateRequest(ulong receiptCase, List<ChargeItem>? chargeItems = null, string? cbCustomer = null)
+    {
+        var queue = new ftQueue { ftQueueId = Guid.NewGuid(), ftCashBoxId = Guid.NewGuid() };
+        var request = new ReceiptRequest
+        {
+            ftCashBoxID = queue.ftCashBoxId,
+            cbReceiptReference = "unit-test",
+            cbReceiptMoment = DateTime.UtcNow,
+            ftReceiptCase = (ReceiptCase)receiptCase,
+            cbChargeItems = chargeItems ?? new List<ChargeItem>(),
+            cbPayItems = new List<PayItem>(),
+        };
+        if (cbCustomer is not null)
+        {
+            request.cbCustomer = cbCustomer;
+        }
+        var response = new ReceiptResponse
+        {
+            ftQueueID = queue.ftQueueId,
+            ftQueueItemID = Guid.NewGuid(),
+            ftReceiptIdentification = "ft1#",
+            ftCashBoxIdentification = "ZAS0000000001",
+        };
+        return new ProcessCommandRequest(queue, request, response);
+    }
+}
+
+public class LifecycleCommandProcessorPLTests : ProcessorTestsBase
+{
+    [Fact]
+    public async Task InitialOperation_ShouldActivateQueue_WhenDeviceIsFiscalized()
+    {
+        var sscd = new FakePLSSCD { Fiscalized = true };
+        var storage = new FakeLocalizedQueueStorageProvider();
+        var sut = new LifecycleCommandProcessorPL(sscd, storage);
+
+        var result = await sut.InitialOperationReceipt0x4001Async(CreateRequest(0x504C_2000_0000_4001));
+
+        storage.Activated.Should().BeTrue();
+        result.receiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.InitialOperationReceipt));
+        result.actionJournals.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task InitialOperation_ShouldFail_WhenDeviceIsNotFiscalized()
+    {
+        var sscd = new FakePLSSCD { Fiscalized = false };
+        var storage = new FakeLocalizedQueueStorageProvider();
+        var sut = new LifecycleCommandProcessorPL(sscd, storage);
+
+        var result = await sut.InitialOperationReceipt0x4001Async(CreateRequest(0x504C_2000_0000_4001));
+
+        storage.Activated.Should().BeFalse();
+        ((ulong)result.receiptResponse.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+    }
+
+    [Fact]
+    public async Task OutOfOperation_ShouldDeactivateQueue()
+    {
+        var sscd = new FakePLSSCD();
+        var storage = new FakeLocalizedQueueStorageProvider();
+        var sut = new LifecycleCommandProcessorPL(sscd, storage);
+
+        var result = await sut.OutOfOperationReceipt0x4002Async(CreateRequest(0x504C_2000_0000_4002));
+
+        storage.Deactivated.Should().BeTrue();
+        result.receiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.OutOfOperationReceipt));
+    }
+}
+
+public class ReceiptCommandProcessorPLTests : ProcessorTestsBase
+{
+    [Fact]
+    public async Task PointOfSaleReceipt_ShouldPassThroughToSCU()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+
+        await sut.PointOfSaleReceipt0x0001Async(CreateRequest(0x504C_2000_0000_0001, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+        }));
+
+        sscd.ProcessReceiptCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PointOfSaleReceipt_ShouldFail_WhenSaleAndReturnAreMixed()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+
+        var result = await sut.PointOfSaleReceipt0x0001Async(CreateRequest(0x504C_2000_0000_0001, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+            new() { Amount = -5m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+        }));
+
+        sscd.ProcessReceiptCalls.Should().Be(0);
+        ((ulong)result.receiptResponse.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+    }
+
+    [Fact]
+    public async Task NipReceipt_ShouldFail_WithoutCustomerData()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+        var receiptCase = 0x504C_2000_0000_0001UL | (ulong)ReceiptCaseFlags.ReceiverIsBusiness;
+
+        var result = await sut.PointOfSaleReceipt0x0001Async(CreateRequest(receiptCase, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+        }));
+
+        sscd.ProcessReceiptCalls.Should().Be(0);
+        ((ulong)result.receiptResponse.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+    }
+
+    [Fact]
+    public async Task NipReceipt_ShouldPassThrough_WithCustomerData()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+        var receiptCase = 0x504C_2000_0000_0001UL | (ulong)ReceiptCaseFlags.ReceiverIsBusiness;
+
+        await sut.PointOfSaleReceipt0x0001Async(CreateRequest(receiptCase, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+        }, cbCustomer: /* language=json */ """{"CustomerVATId":"PL5260250274"}"""));
+
+        sscd.ProcessReceiptCalls.Should().Be(1);
+    }
+}
+
+public class InvoiceCommandProcessorPLTests : ProcessorTestsBase
+{
+    [Fact]
+    public async Task Invoice_ShouldBeStoredNotFiscalized_WithoutTouchingTheSCU()
+    {
+        var sut = new InvoiceCommandProcessorPL();
+
+        var result = await sut.InvoiceB2C0x1001Async(CreateRequest(0x504C_2000_0000_1001));
+
+        result.receiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.StoredNotFiscalized));
+        ((ulong)result.receiptResponse.ftState & 0xFFFF_FFFF).Should().NotBe(0xEEEE_EEEE);
+    }
+}

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/ProcessorTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/ProcessorTests.cs
@@ -155,6 +155,37 @@ public class ReceiptCommandProcessorPLTests : ProcessorTestsBase
     }
 
     [Fact]
+    public async Task DiscountedSale_ShouldNotBeTreatedAsMixedReturn()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+
+        await sut.PointOfSaleReceipt0x0001Async(CreateRequest(0x504C_2000_0000_0001, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+            new() { Amount = -2m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0004_0003 },
+        }));
+
+        sscd.ProcessReceiptCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task NipReceipt_ShouldFail_WithCustomerDataButNoVatId()
+    {
+        var sscd = new FakePLSSCD();
+        var sut = new ReceiptCommandProcessorPL(sscd);
+        var receiptCase = 0x504C_2000_0000_0001UL | (ulong)ReceiptCaseFlags.ReceiverIsBusiness;
+
+        var result = await sut.PointOfSaleReceipt0x0001Async(CreateRequest(receiptCase, new List<ChargeItem>
+        {
+            new() { Amount = 10m, ftChargeItemCase = (ChargeItemCase)0x504C_2000_0000_0003 },
+        }, cbCustomer: """{"CustomerName":"ACME"}"""));
+
+        sscd.ProcessReceiptCalls.Should().Be(0);
+        ((ulong)result.receiptResponse.ftState & 0xFFFF_FFFF).Should().Be(0xEEEE_EEEE);
+    }
+
+    [Fact]
     public async Task NipReceipt_ShouldFail_WithoutCustomerData()
     {
         var sscd = new FakePLSSCD();

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/fiskaltrust.Middleware.Localization.QueuePL.UnitTest.csproj
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePL.UnitTest/fiskaltrust.Middleware.Localization.QueuePL.UnitTest.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>Latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="fiskaltrust.interface" Version="1.3.79-rc1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\fiskaltrust.Middleware.Localization.QueuePL\fiskaltrust.Middleware.Localization.QueuePL.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/scu-pl/Directory.Build.props
+++ b/scu-pl/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <PropertyGroup>
+    <Version>1.3.0-local</Version>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
+    <Authors>fiskaltrust</Authors>
+    <Company>fiskaltrust</Company>
+    <Copyright>Copyright 2022</Copyright>
+    <PackageTags>fiskaltrust signing</PackageTags>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <AssemblyCompany>fiskaltrust</AssemblyCompany>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Deterministic>true</Deterministic>
+    <LangVersion>12.0</LangVersion>
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904;NU5104</WarningsNotAsErrors>
+  </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Nerdbank.GitVersioning" Condition="Exists('version.json')">
+            <PrivateAssets>all</PrivateAssets>
+            <Version>3.9.50</Version>
+        </PackageReference>
+    </ItemGroup>
+</Project>

--- a/scu-pl/fiskaltrust.Middleware.SCU.PL.sln
+++ b/scu-pl/fiskaltrust.Middleware.SCU.PL.sln
@@ -1,0 +1,34 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.Abstraction", "src\fiskaltrust.Middleware.SCU.PL.Abstraction\fiskaltrust.Middleware.SCU.PL.Abstraction.csproj", "{06041BEC-3297-4274-8996-B5973CDBD2DC}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.InMemory", "src\fiskaltrust.Middleware.SCU.PL.InMemory\fiskaltrust.Middleware.SCU.PL.InMemory.csproj", "{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "fiskaltrust.Middleware.SCU.PL.UnitTest", "test\fiskaltrust.Middleware.SCU.PL.UnitTest\fiskaltrust.Middleware.SCU.PL.UnitTest.csproj", "{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{06041BEC-3297-4274-8996-B5973CDBD2DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7FEC29F-3B82-4A56-BD27-55DE3302E9EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C893C9A1-D8C5-4F7A-8945-76669D7D0FB1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/SignatureTypePL.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/SignatureTypePL.cs
@@ -1,0 +1,23 @@
+using System;
+using fiskaltrust.ifPOS.v2.Cases;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+
+public enum SignatureTypePL : long
+{
+    FiscalDocumentNumber = 0x504C_2000_0000_0101,
+    DeviceSerialNumber = 0x504C_2000_0000_0102,
+    UniqueDeviceNumber = 0x504C_2000_0000_0103,
+    ZReportNumber = 0x504C_2000_0000_0104,
+    EReceiptReference = 0x504C_2000_0000_0105,
+    StoredNotFiscalized = 0x504C_2000_0000_0106,
+}
+
+public static class SignatureTypePLExt
+{
+    public static T As<T>(this SignatureTypePL self) where T : Enum, IConvertible => (T) Enum.ToObject(typeof(T), self);
+
+    public static bool IsType(this SignatureType self, SignatureTypePL signatureTypePL) => ((long) self & 0xFFFF) == ((long) signatureTypePL & 0xFFFF);
+    public static SignatureType WithType(this SignatureType self, SignatureTypePL state) => (SignatureType) ((ulong) self & 0xFFFF_FFFF_FFFF_0000 | (ulong) state & 0xFFFF);
+    public static SignatureTypePL Type(this SignatureType self) => (SignatureTypePL) ((long) self & 0xFFFF);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/StatePL.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Cases/StatePL.cs
@@ -1,0 +1,14 @@
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+
+/// <summary>
+/// PL-localized ftState values. The middle three nibbles (0x0000_0FFF_0000_0000) carry the
+/// PL-local flags; the lowest flag nibble bit marks "fiscal device unreachable" — in Poland a
+/// non-working register legally means no sale (Art. 111(3) VAT Act), so callers must be able
+/// to distinguish this failure from any other error.
+/// </summary>
+public enum StatePL : ulong
+{
+    Success = 0x504C_2000_0000_0000,
+    Error = 0x504C_2000_EEEE_EEEE,
+    DeviceUnreachableError = 0x504C_2001_EEEE_EEEE,
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Exceptions/PLSSCDExceptions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Exceptions/PLSSCDExceptions.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+
+/// <summary>Base type for all failures raised by Polish SCUs.</summary>
+public class PLSSCDException : Exception
+{
+    public PLSSCDException(string message) : base(message) { }
+    public PLSSCDException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>
+/// The fiscal register could not be reached (offline printer, network failure, printer farm
+/// endpoint down). In Poland no working register legally means no sale (Art. 111(3) VAT Act),
+/// so this failure carries its own ftState flag — see <c>StatePL.DeviceUnreachableError</c>.
+/// </summary>
+public class PLDeviceUnreachableException : PLSSCDException
+{
+    public PLDeviceUnreachableException(string message) : base(message) { }
+    public PLDeviceUnreachableException(string message, Exception innerException) : base(message, innerException) { }
+}
+
+/// <summary>The register rejected an operation with a device error code.</summary>
+public class PLDeviceErrorException : PLSSCDException
+{
+    public int ErrorCode { get; }
+
+    public PLDeviceErrorException(int errorCode, string message) : base(message)
+    {
+        ErrorCode = errorCode;
+    }
+}
+
+/// <summary>A request violates a PL constraint before any device communication happens.</summary>
+public class PLValidationException : PLSSCDException
+{
+    public PLValidationException(string message) : base(message) { }
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLAmountExtensions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLAmountExtensions.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+/// <summary>
+/// Polish fiscal devices exchange monetary amounts as integer grosze (1 PLN = 100 gr).
+/// </summary>
+public static class PLAmountExtensions
+{
+    public static long ToGrosze(this decimal amountPln) => (long)Math.Round(amountPln * 100m, 0, MidpointRounding.AwayFromZero);
+
+    public static decimal GroszeToPln(this long amountGrosze) => amountGrosze / 100m;
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLReceiptResponseExtensions.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLReceiptResponseExtensions.cs
@@ -1,0 +1,45 @@
+using System.Globalization;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+/// <summary>
+/// The single place where PL SCUs enrich a ReceiptResponse with device-owned identity:
+/// ftCashBoxIdentification carries the numer unikatowy and ftReceiptIdentification is completed
+/// with the fiscal document number issued by the register.
+/// </summary>
+public static class PLReceiptResponseExtensions
+{
+    public static void AddSignatureItem(this ReceiptResponse response, SignatureTypePL signatureType, string caption, string data)
+        => response.ftSignatures.Add(new SignatureItem
+        {
+            ftSignatureFormat = SignatureFormat.Text,
+            ftSignatureType = (SignatureType)(ulong)(long)signatureType,
+            Caption = caption,
+            Data = data,
+        });
+
+    public static void EnrichWithDeviceIdentification(this ReceiptResponse response, PLDeviceInfo deviceInfo)
+    {
+        if (!string.IsNullOrEmpty(deviceInfo.UniqueDeviceNumber))
+        {
+            response.ftCashBoxIdentification = deviceInfo.UniqueDeviceNumber;
+            response.AddSignatureItem(SignatureTypePL.UniqueDeviceNumber, "Numer unikatowy", deviceInfo.UniqueDeviceNumber);
+        }
+
+        if (!string.IsNullOrEmpty(deviceInfo.DeviceSerialNumber))
+        {
+            response.AddSignatureItem(SignatureTypePL.DeviceSerialNumber, "Numer fabryczny", deviceInfo.DeviceSerialNumber);
+        }
+    }
+
+    public static void EnrichWithFiscalDocumentNumber(this ReceiptResponse response, long fiscalDocumentNumber)
+    {
+        var number = fiscalDocumentNumber.ToString(CultureInfo.InvariantCulture);
+        response.ftReceiptIdentification += number;
+        response.AddSignatureItem(SignatureTypePL.FiscalDocumentNumber, "Numer dokumentu fiskalnego", number);
+    }
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLStateMapper.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Helpers/PLStateMapper.cs
@@ -1,0 +1,20 @@
+using System;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+
+public static class PLStateMapper
+{
+    /// <summary>
+    /// Maps an SCU failure to the PL-localized ftState. Device-unreachable failures get their own
+    /// local flag so queues and monitoring can distinguish "no register — no legal sale" from
+    /// ordinary errors.
+    /// </summary>
+    public static State Map(Exception exception) => exception switch
+    {
+        PLDeviceUnreachableException => (State)StatePL.DeviceUnreachableError,
+        _ => (State)StatePL.Error,
+    };
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLDeviceInfo.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLDeviceInfo.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using fiskaltrust.ifPOS.v2.pl;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+/// <summary>
+/// The fiscalization state of the connected Polish register. Fiscalizing a device is a
+/// certified-technician (serwis) act and can never be triggered through the middleware.
+/// </summary>
+public enum PLFiscalizationState
+{
+    Unknown = 0,
+    NonFiscal = 1,
+    Fiscalized = 2,
+    ReadOnly = 3,
+}
+
+/// <summary>
+/// A single slot of the PTU VAT rate table programmed on the register. A slot either carries a
+/// percentage rate or is marked tax-exempt (zwolniona, "zw.").
+/// </summary>
+public class PLVatRateTableEntry
+{
+    /// <summary>The PTU slot letter ("A" to "G").</summary>
+    public string PtuSlot { get; set; } = "";
+
+    /// <summary>The VAT rate in percent (e.g. 23 for the standard rate), or null if the slot is exempt.</summary>
+    public decimal? VatRatePercent { get; set; }
+
+    /// <summary>True if the slot is programmed as tax-exempt (zwolniona, "zw.").</summary>
+    public bool IsExempt { get; set; }
+}
+
+/// <summary>
+/// Typed state of the Polish register as reported by the device. In Poland the certified register
+/// owns the compliance state; this model travels as the json-serialized <c>InfoData</c> blob of
+/// <see cref="PLSSCDInfo"/>. Software registers (kasy wirtualne) have no numer fabryczny — for them
+/// <see cref="DeviceSerialNumber"/> stays null and <see cref="UniqueDeviceNumber"/> identifies the register.
+/// </summary>
+public class PLDeviceInfo
+{
+    /// <summary>The manufacturing serial number (numer fabryczny); null for software registers.</summary>
+    public string? DeviceSerialNumber { get; set; }
+
+    /// <summary>The unique number assigned from the MF pool (numer unikatowy), printed on every fiscal document.</summary>
+    public string? UniqueDeviceNumber { get; set; }
+
+    /// <summary>The registration number assigned during fiscalization (numer ewidencyjny), identifying the register in the CRK.</summary>
+    public string? RegistrationNumber { get; set; }
+
+    public PLFiscalizationState FiscalizationState { get; set; }
+
+    /// <summary>The PTU VAT rate table (slots A–G) currently programmed on the register.</summary>
+    public List<PLVatRateTableEntry> VatRateTable { get; set; } = new();
+
+    /// <summary>Whether the register can currently reach the CRK (Central Repository of Cash Registers).</summary>
+    public bool? CrkReachable { get; set; }
+
+    /// <summary>The moment of the last successful transmission to the CRK, as reported by the register.</summary>
+    public DateTime? CrkLastTransmission { get; set; }
+
+    /// <summary>Whether the register supports issuing e-receipts (e-paragony).</summary>
+    public bool? EReceiptCapable { get; set; }
+
+    /// <summary>The number of the current daily (Z) report period.</summary>
+    public int? CurrentZReportNumber { get; set; }
+
+    public PLSSCDInfo ToPLSSCDInfo() => new()
+    {
+        InfoData = JsonSerializer.Serialize(this)
+    };
+
+    public static PLDeviceInfo? FromPLSSCDInfo(PLSSCDInfo info)
+        => info.InfoData is null ? null : JsonSerializer.Deserialize<PLDeviceInfo>(info.InfoData);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLFiscalCommand.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/Models/PLFiscalCommand.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+/// <summary>
+/// The device-neutral fiscal operations a Polish SCU must be able to perform. Device SCUs
+/// (e.g. Posnet) map these to their protocol frames; the command set follows the receipt flow
+/// trinit → trline → trpayment → trend plus the report and status operations.
+/// </summary>
+public enum PLFiscalCommandType
+{
+    GetStatus,
+    GetDeviceInfo,
+    BeginReceipt,
+    AddReceiptLine,
+    AddPayment,
+    EndReceipt,
+    CancelReceipt,
+    DailyReport,
+    PeriodicReport,
+}
+
+/// <summary>
+/// A single device-neutral fiscal command. Deliberately loosely typed while the Posnet protocol
+/// implementation (market-pl#3) settles the field glossary; device SCUs translate
+/// <see cref="Parameters"/> into their protocol-specific representation.
+/// </summary>
+public class PLFiscalCommand
+{
+    public PLFiscalCommandType CommandType { get; set; }
+
+    public Dictionary<string, string> Parameters { get; set; } = new();
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/PtuSlotResolver.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/PtuSlotResolver.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.Abstraction;
+
+/// <summary>The statutory Polish VAT rates the ftChargeItemCase VAT nibble maps to.</summary>
+public static class PLVatRates
+{
+    public const decimal Normal = 23m;
+    public const decimal Reduced1 = 8m;
+    public const decimal Reduced2 = 5m;
+    public const decimal Zero = 0m;
+}
+
+/// <summary>
+/// Resolves the PTU slot for a charge item against the VAT rate table reported by the register.
+/// The slot letters are never hardcoded: which slot carries which rate (and which slot is the
+/// exempt "zw." one) is owned by the device — only the case→rate mapping is statutory.
+/// </summary>
+public class PtuSlotResolver
+{
+    private readonly IReadOnlyList<PLVatRateTableEntry> _vatRateTable;
+
+    public PtuSlotResolver(IEnumerable<PLVatRateTableEntry> deviceVatRateTable)
+    {
+        _vatRateTable = deviceVatRateTable.ToList();
+    }
+
+    public PLVatRateTableEntry Resolve(ChargeItemCase chargeItemCase) => chargeItemCase.Vat() switch
+    {
+        ChargeItemCase.NormalVatRate => ResolveByRate(PLVatRates.Normal),
+        ChargeItemCase.DiscountedVatRate1 => ResolveByRate(PLVatRates.Reduced1),
+        ChargeItemCase.DiscountedVatRate2 => ResolveByRate(PLVatRates.Reduced2),
+        ChargeItemCase.ZeroVatRate => ResolveByRate(PLVatRates.Zero),
+        ChargeItemCase.NotTaxable => ResolveExempt(),
+        var vat => throw new PLValidationException($"The VAT case {vat} of ftChargeItemCase 0x{(ulong)chargeItemCase:X} has no Polish PTU mapping."),
+    };
+
+    public PLVatRateTableEntry ResolveByRate(decimal vatRatePercent)
+        => _vatRateTable.FirstOrDefault(x => !x.IsExempt && x.VatRatePercent == vatRatePercent)
+            ?? throw new PLValidationException($"The VAT rate table of the register does not contain a PTU slot for {vatRatePercent}%.");
+
+    public PLVatRateTableEntry ResolveExempt()
+        => _vatRateTable.FirstOrDefault(x => x.IsExempt)
+            ?? throw new PLValidationException("The VAT rate table of the register does not contain a tax-exempt (zw.) PTU slot.");
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/fiskaltrust.Middleware.SCU.PL.Abstraction.csproj
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.Abstraction/fiskaltrust.Middleware.SCU.PL.Abstraction.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>Shared abstractions for the fiskaltrust Middleware SCUs for Poland: PTU slot resolution, PL signature types and states, device info, amount helpers and the SCU exception hierarchy.</Description>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+        <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+        <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
+    </ItemGroup>
+
+    <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup Label="FilesToCopy">
+        <Content Include="..\..\LICENSES\**" Pack="true" PackagePath="LICENSES" LinkBase="LICENSES">
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+
+namespace fiskaltrust.Middleware.SCU.PL.InMemory;
+
+/// <summary>
+/// A deterministic, hardware-free IPLSSCD implementation that mimics the behavior of a Polish
+/// online register: it owns the fiscal document numbering and the daily (Z) report counter and
+/// enriches responses with the device identity — enough to run QueuePL acceptance tests without
+/// a printer. Validation hooks let tests inject device behaviors (e.g. tax-class blocking).
+/// </summary>
+public class InMemorySCU : IPLSSCD
+{
+    private readonly PLDeviceInfo _deviceInfo;
+    private readonly List<Action<ProcessRequest>> _validators;
+    private readonly object _syncRoot = new();
+    private long _fiscalDocumentNumber;
+
+    public InMemorySCU(PLDeviceInfo? deviceInfo = null, IEnumerable<Action<ProcessRequest>>? validators = null, long fiscalDocumentNumberSeed = 0)
+    {
+        _deviceInfo = deviceInfo ?? CreateDefaultDeviceInfo();
+        _deviceInfo.CurrentZReportNumber ??= 0;
+        _validators = validators?.ToList() ?? new List<Action<ProcessRequest>>();
+        _fiscalDocumentNumber = fiscalDocumentNumberSeed;
+    }
+
+    public static PLDeviceInfo CreateDefaultDeviceInfo() => new()
+    {
+        DeviceSerialNumber = "INM1234567",
+        UniqueDeviceNumber = "ZAS0000000001",
+        RegistrationNumber = "0000000001",
+        FiscalizationState = PLFiscalizationState.Fiscalized,
+        VatRateTable = new List<PLVatRateTableEntry>
+        {
+            new() { PtuSlot = "A", VatRatePercent = 23m },
+            new() { PtuSlot = "B", VatRatePercent = 8m },
+            new() { PtuSlot = "C", VatRatePercent = 5m },
+            new() { PtuSlot = "D", VatRatePercent = 0m },
+            new() { PtuSlot = "G", IsExempt = true },
+        },
+        CrkReachable = true,
+        CrkLastTransmission = null,
+        EReceiptCapable = true,
+        CurrentZReportNumber = 0,
+    };
+
+    public Task<EchoResponse> EchoAsync(EchoRequest echoRequest)
+        => Task.FromResult(new EchoResponse { Message = echoRequest.Message });
+
+    public Task<PLSSCDInfo> GetInfoAsync()
+        => Task.FromResult(_deviceInfo.ToPLSSCDInfo());
+
+    public Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request)
+    {
+        foreach (var validator in _validators)
+        {
+            validator(request);
+        }
+
+        var receiptCase = request.ReceiptRequest.ftReceiptCase;
+        var response = request.ReceiptResponse;
+
+        if (receiptCase.IsType(ReceiptCaseType.Invoice))
+        {
+            throw new PLValidationException("Invoice cases (0x1xxx) must not reach a Polish SCU — QueuePL persists them without fiscalization.");
+        }
+
+        response.EnrichWithDeviceIdentification(_deviceInfo);
+
+        if (receiptCase.IsType(ReceiptCaseType.Receipt))
+        {
+            long fiscalDocumentNumber;
+            lock (_syncRoot)
+            {
+                fiscalDocumentNumber = ++_fiscalDocumentNumber;
+            }
+            response.EnrichWithFiscalDocumentNumber(fiscalDocumentNumber);
+        }
+        else if (receiptCase.IsType(ReceiptCaseType.DailyOperations) && IsZReportCase(receiptCase))
+        {
+            int zReportNumber;
+            lock (_syncRoot)
+            {
+                zReportNumber = (_deviceInfo.CurrentZReportNumber ?? 0) + 1;
+                _deviceInfo.CurrentZReportNumber = zReportNumber;
+            }
+            response.AddSignatureItem(Abstraction.Cases.SignatureTypePL.ZReportNumber, "Numer raportu dobowego", zReportNumber.ToString());
+        }
+
+        return Task.FromResult(new ProcessResponse { ReceiptResponse = response });
+    }
+
+    private static bool IsZReportCase(ReceiptCase receiptCase)
+        => receiptCase.IsCase(ReceiptCase.DailyClosing0x2011)
+            || receiptCase.IsCase(ReceiptCase.MonthlyClosing0x2012)
+            || receiptCase.IsCase(ReceiptCase.YearlyClosing0x2013);
+}

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/InMemorySCU.cs
@@ -75,7 +75,7 @@ public class InMemorySCU : IPLSSCD
 
         response.EnrichWithDeviceIdentification(_deviceInfo);
 
-        if (receiptCase.IsType(ReceiptCaseType.Receipt))
+        if (IsFiscalReceiptCase(receiptCase))
         {
             long fiscalDocumentNumber;
             lock (_syncRoot)
@@ -84,8 +84,10 @@ public class InMemorySCU : IPLSSCD
             }
             response.EnrichWithFiscalDocumentNumber(fiscalDocumentNumber);
         }
-        else if (receiptCase.IsType(ReceiptCaseType.DailyOperations) && IsZReportCase(receiptCase))
+        else if (receiptCase.IsCase(ReceiptCase.DailyClosing0x2011))
         {
+            // Only the daily closing advances the Z counter — monthly/yearly closings are
+            // periodic reports over already-closed days and do not create a new Z report.
             int zReportNumber;
             lock (_syncRoot)
             {
@@ -98,8 +100,14 @@ public class InMemorySCU : IPLSSCD
         return Task.FromResult(new ProcessResponse { ReceiptResponse = response });
     }
 
-    private static bool IsZReportCase(ReceiptCase receiptCase)
-        => receiptCase.IsCase(ReceiptCase.DailyClosing0x2011)
-            || receiptCase.IsCase(ReceiptCase.MonthlyClosing0x2012)
-            || receiptCase.IsCase(ReceiptCase.YearlyClosing0x2013);
+    /// <summary>
+    /// Only the fiscal sale documents consume a fiscal document number on the register —
+    /// non-fiscal receipt cases (payment transfer, sale without fiscalization obligation,
+    /// delivery note, table check, pro forma) do not.
+    /// </summary>
+    private static bool IsFiscalReceiptCase(ReceiptCase receiptCase)
+        => receiptCase.IsType(ReceiptCaseType.Receipt)
+            && (receiptCase.IsCase(ReceiptCase.UnknownReceipt0x0000)
+                || receiptCase.IsCase(ReceiptCase.PointOfSaleReceipt0x0001)
+                || receiptCase.IsCase(ReceiptCase.ECommerce0x0004));
 }

--- a/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/fiskaltrust.Middleware.SCU.PL.InMemory.csproj
+++ b/scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/fiskaltrust.Middleware.SCU.PL.InMemory.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Description>The fiskaltrust Middleware implementation of the InMemory SCU for Poland.</Description>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+        <Nullable>enable</Nullable>
+        <LangVersion>12.0</LangVersion>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+        <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\fiskaltrust.Middleware.SCU.PL.Abstraction\fiskaltrust.Middleware.SCU.PL.Abstraction.csproj" />
+    </ItemGroup>
+
+    <Target DependsOnTargets="ResolveReferences" Name="CopyProjectReferencesToPackage">
+        <ItemGroup>
+            <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths-&gt;WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+        </ItemGroup>
+    </Target>
+
+    <ItemGroup Label="FilesToCopy">
+        <Content Include="..\..\LICENSES\**" Pack="true" PackagePath="LICENSES" LinkBase="LICENSES">
+            <PackageCopyToOutput>true</PackageCopyToOutput>
+        </Content>
+    </ItemGroup>
+
+</Project>

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/AbstractionHelperTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/AbstractionHelperTests.cs
@@ -1,0 +1,82 @@
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Helpers;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class PLAmountExtensionsTests
+{
+    [Theory]
+    [InlineData("12.34", 1234L)]
+    [InlineData("0.005", 1L)]
+    [InlineData("-1.005", -101L)]
+    [InlineData("23", 2300L)]
+    public void ToGrosze_ShouldRoundAwayFromZero(string amount, long expected)
+        => decimal.Parse(amount, System.Globalization.CultureInfo.InvariantCulture).ToGrosze().Should().Be(expected);
+
+    [Fact]
+    public void GroszeToPln_ShouldRoundTrip()
+        => 1234L.GroszeToPln().Should().Be(12.34m);
+}
+
+public class PLDeviceInfoTests
+{
+    [Fact]
+    public void ToPLSSCDInfo_ShouldRoundTripThroughInfoData()
+    {
+        var deviceInfo = new PLDeviceInfo
+        {
+            DeviceSerialNumber = "ABC1234567",
+            UniqueDeviceNumber = "ZAS1234567890",
+            RegistrationNumber = "1234567890",
+            FiscalizationState = PLFiscalizationState.Fiscalized,
+            VatRateTable = new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } },
+            CrkReachable = true,
+            EReceiptCapable = true,
+            CurrentZReportNumber = 42,
+        };
+
+        var info = deviceInfo.ToPLSSCDInfo();
+        info.InfoData.Should().NotBeNullOrEmpty();
+
+        var roundTripped = PLDeviceInfo.FromPLSSCDInfo(info);
+        roundTripped.Should().BeEquivalentTo(deviceInfo);
+    }
+
+    [Fact]
+    public void FromPLSSCDInfo_ShouldReturnNull_WhenInfoDataIsNull()
+        => PLDeviceInfo.FromPLSSCDInfo(new ifPOS.v2.pl.PLSSCDInfo()).Should().BeNull();
+}
+
+public class PLStateMapperTests
+{
+    [Fact]
+    public void Map_ShouldFlagDeviceUnreachable()
+        => PLStateMapper.Map(new PLDeviceUnreachableException("printer offline"))
+            .Should().Be((State)0x504C_2001_EEEE_EEEE);
+
+    [Fact]
+    public void Map_ShouldReturnPlainError_ForOtherFailures()
+        => PLStateMapper.Map(new PLDeviceErrorException(2005, "no transaction mode"))
+            .Should().Be((State)0x504C_2000_EEEE_EEEE);
+}
+
+public class SignatureTypePLTests
+{
+    [Fact]
+    public void SignatureTypes_ShouldCarryThePLCountryCode()
+    {
+        foreach (SignatureTypePL type in Enum.GetValues(typeof(SignatureTypePL)))
+        {
+            ((SignatureType)(ulong)(long)type).Country().Should().Be("PL");
+        }
+    }
+
+    [Fact]
+    public void IsType_ShouldMatchOnTheLowestNibbles()
+        => ((SignatureType)0x504C_2000_0000_0104UL).IsType(SignatureTypePL.ZReportNumber).Should().BeTrue();
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
@@ -1,0 +1,128 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using fiskaltrust.Middleware.SCU.PL.InMemory;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class InMemorySCUTests
+{
+    private static ProcessRequest CreateRequest(ulong receiptCase) => new()
+    {
+        ReceiptRequest = new ReceiptRequest
+        {
+            cbReceiptReference = "pl-test",
+            ftReceiptCase = (ReceiptCase)receiptCase,
+        },
+        ReceiptResponse = new ReceiptResponse
+        {
+            ftCashBoxID = Guid.NewGuid(),
+            ftReceiptIdentification = "ft1#",
+        },
+    };
+
+    private const ulong CashSale = 0x504C_2000_0000_0001;
+    private const ulong DailyClosing = 0x504C_2000_0000_2011;
+    private const ulong ZeroReceipt = 0x504C_2000_0000_2000;
+    private const ulong Invoice = 0x504C_2000_0000_1001;
+
+    [Fact]
+    public async Task EchoAsync_ShouldMirrorMessage()
+    {
+        var scu = new InMemorySCU();
+        (await scu.EchoAsync(new EchoRequest { Message = "test" })).Message.Should().Be("test");
+    }
+
+    [Fact]
+    public async Task GetInfoAsync_ShouldExposeTypedDeviceInfo_ThroughInfoData()
+    {
+        var scu = new InMemorySCU();
+
+        var info = await scu.GetInfoAsync();
+        var deviceInfo = PLDeviceInfo.FromPLSSCDInfo(info);
+
+        deviceInfo.Should().NotBeNull();
+        deviceInfo!.FiscalizationState.Should().Be(PLFiscalizationState.Fiscalized);
+        deviceInfo.UniqueDeviceNumber.Should().NotBeNullOrEmpty();
+        deviceInfo.VatRateTable.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNumberReceiptsDeterministically()
+    {
+        var scu = new InMemorySCU();
+
+        var first = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+        var second = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        first.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#1");
+        second.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#2");
+        second.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.FiscalDocumentNumber) && x.Data == "2");
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldSetCashBoxIdentification_ToUniqueDeviceNumber()
+    {
+        var deviceInfo = InMemorySCU.CreateDefaultDeviceInfo();
+        var scu = new InMemorySCU(deviceInfo);
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        result.ReceiptResponse.ftCashBoxIdentification.Should().Be(deviceInfo.UniqueDeviceNumber);
+        result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType.IsType(SignatureTypePL.UniqueDeviceNumber));
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldIncrementZCounter_OnDailyClosing()
+    {
+        var scu = new InMemorySCU();
+
+        await scu.ProcessReceiptAsync(CreateRequest(DailyClosing));
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+
+        info!.CurrentZReportNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotNumberZeroReceipts()
+    {
+        var scu = new InMemorySCU();
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(ZeroReceipt));
+
+        result.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#");
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+        info!.CurrentZReportNumber.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldRejectInvoiceCases()
+    {
+        var scu = new InMemorySCU();
+
+        var act = () => scu.ProcessReceiptAsync(CreateRequest(Invoice));
+
+        await act.Should().ThrowAsync<PLValidationException>();
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldRunValidationHooks()
+    {
+        var seen = new List<string?>();
+        var scu = new InMemorySCU(validators: new Action<ProcessRequest>[]
+        {
+            request => seen.Add(request.ReceiptRequest.cbReceiptReference),
+            request => throw new PLValidationException("blocked by hook"),
+        });
+
+        var act = () => scu.ProcessReceiptAsync(CreateRequest(CashSale));
+
+        await act.Should().ThrowAsync<PLValidationException>().WithMessage("blocked by hook");
+        seen.Should().ContainSingle().Which.Should().Be("pl-test");
+    }
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/InMemorySCUTests.cs
@@ -101,6 +101,29 @@ public class InMemorySCUTests
     }
 
     [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotNumberNonFiscalReceiptCases()
+    {
+        var scu = new InMemorySCU();
+
+        var result = await scu.ProcessReceiptAsync(CreateRequest(0x504C_2000_0000_0003));
+
+        result.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#");
+        var next = await scu.ProcessReceiptAsync(CreateRequest(CashSale));
+        next.ReceiptResponse.ftReceiptIdentification.Should().Be("ft1#1");
+    }
+
+    [Fact]
+    public async Task ProcessReceiptAsync_ShouldNotAdvanceZCounter_OnMonthlyClosing()
+    {
+        var scu = new InMemorySCU();
+
+        await scu.ProcessReceiptAsync(CreateRequest(0x504C_2000_0000_2012));
+        var info = PLDeviceInfo.FromPLSSCDInfo(await scu.GetInfoAsync());
+
+        info!.CurrentZReportNumber.Should().Be(0);
+    }
+
+    [Fact]
     public async Task ProcessReceiptAsync_ShouldRejectInvoiceCases()
     {
         var scu = new InMemorySCU();

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/PtuSlotResolverTests.cs
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/PtuSlotResolverTests.cs
@@ -1,0 +1,78 @@
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.PL.Abstraction;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Exceptions;
+using fiskaltrust.Middleware.SCU.PL.Abstraction.Models;
+using FluentAssertions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.PL.UnitTest;
+
+public class PtuSlotResolverTests
+{
+    private static List<PLVatRateTableEntry> DefaultTable() => new()
+    {
+        new() { PtuSlot = "A", VatRatePercent = 23m },
+        new() { PtuSlot = "B", VatRatePercent = 8m },
+        new() { PtuSlot = "C", VatRatePercent = 5m },
+        new() { PtuSlot = "D", VatRatePercent = 0m },
+        new() { PtuSlot = "G", IsExempt = true },
+    };
+
+    [Theory]
+    [InlineData(ChargeItemCase.NormalVatRate, "A")]
+    [InlineData(ChargeItemCase.DiscountedVatRate1, "B")]
+    [InlineData(ChargeItemCase.DiscountedVatRate2, "C")]
+    [InlineData(ChargeItemCase.ZeroVatRate, "D")]
+    [InlineData(ChargeItemCase.NotTaxable, "G")]
+    public void Resolve_ShouldMapVatCase_ToDefaultSlots(ChargeItemCase vatCase, string expectedSlot)
+    {
+        var resolver = new PtuSlotResolver(DefaultTable());
+        var chargeItemCase = ((ChargeItemCase)0x504C_2000_0000_0000).WithVat(vatCase);
+
+        resolver.Resolve(chargeItemCase).PtuSlot.Should().Be(expectedSlot);
+    }
+
+    [Fact]
+    public void Resolve_ShouldFollowTheDeviceTable_NotHardcodedLetters()
+    {
+        // A register may have 23% programmed on a different slot — the device owns the assignment.
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry>
+        {
+            new() { PtuSlot = "B", VatRatePercent = 23m },
+            new() { PtuSlot = "E", IsExempt = true },
+        });
+
+        resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.NormalVatRate)).PtuSlot.Should().Be("B");
+        resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.NotTaxable)).PtuSlot.Should().Be("E");
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_WhenRateNotProgrammedOnDevice()
+    {
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } });
+
+        var act = () => resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.DiscountedVatRate1));
+
+        act.Should().Throw<PLValidationException>().WithMessage("*8%*");
+    }
+
+    [Fact]
+    public void Resolve_ShouldThrow_ForVatCasesWithoutPolishMapping()
+    {
+        var resolver = new PtuSlotResolver(DefaultTable());
+
+        var act = () => resolver.Resolve(((ChargeItemCase)0x504C_2000_0000_0000).WithVat(ChargeItemCase.ParkingVatRate));
+
+        act.Should().Throw<PLValidationException>();
+    }
+
+    [Fact]
+    public void ResolveExempt_ShouldThrow_WhenNoExemptSlotExists()
+    {
+        var resolver = new PtuSlotResolver(new List<PLVatRateTableEntry> { new() { PtuSlot = "A", VatRatePercent = 23m } });
+
+        var act = () => resolver.ResolveExempt();
+
+        act.Should().Throw<PLValidationException>().WithMessage("*zw.*");
+    }
+}

--- a/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/fiskaltrust.Middleware.SCU.PL.UnitTest.csproj
+++ b/scu-pl/test/fiskaltrust.Middleware.SCU.PL.UnitTest/fiskaltrust.Middleware.SCU.PL.UnitTest.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>net8.0</TargetFrameworks>
+        <LangVersion>Latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" Version="6.12.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+        <PackageReference Include="xunit" Version="2.6.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Update="fiskaltrust.interface" Version="1.3.79-rc1-26216-90828" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\fiskaltrust.Middleware.SCU.PL.InMemory\fiskaltrust.Middleware.SCU.PL.InMemory.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/storage/src/fiskaltrust.storage/Models/ftQueuePL.cs
+++ b/storage/src/fiskaltrust.storage/Models/ftQueuePL.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace fiskaltrust.storage.V0
+{
+    public class ftQueuePL
+    {
+        public Guid ftQueuePLId { get; set; }
+
+        public Guid? ftSignaturCreationUnitPLId { get; set; }
+
+        public string CashBoxIdentification { get; set; }
+
+        public int SSCDFailCount { get; set; }
+
+        public DateTime? SSCDFailMoment { get; set; }
+
+        public Guid? SSCDFailQueueItemId { get; set; }
+
+        public int UsedFailedCount { get; set; }
+
+        public DateTime? UsedFailedMomentMin { get; set; }
+
+        public DateTime? UsedFailedMomentMax { get; set; }
+
+        public Guid? UsedFailedQueueItemId { get; set; }
+
+        public long TimeStamp { get; set; }
+    }
+}

--- a/storage/src/fiskaltrust.storage/Models/ftSignaturCreationUnitPL.cs
+++ b/storage/src/fiskaltrust.storage/Models/ftSignaturCreationUnitPL.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace fiskaltrust.storage.V0
+{
+    public class ftSignaturCreationUnitPL
+    {
+        public Guid ftSignaturCreationUnitPLId { get; set; }
+
+        public long TimeStamp { get; set; }
+
+        public string Url { get; set; }
+
+        public string InfoJson { get; set; }
+    }
+}

--- a/storage/src/fiskaltrust.storage/Repositories/IConfigurationRepository.cs
+++ b/storage/src/fiskaltrust.storage/Repositories/IConfigurationRepository.cs
@@ -14,6 +14,7 @@ namespace fiskaltrust.storage.V0
         Task InsertOrUpdateSignaturCreationUnitGRAsync(ftSignaturCreationUnitGR scu);
         Task InsertOrUpdateSignaturCreationUnitITAsync(ftSignaturCreationUnitIT scu);
         Task InsertOrUpdateSignaturCreationUnitMEAsync(ftSignaturCreationUnitME scu);
+        Task InsertOrUpdateSignaturCreationUnitPLAsync(ftSignaturCreationUnitPL scu);
         Task InsertOrUpdateQueueATAsync(ftQueueAT queue);
         Task InsertOrUpdateQueueBEAsync(ftQueueBE queue);
         Task InsertOrUpdateQueueDEAsync(ftQueueDE queue);
@@ -23,5 +24,6 @@ namespace fiskaltrust.storage.V0
         Task InsertOrUpdateQueueGRAsync(ftQueueGR queue);
         Task InsertOrUpdateQueueITAsync(ftQueueIT queue);
         Task InsertOrUpdateQueueMEAsync(ftQueueME queue);
+        Task InsertOrUpdateQueuePLAsync(ftQueuePL queue);
     }
 }

--- a/storage/src/fiskaltrust.storage/Repositories/IReadOnlyConfigurationRepository.cs
+++ b/storage/src/fiskaltrust.storage/Repositories/IReadOnlyConfigurationRepository.cs
@@ -33,6 +33,9 @@ namespace fiskaltrust.storage.V0
         Task<IEnumerable<ftSignaturCreationUnitME>> GetSignaturCreationUnitMEListAsync();
         Task<ftSignaturCreationUnitME> GetSignaturCreationUnitMEAsync(Guid signaturCreationUnitDEId);
 
+        Task<IEnumerable<ftSignaturCreationUnitPL>> GetSignaturCreationUnitPLListAsync();
+        Task<ftSignaturCreationUnitPL> GetSignaturCreationUnitPLAsync(Guid signaturCreationUnitPLId);
+
         Task<IEnumerable<ftQueue>> GetQueueListAsync();
         Task<ftQueue> GetQueueAsync(Guid queueId);
 
@@ -62,5 +65,8 @@ namespace fiskaltrust.storage.V0
 
         Task<IEnumerable<ftQueueME>> GetQueueMEListAsync();
         Task<ftQueueME> GetQueueMEAsync(Guid queueMEId);
+
+        Task<IEnumerable<ftQueuePL>> GetQueuePLListAsync();
+        Task<ftQueuePL> GetQueuePLAsync(Guid queuePLId);
     }
 }

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/.gitignore
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/.gitignore
@@ -1,3 +1,6 @@
-json-requests
+json-requests/*
+!json-requests/PL
 queue-configuration*.json
+!queue-configuration-pl.json
 scu-configuration*.json
+!scu-configuration-pl-inmemory.json

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/CashBoxBuilder.cs
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/CashBoxBuilder.cs
@@ -79,6 +79,13 @@ class CashBoxBuilder
                 [ChargeItemCase.SuperReducedVatRate1] = 0.04m,
                 [ChargeItemCase.SuperReducedVatRate2] = 0.04m,
             },
+            "PL" => new Dictionary<ChargeItemCase, decimal>
+            {
+                [ChargeItemCase.NormalVatRate] = 0.23m,
+                [ChargeItemCase.DiscountedVatRate1] = 0.08m,
+                [ChargeItemCase.DiscountedVatRate2] = 0.05m,
+                [ChargeItemCase.ZeroVatRate] = 0.00m,
+            },
             _ => throw new NotImplementedException()
         });
     }

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/ES/VeriFactuInMemoryClient.cs
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/ES/VeriFactuInMemoryClient.cs
@@ -1,4 +1,6 @@
 using fiskaltrust.Middleware.SCU.ES.VeriFactu;
+using GovernmentAPI = fiskaltrust.Middleware.SCU.ES.Common.Models.GovernmentAPI;
+using GovernmentAPISchemaVersion = fiskaltrust.Middleware.SCU.ES.Common.Models.GovernmentAPISchemaVersion;
 using fiskaltrust.Middleware.SCU.ES.VeriFactu.Helpers;
 using fiskaltrust.Middleware.SCU.ES.VeriFactu.Models;
 using fiskaltrust.Middleware.SCU.ES.VeriFactu.Soap;
@@ -12,7 +14,7 @@ class VeriFactuInMemoryClient : IClient
         return Task.FromResult<(Result<RespuestaRegFactuSistemaFacturacion, Error>, GovernmentAPI)>((
             new RespuestaRegFactuSistemaFacturacion
             {
-                Cabecera = new Cabecera
+                Cabecera = new fiskaltrust.Middleware.SCU.ES.VeriFactu.Models.Cabecera
                 {
                     ObligadoEmision = new PersonaFisicaJuridicaES
                     {

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/PL/CashBoxBuilderPL.cs
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/PL/CashBoxBuilderPL.cs
@@ -1,0 +1,67 @@
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.Middleware.Localization.v2.Interface;
+using fiskaltrust.Middleware.SCU.PL.InMemory;
+using fiskaltrust.Middleware.Test.Launcher.v2.Helpers.PL;
+using fiskaltrust.storage.serialization.V0;
+using fiskaltrust.storage.V0;
+using Microsoft.Extensions.Logging;
+
+namespace fiskaltrust.Middleware.Test.Launcher.v2.Helpers;
+
+class CashBoxBuilderPL : ICashBoxBuilder
+{
+    public string Market { get => "PL"; }
+
+    public PackageConfiguration? _scuConfiguration { get; set; }
+
+    public void AddSCU(ref PackageConfiguration queueConfiguration, PackageConfiguration scuConfiguration, Guid scuId)
+    {
+        queueConfiguration.Configuration.Add(
+                $"init_ftSignaturCreationUnitPL",
+                new List<ftSignaturCreationUnitPL> {
+                    new ftSignaturCreationUnitPL
+                    {
+                        ftSignaturCreationUnitPLId = scuId,
+                    }
+                }
+        );
+        _scuConfiguration = scuConfiguration;
+    }
+
+    public void AddMarketQueue(ref PackageConfiguration queueConfiguration, Guid queueId, Guid scuId)
+    {
+        queueConfiguration.Configuration.Add(
+                $"init_ftQueuePL",
+                new List<ftQueuePL> {
+                    new ftQueuePL
+                    {
+                        ftQueuePLId = queueId,
+                        CashBoxIdentification = queueId.ToString().Substring(0, 18),
+                        ftSignaturCreationUnitPLId = scuId
+                    }
+                }
+        );
+    }
+
+    public IV2QueueBootstrapper CreateBootStrapper(PackageConfiguration queueConfiguration, PackageConfiguration scuConfiguration, Guid queueId)
+    {
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.AddConsole();
+        });
+
+        IPLSSCD scu = _scuConfiguration!.Package switch
+        {
+            "fiskaltrust.Middleware.SCU.PL.InMemory" => new InMemorySCU(),
+            _ => throw new NotImplementedException("SCU Type not implemented")
+        };
+
+        return new Localization.QueuePL.QueuePLBootstrapper(
+            queueId,
+            loggerFactory,
+            queueConfiguration.Configuration,
+            new PLSSCDJsonWarper(scu),
+            new InMemoryStorageProvider(loggerFactory, queueId, queueConfiguration.Configuration));
+    }
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/PL/PLSSCDJsonWarper.cs
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Helpers/PL/PLSSCDJsonWarper.cs
@@ -1,0 +1,18 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.pl;
+using fiskaltrust.Middleware.Test.Launcher.v2.Extensions;
+
+namespace fiskaltrust.Middleware.Test.Launcher.v2.Helpers.PL;
+
+public class PLSSCDJsonWarper : IPLSSCD
+{
+    private readonly IPLSSCD _plsscd;
+    public PLSSCDJsonWarper(IPLSSCD plsscd)
+    {
+        _plsscd = plsscd;
+    }
+
+    public Task<EchoResponse> EchoAsync(EchoRequest echoRequest) => _plsscd.EchoAsync(echoRequest.JsonWarp());
+    public Task<PLSSCDInfo> GetInfoAsync() => _plsscd.GetInfoAsync();
+    public async Task<ProcessResponse> ProcessReceiptAsync(ProcessRequest request) => (await _plsscd.ProcessReceiptAsync(request.JsonWarp())).JsonWarp()!;
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Program.cs
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/Program.cs
@@ -6,14 +6,19 @@ using fiskaltrust.Middleware.Test.Launcher.v2.Helpers;
 using fiskaltrust.storage.serialization.V0;
 using FluentAssertions;
 
+var market = Environment.GetEnvironmentVariable("MW_MARKET") ?? "ES";
+var queueConfigurationFile = Environment.GetEnvironmentVariable("MW_QUEUE_CONFIGURATION") ?? (market == "PL" ? "queue-configuration-pl.json" : "queue-configuration.json");
+var scuConfigurationFile = Environment.GetEnvironmentVariable("MW_SCU_CONFIGURATION") ?? (market == "PL" ? "scu-configuration-pl-inmemory.json" : "scu-configuration-bizkaia.json");
+
 var builder = new CashBoxBuilder(
-    "ES" switch
+    market switch
     {
-        "ES" => new CashBoxBuilderES(),
+        "ES" => (ICashBoxBuilder)new CashBoxBuilderES(),
+        "PL" => new CashBoxBuilderPL(),
         _ => throw new NotImplementedException(),
     },
-    Newtonsoft.Json.JsonConvert.DeserializeObject<PackageConfiguration>(await File.ReadAllTextAsync(Path.Join(AppContext.BaseDirectory, "queue-configuration.json"))),
-    Newtonsoft.Json.JsonConvert.DeserializeObject<PackageConfiguration>(await File.ReadAllTextAsync(Path.Join(AppContext.BaseDirectory, "scu-configuration-bizkaia.json")))
+    Newtonsoft.Json.JsonConvert.DeserializeObject<PackageConfiguration>(await File.ReadAllTextAsync(Path.Join(AppContext.BaseDirectory, queueConfigurationFile))),
+    Newtonsoft.Json.JsonConvert.DeserializeObject<PackageConfiguration>(await File.ReadAllTextAsync(Path.Join(AppContext.BaseDirectory, scuConfigurationFile)))
 );
 
 var middleware = builder.Build();
@@ -33,6 +38,7 @@ var middleware = builder.Build();
         cbReceiptReference = Guid.NewGuid().ToString().Substring(0, 8),
         cbChargeItems = [],
         cbPayItems = [],
+        Currency = builder.Market == "PL" ? Currency.PLN : Currency.EUR,
         ftReceiptCase = ReceiptCase.InitialOperationReceipt0x4001.WithCountry(builder.Market)
     }).ConfigureAwait(false);
     response.Should().NotBeNull();

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/fiskaltrust.Middleware.Test.Launcher.v2.csproj
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/fiskaltrust.Middleware.Test.Launcher.v2.csproj
@@ -19,6 +19,8 @@
     <ProjectReference Include="../../../../queue/src/fiskaltrust.Middleware.Localization.v2/fiskaltrust.Middleware.Localization.v2.csproj" />
 
     <ProjectReference Include="../../../../queue/src/fiskaltrust.Middleware.Localization.QueueES/fiskaltrust.Middleware.Localization.QueueES.csproj" />
+    <ProjectReference Include="../../../../queue/src/fiskaltrust.Middleware.Localization.QueuePL/fiskaltrust.Middleware.Localization.QueuePL.csproj" />
+    <ProjectReference Include="../../../../scu-pl/src/fiskaltrust.Middleware.SCU.PL.InMemory/fiskaltrust.Middleware.SCU.PL.InMemory.csproj" />
     <ProjectReference Include="../../../../scu-es/src/fiskaltrust.Middleware.SCU.ES.VeriFactu/fiskaltrust.Middleware.SCU.ES.VeriFactu.csproj" />
     <ProjectReference Include="../../../../scu-es/src/fiskaltrust.Middleware.SCU.ES.TicketBaiAraba/fiskaltrust.Middleware.SCU.ES.TicketBaiAraba.csproj" />
     <ProjectReference Include="../../../../scu-es/src/fiskaltrust.Middleware.SCU.ES.TicketBaiBizkaia/fiskaltrust.Middleware.SCU.ES.TicketBaiBizkaia.csproj" />

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestDailyOperations_DailyClosing/daily-closing.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestDailyOperations_DailyClosing/daily-closing.json
@@ -1,0 +1,11 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-daily-closing",
+  "cbReceiptMoment": "2026-08-04T22:00:00Z",
+  "cbChargeItems": [],
+  "cbPayItems": [],
+  "ftReceiptCase": 5786034805636341777,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestDailyOperations_MonthlyClosing/monthly-closing.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestDailyOperations_MonthlyClosing/monthly-closing.json
@@ -1,0 +1,11 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-monthly-closing",
+  "cbReceiptMoment": "2026-08-31T22:00:00Z",
+  "cbChargeItems": [],
+  "cbPayItems": [],
+  "ftReceiptCase": 5786034805636341778,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestLifecycle_OutOfOperation/out-of-operation.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestLifecycle_OutOfOperation/out-of-operation.json
@@ -1,0 +1,11 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-out-of-operation",
+  "cbReceiptMoment": "2026-08-04T23:00:00Z",
+  "cbChargeItems": [],
+  "cbPayItems": [],
+  "ftReceiptCase": 5786034805636349954,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_CardSaleReceipt/card-sale.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_CardSaleReceipt/card-sale.json
@@ -1,0 +1,29 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-card-sale",
+  "cbReceiptMoment": "2026-08-04T10:00:00Z",
+  "cbChargeItems": [
+    {
+      "Quantity": 2,
+      "Description": "Bilet normalny",
+      "Amount": 16.0,
+      "VATRate": 8,
+      "ftChargeItemCase": 5786034805636333569,
+      "Currency": "PLN"
+    }
+  ],
+  "cbPayItems": [
+    {
+      "Quantity": 1,
+      "Description": "Karta płatnicza",
+      "Amount": 16.0,
+      "ftPayItemCase": 5786034805636333572,
+      "Currency": "PLN"
+    }
+  ],
+  "cbReceiptAmount": 16.0,
+  "ftReceiptCase": 5786034805636333569,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_CashSaleReceipt/cash-sale.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_CashSaleReceipt/cash-sale.json
@@ -1,0 +1,29 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-cash-sale",
+  "cbReceiptMoment": "2026-08-04T10:00:00Z",
+  "cbChargeItems": [
+    {
+      "Quantity": 1,
+      "Description": "Woda mineralna 0,5l",
+      "Amount": 3.69,
+      "VATRate": 23,
+      "ftChargeItemCase": 5786034805636333571,
+      "Currency": "PLN"
+    }
+  ],
+  "cbPayItems": [
+    {
+      "Quantity": 1,
+      "Description": "Gotówka",
+      "Amount": 3.69,
+      "ftPayItemCase": 5786034805636333569,
+      "Currency": "PLN"
+    }
+  ],
+  "cbReceiptAmount": 3.69,
+  "ftReceiptCase": 5786034805636333569,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_NipReceipt/nip-receipt.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_NipReceipt/nip-receipt.json
@@ -1,0 +1,30 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-nip-receipt",
+  "cbReceiptMoment": "2026-08-04T10:00:00Z",
+  "cbCustomer": "{\"CustomerVATId\":\"PL5260250274\"}",
+  "cbChargeItems": [
+    {
+      "Quantity": 1,
+      "Description": "Materiały biurowe",
+      "Amount": 123.0,
+      "VATRate": 23,
+      "ftChargeItemCase": 5786034805636333571,
+      "Currency": "PLN"
+    }
+  ],
+  "cbPayItems": [
+    {
+      "Quantity": 1,
+      "Description": "Gotówka",
+      "Amount": 123.0,
+      "ftPayItemCase": 5786034805636333569,
+      "Currency": "PLN"
+    }
+  ],
+  "cbReceiptAmount": 123.0,
+  "ftReceiptCase": 5786034805638430721,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_ReturnReceipt/return.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_ReturnReceipt/return.json
@@ -1,0 +1,30 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-return",
+  "cbPreviousReceiptReference": "pl-cash-sale",
+  "cbReceiptMoment": "2026-08-04T11:00:00Z",
+  "cbChargeItems": [
+    {
+      "Quantity": -1,
+      "Description": "Woda mineralna 0,5l",
+      "Amount": -3.69,
+      "VATRate": 23,
+      "ftChargeItemCase": 5786034805636333571,
+      "Currency": "PLN"
+    }
+  ],
+  "cbPayItems": [
+    {
+      "Quantity": 1,
+      "Description": "Gotówka",
+      "Amount": -3.69,
+      "ftPayItemCase": 5786034805636333569,
+      "Currency": "PLN"
+    }
+  ],
+  "cbReceiptAmount": -3.69,
+  "ftReceiptCase": 5786034805653110785,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_ZeroReceipt/zero-receipt.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/json-requests/PL/SignRequestReceipt_ZeroReceipt/zero-receipt.json
@@ -1,0 +1,11 @@
+{
+  "ftCashBoxID": "{{ ftCashBoxID }}",
+  "ftPosSystemId": "{{ ftPosSystemID }}",
+  "cbTerminalID": "1",
+  "cbReceiptReference": "pl-zero-receipt",
+  "cbReceiptMoment": "2026-08-04T10:00:00Z",
+  "cbChargeItems": [],
+  "cbPayItems": [],
+  "ftReceiptCase": 5786034805636341760,
+  "Currency": "PLN"
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/queue-configuration-pl.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/queue-configuration-pl.json
@@ -1,0 +1,6 @@
+{
+  "Id": "00000000-0000-0000-0000-000000000000",
+  "Package": "fiskaltrust.Middleware.Localization.QueuePL",
+  "Version": "1.3.79",
+  "Configuration": {}
+}

--- a/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/scu-configuration-pl-inmemory.json
+++ b/test/fiskaltrust.Middleware.Test.Launcher/src/fiskaltrust.Middleware.Test.Launcher.v2/scu-configuration-pl-inmemory.json
@@ -1,0 +1,6 @@
+{
+  "Id": "00000000-0000-0000-0000-000000000000",
+  "Package": "fiskaltrust.Middleware.SCU.PL.InMemory",
+  "Version": "1.3.79",
+  "Configuration": {}
+}


### PR DESCRIPTION
## Summary

PL support for the v2 test launcher per [market-pl#52](https://github.com/fiskaltrust/market-pl/issues/52) (part of [market-pl#2](https://github.com/fiskaltrust/market-pl/issues/2), section 3):

- `CashBoxBuilderPL` + `PLSSCDJsonWarper` wire `QueuePLBootstrapper` with the `SCU.PL.InMemory` register and the `InMemoryStorageProvider`
- Market/config selectable via `MW_MARKET` / `MW_QUEUE_CONFIGURATION` / `MW_SCU_CONFIGURATION` env vars (defaults unchanged: ES)
- **`json-requests/PL/**` committed sample set** (un-gitignored for PL only): cash sale, card sale, return (with `cbPreviousReceiptReference`), NIP receipt, zero receipt, daily/monthly closing, out-of-operation — all requests carry `Currency: PLN` incl. every charge/pay item, per rfcs/0705
- PL config templates (`queue-configuration-pl.json`, `scu-configuration-pl-inmemory.json`) committed
- Drive-by fix: the pre-existing ES VeriFactu in-memory mock no longer compiled against the reorganized scu-es models (`GovernmentAPI` moved to `SCU.ES.Common.Models`; a global-namespace xsd type shadows `Cabecera`) — the launcher isn't CI-built, so this had rotted on main

## Verified

`MW_MARKET=PL dotnet run` **exits 0**: echo → initial-operation (fiscalized-check against the in-memory register) → zero receipt → cash sales from the committed samples, all FluentAssertions green.

## Stacking

Contains the queuepl + scu-pl-foundation branches (needs both projects). Targets `market-pl`; diffs collapse as #737/#744/#745 merge into the integration branch.

**Tracked in** fiskaltrust/market-pl#52 (sub-issue of fiskaltrust/market-pl#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)