### PR TITLE
[IT] EpsonRTPrinter: fall back to cached serial number in documento commerciale signatures

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/SignatureFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/SignatureFactory.cs
@@ -72,8 +72,8 @@ public static class SignatureFactory
             new SignaturItem
             {
                 Caption = "<rt-serialnumber>",
-                // Data is required by consumers deserializing the receipt response; a null here
-                // gets omitted from the serialized JSON and breaks their contract.
+                // Last resort against a null from any SCU: consumers require Data, and JSON
+                // serialization omits the property when it is null (#743).
                 Data = data.RTSerialNumber ?? "",
                 ftSignatureFormat = (long) SignaturItem.Formats.Text,
                 ftSignatureType = ITConstants.BASE_STATE |(long) SignatureTypesIT.RTSerialNumber

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/SignatureFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/SignatureFactory.cs
@@ -72,7 +72,9 @@ public static class SignatureFactory
             new SignaturItem
             {
                 Caption = "<rt-serialnumber>",
-                Data = data.RTSerialNumber,
+                // Data is required by consumers deserializing the receipt response; a null here
+                // gets omitted from the serialized JSON and breaks their contract.
+                Data = data.RTSerialNumber ?? "",
                 ftSignatureFormat = (long) SignaturItem.Formats.Text,
                 ftSignatureType = ITConstants.BASE_STATE |(long) SignatureTypesIT.RTSerialNumber
             },

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -253,7 +253,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             }
             var posReceiptSignatur = new POSReceiptSignatureData
             {
-                RTSerialNumber = result?.Receipt?.SerialNumber,
+                RTSerialNumber = result?.Receipt?.SerialNumber ?? _serialnr ?? "",
                 RTZNumber = fiscalReceiptResponse.ZRepNumber,
                 RTDocNumber = fiscalReceiptResponse.ReceiptNumber,
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
@@ -574,9 +574,16 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         }
         else
         {
+            // The reprint directIO (3098) response carries no receiptInfo block, so the serial
+            // number can only come from the cached value queried via GetRTInfoAsync.
+            if (string.IsNullOrEmpty(_serialnr))
+            {
+                _ = await GetRTInfoAsync();
+            }
+
             var posReceiptSignatur = new POSReceiptSignatureData
             {
-                RTSerialNumber = result?.Receipt?.SerialNumber,
+                RTSerialNumber = result?.Receipt?.SerialNumber ?? _serialnr ?? "",
                 RTZNumber = fiscalResponse.ZRepNumber,
                 RTDocNumber = fiscalResponse.ReceiptNumber,
                 RTDocMoment = fiscalResponse.ReceiptDateTime,
@@ -658,7 +665,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
 
             var posReceiptSignatur = new POSReceiptSignatureData
             {
-                RTSerialNumber = result?.Receipt?.SerialNumber,
+                RTSerialNumber = result?.Receipt?.SerialNumber ?? _serialnr ?? "",
                 RTZNumber = fiscalReceiptResponse.ZRepNumber,
                 RTDocNumber = fiscalReceiptResponse.ReceiptNumber,
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
@@ -732,7 +739,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             }
             var posReceiptSignatur = new POSReceiptSignatureData
             {
-                RTSerialNumber = result?.Receipt?.SerialNumber,
+                RTSerialNumber = result?.Receipt?.SerialNumber ?? _serialnr ?? "",
                 RTZNumber = fiscalReceiptResponse.ZRepNumber,
                 RTDocNumber = fiscalReceiptResponse.ReceiptNumber,
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -519,6 +519,13 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             };
         }
 
+        // The reprint directIO (3098) response carries no receiptInfo block, so the serial number
+        // must be read before the reprint. A failure afterwards would error an already printed document.
+        if (string.IsNullOrEmpty(_serialnr))
+        {
+            _ = await GetRTInfoAsync();
+        }
+
         FiscalReceiptResponse fiscalResponse;
         PrinterReceiptResponse result = null;
         try
@@ -574,13 +581,6 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         }
         else
         {
-            // The reprint directIO (3098) response carries no receiptInfo block, so the serial
-            // number can only come from the cached value queried via GetRTInfoAsync.
-            if (string.IsNullOrEmpty(_serialnr))
-            {
-                _ = await GetRTInfoAsync();
-            }
-
             var posReceiptSignatur = new POSReceiptSignatureData
             {
                 RTSerialNumber = result?.Receipt?.SerialNumber ?? _serialnr ?? "",

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ReprintSerialNumberTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ReprintSerialNumberTests.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.ifPOS.v1.it;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    public class ReprintSerialNumberTests
+    {
+        private const string ReprintCommand = "3098";
+        private const string SerialNumberCommand = "3217";
+        private const string StatusCommand = "queryPrinterStatus";
+
+        // Layout the 3217 response data must have for GetSerialNumberAsync: [2..7] digits, [8..9] letters, [10..11] digits.
+        private const string SerialResponseData = "XX123456AB99";
+        private const string RtType = "M";
+        private const string ExpectedSerialNumber = "99MAB123456";
+
+        private static ReceiptRequest Reprint() => new() { ftReceiptCase = 0x4954_2000_0000_3010 };
+
+        private static SignaturItem Reference(SignatureTypesIT signatureType, string data) => new()
+        {
+            Data = data,
+            ftSignatureFormat = (long) SignaturItem.Formats.Text,
+            ftSignatureType = ITConstants.BASE_STATE | (long) signatureType
+        };
+
+        private static ReceiptResponse ResponseWithReferences() => new()
+        {
+            ftSignatures = new[]
+            {
+                Reference(SignatureTypesIT.RTReferenceZNumber, "0090"),
+                Reference(SignatureTypesIT.RTReferenceDocumentNumber, "0006"),
+                Reference(SignatureTypesIT.RTReferenceDocumentMoment, "2026-08-06")
+            }
+        };
+
+        private static EpsonRTPrinterSCU CreateSut(IEpsonFpMateClient client) =>
+            new(NullLogger<EpsonRTPrinterSCU>.Instance, new EpsonRTPrinterSCUConfiguration(), client);
+
+        private static Mock<IEpsonFpMateClient> PrinterReturning(string rtType, ICollection<string> sentPayloads)
+        {
+            // The reprint response omits the addInfo block, as the device does for directIO 3098 (#743).
+            var reprint = SoapSerializer.Serialize(new PrinterReceiptResponse { Success = true });
+            var status = SoapSerializer.Serialize(new StatusResponse
+            {
+                Success = true,
+                Printerstatus = new Printerstatus { RtType = rtType, MfStatus = "02", DailyOpen = "1" }
+            });
+            var serial = SoapSerializer.Serialize(new PrinterCommandResponse
+            {
+                Success = true,
+                CommandResponse = new CommandResponse { ResponseData = SerialResponseData }
+            });
+            var generic = SoapSerializer.Serialize(new PrinterResponse { Success = true });
+
+            var client = new Mock<IEpsonFpMateClient>();
+            client.Setup(c => c.SendCommandAsync(It.IsAny<string>()))
+                  .ReturnsAsync((string payload) =>
+                  {
+                      sentPayloads.Add(payload);
+                      var body = generic;
+                      if (payload.Contains(ReprintCommand))
+                      {
+                          body = reprint;
+                      }
+                      else if (payload.Contains(SerialNumberCommand))
+                      {
+                          body = serial;
+                      }
+                      else if (payload.Contains(StatusCommand))
+                      {
+                          body = status;
+                      }
+                      return new HttpResponseMessage { Content = new StringContent(body) };
+                  });
+            return client;
+        }
+
+        private static async Task<ReceiptResponse> ReprintAsync(string rtType, ICollection<string> sentPayloads)
+        {
+            var sut = CreateSut(PrinterReturning(rtType, sentPayloads).Object);
+            var response = await sut.ProcessReceiptAsync(new ProcessRequest
+            {
+                ReceiptRequest = Reprint(),
+                ReceiptResponse = ResponseWithReferences()
+            });
+            return response.ReceiptResponse;
+        }
+
+        private static SignaturItem SerialNumberSignature(ReceiptResponse response) =>
+            response.ftSignatures.FirstOrDefault(x => x.Caption == "<rt-serialnumber>");
+
+        [Fact]
+        public async Task Reprint_WhenTheResponseCarriesNoReceiptInfo_SignsWithTheSerialNumberOfThePrinter()
+        {
+            var response = await ReprintAsync(RtType, new List<string>());
+
+            response.HasFailed().Should().BeFalse();
+            var serialNumber = SerialNumberSignature(response);
+            serialNumber.Should().NotBeNull();
+            serialNumber.Data.Should().Be(ExpectedSerialNumber);
+        }
+
+        [Fact]
+        public async Task Reprint_WhenThePrinterReportsNoRtType_SignsWithAnEmptyStringInsteadOfNull()
+        {
+            var response = await ReprintAsync(null, new List<string>());
+
+            response.HasFailed().Should().BeFalse();
+            var serialNumber = SerialNumberSignature(response);
+            serialNumber.Should().NotBeNull();
+            serialNumber.Data.Should().NotBeNull();
+            serialNumber.Data.Should().Be("");
+        }
+
+        [Fact]
+        public async Task Reprint_ReadsTheSerialNumberBeforeItSendsTheReprintCommand()
+        {
+            // A failed read after the reprint would error a document that the printer already printed.
+            var sentPayloads = new List<string>();
+
+            await ReprintAsync(RtType, sentPayloads);
+
+            var serialIndex = sentPayloads.FindIndex(x => x.Contains(SerialNumberCommand));
+            var reprintIndex = sentPayloads.FindIndex(x => x.Contains(ReprintCommand));
+            serialIndex.Should().BeGreaterOrEqualTo(0);
+            reprintIndex.Should().BeGreaterOrEqualTo(0);
+            serialIndex.Should().BeLessThan(reprintIndex);
+        }
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/SignatureFactoryTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/SignatureFactoryTests.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.IT.UnitTest
+{
+    public class SignatureFactoryTests
+    {
+        [Fact]
+        public void CreateDocumentoCommercialeSignatures_NullSerialNumber_EmitsEmptyDataInsteadOfNull()
+        {
+            var data = new POSReceiptSignatureData
+            {
+                RTSerialNumber = null!,
+                RTZNumber = 5,
+                RTDocNumber = 3,
+                RTDocMoment = new DateTime(2026, 8, 5, 10, 30, 0),
+                RTDocType = "Documento Gestionale",
+                RTReferenceZNumber = 5,
+                RTReferenceDocNumber = 2,
+                RTReferenceDocMoment = new DateTime(2026, 8, 4, 15, 0, 0)
+            };
+
+            var signatures = SignatureFactory.CreateDocumentoCommercialeSignatures(data);
+
+            var serialNumberSignature = signatures.Single(x => x.Caption == "<rt-serialnumber>");
+            serialNumberSignature.Data.Should().NotBeNull();
+            serialNumberSignature.Data.Should().Be("");
+        }
+
+        [Fact]
+        public void CreateDocumentoCommercialeSignatures_SerialNumberSet_EmitsSerialNumber()
+        {
+            var data = new POSReceiptSignatureData
+            {
+                RTSerialNumber = "99IEB012345",
+                RTZNumber = 5,
+                RTDocNumber = 3,
+                RTDocMoment = new DateTime(2026, 8, 5, 10, 30, 0),
+                RTDocType = "POSRECEIPT"
+            };
+
+            var signatures = SignatureFactory.CreateDocumentoCommercialeSignatures(data);
+
+            var serialNumberSignature = signatures.Single(x => x.Caption == "<rt-serialnumber>");
+            serialNumberSignature.Data.Should().Be("99IEB012345");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #743.

### Problem

Reprints (`0x3010`) on the EpsonRTPrinter SCU run through directIO `3098`. That response carries no `receiptInfo` block, so `ProcessPerformReprint` built the `<rt-serialnumber>` signature with `Data = null`. JSON serialization omits a null property, and consumers that require the field fail to deserialize the response with a 400, even though the printer completed the reprint. The refund and void paths carried the same latent issue.

The 400 arrives after the printer printed and after the queue stored the receipt, so a client retry prints a second copy.

Confirmed again on a device on 2026-08-06. The response held `<rt-serialnumber>` without `Data`, `rt-z-number` `0000`, `rt-doc-number` `0000`, `rt-doc-moment` at the request time, and `ftState` `0x4954200000000000`, the plain success state.

### Fix

- `ProcessPerformReprint` reads the serial number through `GetRTInfoAsync()` when the cached value is empty, and it reads it **before** it sends the reprint command. `GetRTInfoAsync` sends two commands to the printer and it can throw. A failure before the print errors the receipt with no document on paper. A failure after the print would error a document that already exists. The refund path (line 627) and the void path (line 710) already use this order.
- All `POSReceiptSignatureData` construction sites in `EpsonRTPrinterSCU` use `result?.Receipt?.SerialNumber ?? _serialnr ?? ""` instead of a value that can be null.
- Last-resort guard in `SignatureFactory.CreateDocumentoCommercialeSignatures`: `Data = data.RTSerialNumber ?? ""`.

### Scope check (other IT SCUs)

`POSReceiptSignatureData.RTSerialNumber` is declared `string`, not `string?`. Nullable is enabled, and `TreatWarningsAsErrors` is commented out in `scu-it/Directory.Build.props:13`, so the compiler warnings for these assignments go unread. Eight sites outside the reprint path assign a value that can be null:

| SCU | Sites | Source |
| --- | --- | --- |
| CustomRTPrinter | 300, 421, 518, 659, 704 | `_serialnr`, declared `string?` |
| CustomRTServer | 333 | `cashuuid.RTServerSerialNumber` |
| EpsonRTServer | 306 | `tillState.RTServerSerialNumber` |

None of the three SCUs handles `0x3010`, so none reproduces #743. Each one can still emit a null serial number on its own paths when the serial is unknown. The new guard in `SignatureFactory` covers all of them. A change of those eight sites belongs in a separate PR.

### Tests

- New `ReprintSerialNumberTests` covering `ProcessPerformReprint` with a mocked `IEpsonFpMateClient`:
  - a `3098` response without an `addInfo` block signs the serial number of the printer,
  - a printer that reports no `rtType` signs `""` and never `null`,
  - the SCU reads the serial number before it sends the reprint command.
- All three tests fail against `main` and pass with this change.
- New `SignatureFactoryTests` covering the null-serial guard.

Local results: EpsonRTPrinter 12/12, SCU.IT UnitTest 5/5, CustomRTServer 32 passed with 4 skipped, EpsonRTServer 85/85. The CustomRTPrinter suite stays device-gated and reports 32 skipped.

### Open point

Device validation of the fix on a physical Epson RT printer is still pending.

The reprint signature still reports `rt-z-number` `0000`, `rt-doc-number` `0000` and `rt-doc-moment` at the request time, because the `3098` response carries none of those values. The original document values remain available in `rt-reference-z-number`, `rt-reference-doc-number` and `rt-reference-doc-moment`. A change of the three fields is a behaviour change beyond #743 and needs its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
