### PR TITLE
fix(it): validate customer codice fiscale / partita IVA before reaching the RT device

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/CustomerTaxIdValidation.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/CustomerTaxIdValidation.cs
@@ -1,0 +1,82 @@
+using fiskaltrust.ifPOS.v1;
+
+namespace fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
+
+/// <summary>
+/// Request level validation of the customer tax identifiers. Both identifiers are optional: a receipt
+/// without cbCustomer, or with an empty codice fiscale / partita IVA, is valid. A value that is present
+/// but malformed fails the receipt, because the RT device would either reject it or - worse - print an
+/// unusable "scontrino parlante" without telling the PoS anything.
+/// </summary>
+public static class CustomerTaxIdValidation
+{
+    public const string CustomerTaxIdErrorCaption = "it-customer-taxid-invalid";
+
+    /// <summary>
+    /// True only for receipts that actually carry a customer tax identifier worth validating.
+    /// Management receipts (initial operation, out of operation, zero receipt, daily/monthly/yearly
+    /// closing, reprint) are excluded on purpose: a PoS that leaves a stale cbCustomer on a Z-closing
+    /// must never be prevented from closing the day.
+    /// </summary>
+    public static bool CarriesCustomerTaxIds(this ReceiptRequest receiptRequest)
+    {
+        if ((receiptRequest == null) || string.IsNullOrEmpty(receiptRequest.cbCustomer))
+        {
+            return false;
+        }
+
+        if (receiptRequest.IsInitialOperationReceipt() || receiptRequest.IsOutOfOperationReceipt() || receiptRequest.IsZeroReceipt())
+        {
+            return false;
+        }
+
+        if (receiptRequest.IsDailyClosing() || receiptRequest.IsMonthlyClosing() || receiptRequest.IsYearlyClosing())
+        {
+            return false;
+        }
+
+        if (receiptRequest.IsReprint())
+        {
+            return false;
+        }
+
+        // Malformed cbCustomer JSON yields null today and is silently ignored; that behaviour is kept.
+        var customer = receiptRequest.GetCustomer();
+        if (customer == null)
+        {
+            return false;
+        }
+
+        return !string.IsNullOrWhiteSpace(customer.CustomerId) || !string.IsNullOrWhiteSpace(customer.CustomerVATId);
+    }
+
+    /// <summary>
+    /// Validates <see cref="Customer.CustomerId"/> (codice fiscale) and <see cref="Customer.CustomerVATId"/>
+    /// (partita IVA) of the request's cbCustomer. Empty fields are valid - both identifiers are optional.
+    /// </summary>
+    /// <param name="errorMessage">The failure reason, or null when the request is valid.</param>
+    public static bool TryValidateCustomerTaxIds(this ReceiptRequest receiptRequest, out string? errorMessage)
+    {
+        errorMessage = null;
+
+        var customer = receiptRequest?.GetCustomer();
+        if (customer == null)
+        {
+            return true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(customer.CustomerId) && !ItalyValidationHelpers.IsValidCodiceFiscale(customer.CustomerId))
+        {
+            errorMessage = $"The given codice fiscale '{customer.CustomerId}' is not valid. cbCustomer.CustomerId must contain either a 16 character Italian codice fiscale with a valid check character, or an 11 digit partita IVA, or must be left empty.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(customer.CustomerVATId) && !ItalyValidationHelpers.IsValidPartitaIva(customer.CustomerVATId))
+        {
+            errorMessage = $"The given partita IVA '{customer.CustomerVATId}' is not valid. cbCustomer.CustomerVATId must contain 11 digits with a valid check digit, optionally prefixed with 'IT', or must be left empty.";
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/ItalyValidationHelpers.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/ItalyValidationHelpers.cs
@@ -1,0 +1,227 @@
+using System;
+
+namespace fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
+
+/// <summary>
+/// Validation and normalization of the Italian tax identifiers carried by <see cref="Customer"/>: the
+/// codice fiscale (<see cref="Customer.CustomerId"/>) and the partita IVA (<see cref="Customer.CustomerVATId"/>).
+/// Algorithms: DM 23/12/1976 (codice fiscale and its check character) and DPR 605/1973 art. 4
+/// (partita IVA check digit).
+/// </summary>
+public static class ItalyValidationHelpers
+{
+    private const int CodiceFiscaleLength = 16;
+    private const int PartitaIvaLength = 11;
+    private const string CountryPrefix = "IT";
+
+    /// <summary>Month letters of the codice fiscale; index + 1 is the month.</summary>
+    private const string MonthLetters = "ABCDEHLMPRST";
+
+    /// <summary>Letters that replace a digit in case of omocodia; the index is the replaced digit.</summary>
+    private const string OmocodiaLetters = "LMNPQRSTUV";
+
+    /// <summary>
+    /// Value of a character sitting on an odd (1-based) position of the codice fiscale: digits are first
+    /// mapped to letters ('0' -> 'A' ... '9' -> 'J'), the value is then the index in this string.
+    /// </summary>
+    private const string OddPositionValues = "BAKPLCQDREVOSFTGUHMINJWZYX";
+
+    /// <summary>Trims and upper-cases a tax identifier. Returns an empty string for null.</summary>
+    public static string Normalize(string? value) => value?.Trim().ToUpperInvariant() ?? "";
+
+    /// <summary>
+    /// <see cref="Normalize(string?)"/> plus unconditional removal of the optional 'IT' country prefix,
+    /// which the RT devices do not expect on a partita IVA.
+    /// </summary>
+    public static string NormalizeVatId(string? value)
+    {
+        var normalized = Normalize(value);
+        return normalized.StartsWith(CountryPrefix, StringComparison.Ordinal)
+            ? normalized.Substring(CountryPrefix.Length)
+            : normalized;
+    }
+
+    /// <summary>
+    /// <see cref="Normalize(string?)"/> plus removal of the 'IT' country prefix, but only when what
+    /// remains is an 11 digit partita IVA. A codice fiscale is never stripped, because a surname can
+    /// legitimately start with 'IT' (e.g. ITALIANO) and blind stripping would corrupt the code.
+    /// </summary>
+    public static string NormalizeTaxCode(string? value)
+    {
+        var normalized = Normalize(value);
+        if (!normalized.StartsWith(CountryPrefix, StringComparison.Ordinal))
+        {
+            return normalized;
+        }
+
+        var withoutPrefix = normalized.Substring(CountryPrefix.Length);
+        return ((withoutPrefix.Length == PartitaIvaLength) && IsAllDigits(withoutPrefix)) ? withoutPrefix : normalized;
+    }
+
+    /// <summary>
+    /// Picks the tax identifier to hand to a device that offers a single slot for it (the Custom printer
+    /// fixed line, the Epson directIO and printRecTaxID): the codice fiscale takes precedence over the
+    /// partita IVA. Both values are normalized, so a whitespace only or empty codice fiscale correctly
+    /// falls through to the partita IVA. Returns an empty string when the customer carries neither.
+    /// </summary>
+    public static string SelectCustomerTaxId(string? customerId, string? customerVatId)
+    {
+        var taxCode = NormalizeTaxCode(customerId);
+        return (taxCode.Length > 0) ? taxCode : NormalizeVatId(customerVatId);
+    }
+
+    /// <summary>
+    /// Validates an Italian partita IVA: 11 digits with a valid check digit (DPR 605/1973 art. 4).
+    /// An 'IT' country prefix is accepted and stripped; any other country prefix makes the value invalid.
+    /// </summary>
+    public static bool IsValidPartitaIva(string? partitaIva)
+    {
+        if (string.IsNullOrWhiteSpace(partitaIva))
+        {
+            return false;
+        }
+
+        var value = NormalizeVatId(partitaIva);
+        if ((value.Length != PartitaIvaLength) || !IsAllDigits(value))
+        {
+            return false;
+        }
+
+        var sum = 0;
+        for (var i = 0; i < (PartitaIvaLength - 1); i++)
+        {
+            var digit = value[i] - '0';
+
+            // Digits on even 1-based positions are doubled; a two digit result is reduced by 9.
+            if ((i % 2) != 0)
+            {
+                digit *= 2;
+                if (digit > 9)
+                {
+                    digit -= 9;
+                }
+            }
+
+            sum += digit;
+        }
+
+        var checkDigit = value[PartitaIvaLength - 1] - '0';
+
+        // '00000000000' satisfies the checksum but is never an issued partita IVA - it is a placeholder
+        // that PoS systems send when no customer is known, so it is rejected explicitly.
+        if ((sum == 0) && (checkDigit == 0))
+        {
+            return false;
+        }
+
+        return checkDigit == ((10 - (sum % 10)) % 10);
+    }
+
+    /// <summary>
+    /// Validates an Italian codice fiscale: 16 characters matching
+    /// ^[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$ with a
+    /// plausible day of birth and a valid check character (CIN).
+    /// Legal entities use their 11 digit partita IVA as codice fiscale, so such values are accepted as
+    /// well and validated with <see cref="IsValidPartitaIva(string?)"/>.
+    /// </summary>
+    public static bool IsValidCodiceFiscale(string? codiceFiscale)
+    {
+        if (string.IsNullOrWhiteSpace(codiceFiscale))
+        {
+            return false;
+        }
+
+        var value = Normalize(codiceFiscale);
+        if (value.Length != CodiceFiscaleLength)
+        {
+            return IsValidPartitaIva(value);
+        }
+
+        return HasValidCodiceFiscaleShape(value) && (value[CodiceFiscaleLength - 1] == CalculateCin(value));
+    }
+
+    private static bool HasValidCodiceFiscaleShape(string value)
+    {
+        // Positions 1-6 carry the surname and name letters.
+        for (var i = 0; i < 6; i++)
+        {
+            if (!IsLetter(value[i]))
+            {
+                return false;
+            }
+        }
+
+        // Position 12 is the first character of the Belfiore code, position 16 the check character.
+        if (!IsLetter(value[11]) || !IsLetter(value[15]))
+        {
+            return false;
+        }
+
+        // Position 9 is the month of birth.
+        if (MonthLetters.IndexOf(value[8]) < 0)
+        {
+            return false;
+        }
+
+        // Positions 7-8 (year), 10-11 (day) and 13-15 (Belfiore digits) carry a number, written either as
+        // a digit or - in case of omocodia - as a substitute letter.
+        if (!IsNumericCharacter(value[6]) || !IsNumericCharacter(value[7])
+            || !IsNumericCharacter(value[9]) || !IsNumericCharacter(value[10])
+            || !IsNumericCharacter(value[12]) || !IsNumericCharacter(value[13]) || !IsNumericCharacter(value[14]))
+        {
+            return false;
+        }
+
+        // The day of birth is increased by 40 for women.
+        var day = (DecodeDigit(value[9]) * 10) + DecodeDigit(value[10]);
+        return ((day >= 1) && (day <= 31)) || ((day >= 41) && (day <= 71));
+    }
+
+    /// <summary>
+    /// Calculates the check character (CIN) over the first 15 characters. The characters are used exactly
+    /// as they are written: omocodia letters are deliberately NOT decoded back to digits, because the CIN
+    /// of an omocode is recalculated on the substituted code. Only called after
+    /// <see cref="HasValidCodiceFiscaleShape(string)"/>, so every character is a digit or A-Z.
+    /// </summary>
+    private static char CalculateCin(string value)
+    {
+        var sum = 0;
+        for (var i = 0; i < (CodiceFiscaleLength - 1); i++)
+        {
+            var character = value[i];
+            var isDigit = (character >= '0') && (character <= '9');
+            if ((i % 2) == 0)
+            {
+                var letter = isDigit ? (char) ('A' + (character - '0')) : character;
+                sum += OddPositionValues.IndexOf(letter);
+            }
+            else
+            {
+                sum += isDigit ? (character - '0') : (character - 'A');
+            }
+        }
+
+        return (char) ('A' + (sum % 26));
+    }
+
+    private static bool IsLetter(char character) => (character >= 'A') && (character <= 'Z');
+
+    private static bool IsNumericCharacter(char character) => DecodeDigit(character) >= 0;
+
+    /// <summary>Digit carried by the given character, decoding the omocodia letters, or -1.</summary>
+    private static int DecodeDigit(char character) =>
+        ((character >= '0') && (character <= '9')) ? (character - '0') : OmocodiaLetters.IndexOf(character);
+
+    private static bool IsAllDigits(string value)
+    {
+        foreach (var character in value)
+        {
+            if ((character < '0') || (character > '9'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
@@ -260,9 +260,9 @@ public sealed class CustomRTPrinterSCU : LegacySCU
             }
 
             // Customer fiscal code / VAT (scontrino parlante) — goes AFTER items/subtotal and BEFORE printRecTotal.
-            var customerCfOrVat = customer?.CustomerId ?? customer?.CustomerVATId;
+            var customerCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
             if (!string.IsNullOrEmpty(customerCfOrVat))
-                records.Add(new FixedLines { Pitch = "B", Description = customerCfOrVat.Trim().ToUpperInvariant() });
+                records.Add(new FixedLines { Pitch = "B", Description = customerCfOrVat });
 
             if (receiptRequest.cbPayItems?.Any() == true)
             {
@@ -315,7 +315,9 @@ public sealed class CustomRTPrinterSCU : LegacySCU
                 RTDocMoment = docMoment,
                 RTDocType = "POSRECEIPT",
                 RTCodiceLotteria = lotteryCode,
-                RTCustomerID = customer?.CustomerId ?? ""
+                // Same value that was printed on the receipt: normalized, and falling back to the
+                // partita IVA so a business customer is reported even when only CustomerVATId is set.
+                RTCustomerID = customerCfOrVat
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignature).ToArray();
             return receiptResponse;
@@ -633,9 +635,9 @@ public sealed class CustomRTPrinterSCU : LegacySCU
                 records.Add(new PrintRecSubtotal());
             }
 
-            var deliveryCfOrVat = customer?.CustomerId ?? customer?.CustomerVATId;
+            var deliveryCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
             if (!string.IsNullOrEmpty(deliveryCfOrVat))
-                records.Add(new FixedLines { Pitch = "B", Description = deliveryCfOrVat.Trim().ToUpperInvariant() });
+                records.Add(new FixedLines { Pitch = "B", Description = deliveryCfOrVat });
 
             if (receiptRequest.cbPayItems?.Any() == true)
             {
@@ -674,7 +676,8 @@ public sealed class CustomRTPrinterSCU : LegacySCU
                 RTDocMoment = response.AddInfo?.DateTime ?? DateTime.UtcNow,
                 RTDocType = "POSRECEIPT",
                 RTCodiceLotteria = lotteryCode,
-                RTCustomerID = customer?.CustomerId ?? ""
+                // Same value that was printed on the delivery note, see PerformClassicReceiptAsync.
+                RTCustomerID = deliveryCfOrVat
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignature).ToArray();
             return receiptResponse;

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.Clients;
 using fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.Models.Requests;
 using fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.Models.Responses;
@@ -62,6 +63,17 @@ public sealed class CustomRTPrinterSCU : LegacySCU
         try
         {
             var receiptCase = request.ReceiptRequest.GetReceiptCase();
+
+            // Reject a malformed codice fiscale / partita IVA before contacting the printer at all, so the
+            // PoS gets the validation error instead of a device or network error.
+            if (request.ReceiptRequest.CarriesCustomerTaxIds()
+                && !request.ReceiptRequest.TryValidateCustomerTaxIds(out var customerTaxIdError))
+            {
+                _logger.LogWarning("({receiptreference}) Rejected: {error}", request.ReceiptRequest.cbReceiptReference, customerTaxIdError);
+                request.ReceiptResponse.SetReceiptResponseErrored(CustomerTaxIdValidation.CustomerTaxIdErrorCaption, customerTaxIdError!);
+                return CreateResponse(request.ReceiptResponse);
+            }
+
             if (string.IsNullOrEmpty(_serialnr))
             {
                 var info = await _printerClient.SendCommand<InfoResp>(new GetInfo());

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
@@ -4,6 +4,7 @@ using fiskaltrust.ifPOS.v1;
 using System.Linq;
 using Newtonsoft.Json;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.CustomRTServer.Models;
 using System.Globalization;
 
@@ -176,21 +177,14 @@ public static class CustomRTServerMapping
     /// Reads the customer identification from cbCustomer. By convention across the IT SCUs
     /// (cf. CustomRTPrinterSCU) Customer.CustomerId carries the codice fiscale and
     /// Customer.CustomerVATId the partita IVA, so each one maps to its own document field.
-    /// Both values are forwarded as-is: validating their shape is handled separately.
+    /// Both values are forwarded as-is apart from normalization: their shape is validated upstream in
+    /// CustomRTServerSCU.ProcessReceiptAsync.
     /// </summary>
     public static (string fiscalcode, string vatcode) GetCustomerDataForReceiptRequest(ReceiptRequest receiptRequest)
     {
         var customer = receiptRequest.GetCustomer();
-        return (Normalize(customer?.CustomerId), NormalizeVatId(customer?.CustomerVATId));
+        return (ItalyValidationHelpers.NormalizeTaxCode(customer?.CustomerId), ItalyValidationHelpers.NormalizeVatId(customer?.CustomerVATId));
     }
-
-    private static string NormalizeVatId(string? vatId)
-    {
-        var vat = Normalize(vatId);
-        return vat.StartsWith("IT", StringComparison.Ordinal) ? vat.Substring(2) : vat;
-    }
-
-    private static string Normalize(string? value) => value?.Trim().ToUpperInvariant() ?? "";
 
     public static bool InverseAmount(ReceiptRequest receiptRequest, ChargeItem chargeItem) => receiptRequest.IsRefund() || receiptRequest.IsVoid() || chargeItem.IsRefund() || chargeItem.IsVoid();
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerSCU.cs
@@ -3,6 +3,7 @@ using System;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using Microsoft.Extensions.Logging;
 using fiskaltrust.ifPOS.v1;
 using System.Linq;
@@ -67,6 +68,19 @@ public sealed class CustomRTServerSCU : LegacySCU
         try
         {
             var receiptCase = request.ReceiptRequest.GetReceiptCase();
+
+            // Reject a malformed codice fiscale / partita IVA before any RT Server call. This has to be an
+            // explicit pre-check rather than a thrown exception: the catch below would relabel it as
+            // rt-server-generic-error and bury the actual cause.
+            if (request.ReceiptRequest.CarriesCustomerTaxIds()
+                && !request.ReceiptRequest.TryValidateCustomerTaxIds(out var customerTaxIdError))
+            {
+                _logger.LogWarning("({receiptreference}) Rejected: {error}", request.ReceiptRequest.cbReceiptReference, customerTaxIdError);
+                request.ReceiptResponse.SetReceiptResponseErrored(CustomerTaxIdValidation.CustomerTaxIdErrorCaption, customerTaxIdError!);
+                request.ReceiptResponse.ftState = 0x4954_2001_EEEE_EEEE;
+                return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, new List<SignaturItem>());
+            }
+
             if (request.ReceiptRequest.IsInitialOperationReceipt())
             {
                 (var signatures, var state) = await PerformInitOperationAsync(request.ReceiptRequest, request.ReceiptResponse);

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -212,6 +212,18 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
     private static string GetLotteryCode(ReceiptRequest receiptRequest)
         => receiptRequest.GetLotteryData()?.servizi_lotteriadegliscontrini_gov_it?.codicelotteria ?? "";
 
+    /// <summary>
+    /// Customer tax identifier reported in the RTCustomerID signature. Uses the same selection rule as
+    /// EpsonCommandFactory, so the signature always carries what was actually sent to the printer: on the
+    /// document types signed here (POSRECEIPT/REFUND/VOID) the request level validation has already run,
+    /// so a non empty value is a valid codice fiscale or partita IVA.
+    /// </summary>
+    private static string GetCustomerTaxId(ReceiptRequest receiptRequest)
+    {
+        var customer = receiptRequest.GetCustomer();
+        return ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+    }
+
     public async Task<ReceiptResponse> PerformProtocolReceiptAsync(ReceiptRequest receiptRequest, ReceiptResponse receiptResponse)
     {
         string? data = null;
@@ -270,7 +282,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "POSRECEIPT",
                 RTCodiceLotteria = GetLotteryCode(receiptRequest),
-                RTCustomerID = "", // Todo dread customerid from data
+                RTCustomerID = GetCustomerTaxId(receiptRequest),
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignatur).ToArray();
             _lastSuccessfulDoc = (fiscalReceiptResponse.ZRepNumber, fiscalReceiptResponse.ReceiptNumber);
@@ -326,7 +338,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "POSRECEIPT",
                 RTCodiceLotteria = GetLotteryCode(receiptRequest),
-                RTCustomerID = "", // Todo dread customerid from data
+                RTCustomerID = GetCustomerTaxId(receiptRequest),
             };
             receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(posReceiptSignatur).ToArray();
             _lastSuccessfulDoc = (fiscalReceiptResponse.ZRepNumber, fiscalReceiptResponse.ReceiptNumber);
@@ -675,7 +687,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "REFUND",
                 RTCodiceLotteria = "",
-                RTCustomerID = "", // Todo dread customerid from data
+                RTCustomerID = GetCustomerTaxId(request.ReceiptRequest),
                 RTReferenceZNumber = long.Parse(referenceZNumberString),
                 RTReferenceDocNumber = long.Parse(referenceDocNumberString),
                 RTReferenceDocMoment = referenceDateTime
@@ -749,7 +761,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 RTDocMoment = fiscalReceiptResponse.ReceiptDateTime,
                 RTDocType = "VOID",
                 RTCodiceLotteria = "",
-                RTCustomerID = "", // Todo dread customerid from data
+                RTCustomerID = GetCustomerTaxId(request.ReceiptRequest),
                 RTReferenceZNumber = long.Parse(referenceZNumber),
                 RTReferenceDocNumber = long.Parse(referenceDocNumber),
                 RTReferenceDocMoment = DateTime.Parse(referenceDateTime)

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -1,6 +1,7 @@
 ﻿using fiskaltrust.ifPOS.v1.errors;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
 using Newtonsoft.Json;
@@ -69,6 +70,16 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         try
         {
             var receiptCase = request.ReceiptRequest.GetReceiptCase();
+
+            // Reject a malformed codice fiscale / partita IVA before anything is sent to the printer.
+            if (request.ReceiptRequest.CarriesCustomerTaxIds()
+                && !request.ReceiptRequest.TryValidateCustomerTaxIds(out var customerTaxIdError))
+            {
+                _logger.LogWarning("({receiptreference}) Rejected: {error}", request.ReceiptRequest.cbReceiptReference, customerTaxIdError);
+                request.ReceiptResponse.SetReceiptResponseErrored(CustomerTaxIdValidation.CustomerTaxIdErrorCaption, customerTaxIdError!);
+                return Helpers.CreateResponse(request.ReceiptResponse);
+            }
+
             if (request.ReceiptRequest.IsInitialOperationReceipt())
             {
                 return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, SignatureFactory.CreateInitialOperationSignatures().ToList());

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using System.Security.Cryptography;
@@ -327,26 +328,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             fiscalReceipt.AdjustmentAndMessages = new List<AdjustmentAndMessage>();
             fiscalReceipt.PrintRecSubtotalAdjustment = GetSubtotalAdjustments(receiptRequest);
             fiscalReceipt.RecTotalAndMessages = GetTotalAndMessages(receiptRequest);
-            var customerData = receiptRequest.GetCustomer();
-            if (customerData != null)
-            {
-                if (!string.IsNullOrEmpty(customerData.CustomerVATId))
-                {
-                    var vat = customerData.CustomerVATId!;
-                    if (vat.ToUpper().StartsWith("IT"))
-                    {
-                        vat = vat.Substring(2);
-                    }
-                    if (vat.Length == 11)
-                    {
-                        fiscalReceipt.DirectIOCommands.Add(new DirectIO
-                        {
-                            Command = "1060",
-                            Data = "01" + vat,
-                        });
-                    }
-                }
-            }
+            AddCustomerTaxIdDirectIO(fiscalReceipt, receiptRequest);
 
             var lotteryData = receiptRequest.GetLotteryData();
             if (!string.IsNullOrEmpty(lotteryData?.servizi_lotteriadegliscontrini_gov_it?.codicelotteria))
@@ -359,6 +341,48 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             AddTrailerLines(configuration, receiptRequest, fiscalReceipt);
             return fiscalReceipt;
         }
+
+        private const int PartitaIvaLength = 11;
+        private const int CodiceFiscaleLength = 16;
+
+        /// <summary>
+        /// Emits the customer tax identifier for the "scontrino parlante". The codice fiscale takes
+        /// precedence over the partita IVA, as in the Custom SCUs. The two identifiers use different
+        /// commands, which share the same data layout: an 11 digit partita IVA goes to directIO 1060, a
+        /// 16 character alphanumeric codice fiscale to directIO 1061.
+        /// Shape and checksum are validated upstream in EpsonRTPrinterSCU.ProcessReceiptAsync, so the checks
+        /// here are only defence in depth for the receipts the validation gate deliberately skips: a
+        /// malformed value must still be dropped rather than sent to the printer, which would answer with a
+        /// checksum error instead of printing.
+        /// </summary>
+        private static void AddCustomerTaxIdDirectIO(FiscalReceipt fiscalReceipt, ReceiptRequest receiptRequest)
+        {
+            var customer = receiptRequest.GetCustomer();
+            var taxId = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+
+            string command;
+            if ((taxId.Length == PartitaIvaLength) && taxId.All(char.IsDigit))
+            {
+                command = "1060";
+            }
+            else if ((taxId.Length == CodiceFiscaleLength) && taxId.All(IsUpperCaseAlphanumeric))
+            {
+                command = "1061";
+            }
+            else
+            {
+                return;
+            }
+
+            fiscalReceipt.DirectIOCommands.Add(new DirectIO
+            {
+                Command = command,
+                Data = "01" + taxId,
+            });
+        }
+
+        /// <summary>The tax identifiers are already upper cased by the shared normalization.</summary>
+        private static bool IsUpperCaseAlphanumeric(char c) => ((c >= '0') && (c <= '9')) || ((c >= 'A') && (c <= 'Z'));
 
         private static void AddTrailerLines(EpsonRTPrinterSCUConfiguration configuration, ReceiptRequest receiptRequest, FiscalReceipt fiscalReceipt)
         {
@@ -413,26 +437,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 AdjustmentAndMessages = new List<AdjustmentAndMessage>(),
                 RecTotalAndMessages = GetTotalAndMessages(receiptRequest)
             };
-            var customerData = receiptRequest.GetCustomer();
-            if (customerData != null)
-            {
-                if (!string.IsNullOrEmpty(customerData.CustomerVATId))
-                {
-                    var vat = customerData.CustomerVATId!;
-                    if (vat.ToUpper().StartsWith("IT"))
-                    {
-                        vat = vat.Substring(2);
-                    }
-                    if (vat.Length == 11)
-                    {
-                        fiscalReceipt.DirectIOCommands.Add(new DirectIO
-                        {
-                            Command = "1060",
-                            Data = "01" + vat,
-                        });
-                    }
-                }
-            }
+            AddCustomerTaxIdDirectIO(fiscalReceipt, receiptRequest);
             AddTrailerLines(configuration, receiptRequest, fiscalReceipt);
             return fiscalReceipt;
         }
@@ -453,26 +458,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 AdjustmentAndMessages = new List<AdjustmentAndMessage>(),
                 RecTotalAndMessages = GetTotalAndMessages(receiptRequest)
             };
-            var customerData = receiptRequest.GetCustomer();
-            if (customerData != null)
-            {
-                if (!string.IsNullOrEmpty(customerData.CustomerVATId))
-                {
-                    var vat = customerData.CustomerVATId!;
-                    if (vat.ToUpper().StartsWith("IT"))
-                    {
-                        vat = vat.Substring(2);
-                    }
-                    if (vat.Length == 11)
-                    {
-                        fiscalReceipt.DirectIOCommands.Add(new DirectIO
-                        {
-                            Command = "1060",
-                            Data = "01" + vat,
-                        });
-                    }
-                }
-            }
+            AddCustomerTaxIdDirectIO(fiscalReceipt, receiptRequest);
             AddTrailerLines(configuration, receiptRequest, fiscalReceipt);
             return fiscalReceipt;
         }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -6,6 +6,7 @@ using System.Security;
 using System.Text;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
 
 namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
@@ -154,7 +155,11 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
             }
             else
             {
-                var customerTaxId = receiptRequest.GetCustomer()?.CustomerVATId;
+                // printRecTaxID offers a single slot, so the codice fiscale takes precedence over the
+                // partita IVA, as in the Custom SCUs. Normalized so the IT country prefix is not
+                // forwarded to the server as part of the tax id.
+                var customer = receiptRequest.GetCustomer();
+                var customerTaxId = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
                 if (!string.IsNullOrEmpty(customerTaxId))
                 {
                     sb.Append($"<printRecTaxID taxID=\"{Escape(customerTaxId)}\" />");

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -82,6 +83,16 @@ public sealed class EpsonRTServerSCU : LegacySCU
         try
         {
             var receiptCase = request.ReceiptRequest.GetReceiptCase();
+
+            // Reject a malformed codice fiscale / partita IVA before any RT Server call.
+            if (request.ReceiptRequest.CarriesCustomerTaxIds()
+                && !request.ReceiptRequest.TryValidateCustomerTaxIds(out var customerTaxIdError))
+            {
+                _logger.LogWarning("({receiptreference}) Rejected: {error}", request.ReceiptRequest.cbReceiptReference, customerTaxIdError);
+                request.ReceiptResponse.SetReceiptResponseErrored(CustomerTaxIdValidation.CustomerTaxIdErrorCaption, customerTaxIdError!);
+                request.ReceiptResponse.ftState = StateFailed;
+                return ProcessResponseHelpers.CreateResponse(request.ReceiptResponse, new List<SignaturItem>());
+            }
 
             if (request.ReceiptRequest.IsInitialOperationReceipt())
             {

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -312,6 +312,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
         }
         PersistState();
 
+        var customer = receiptRequest.GetCustomer();
         var signatureData = new POSReceiptSignatureData
         {
             RTSerialNumber = tillState.RTServerSerialNumber,
@@ -321,7 +322,11 @@ public sealed class EpsonRTServerSCU : LegacySCU
             RTDocType = docType switch { 1 => "REFUND", 3 => "VOID", _ => "POSRECEIPT" },
             RTServerSHAMetadata = document.Ccdc,
             RTCodiceLotteria = document.LotteryCode,
-            RTCustomerID = "",
+            // Reports what was actually sent: printRecTaxID is suppressed when a lottery code is present,
+            // because the two are mutually exclusive (see EpsonRTServerMapping).
+            RTCustomerID = string.IsNullOrEmpty(document.LotteryCode)
+                ? ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId)
+                : "",
             RTReferenceZNumber = document.ReferenceZNumber,
             RTReferenceDocNumber = document.ReferenceDocNumber,
             RTReferenceDocMoment = document.ReferenceDocMoment

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ITSSCDTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ITSSCDTests.cs
@@ -2,6 +2,7 @@
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.DependencyInjection;
@@ -336,7 +337,7 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
         }
 
         [Fact]
-        public async Task ProcessPosReceipt_0x4954_2000_0000_0001_TakeAway_Delivery_Card_WithInvalidCustomerIVA()
+        public async Task ProcessPosReceipt_0x4954_2000_0000_0001_TakeAway_Delivery_Card_WithInvalidCustomerIVA_ShouldReturnError()
         {
             var itsscd = GetSUT();
             var result = await itsscd.ProcessReceiptAsync(new ProcessRequest
@@ -346,23 +347,11 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
             });
 
             using var scope = new AssertionScope();
-            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTSerialNumber));
-            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTZNumber));
-            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentNumber));
-            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentMoment));
-            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentType));
-        }
-
-        [Fact]
-        public async Task ProcessPosReceipt_0x4954_2000_0000_0001_TakeAway_Delivery_Card_WithInvalidCustomerIVA_ShouldReturnError()
-        {
-            var itsscd = GetSUT();
-            var result = await itsscd.ProcessReceiptAsync(new ProcessRequest
-            {
-                ReceiptRequest = ReceiptExamples.GetTakeAway_Delivery_Card_WithInvalidCustomerIva(),
-                ReceiptResponse = _receiptResponse
-            });
             result.ReceiptResponse.HasFailed().Should().BeTrue();
+            result.ReceiptResponse.ftSignatures.Should().ContainSingle()
+                .Which.Caption.Should().Be(CustomerTaxIdValidation.CustomerTaxIdErrorCaption);
+            // No document was created, so none of the RT signatures may be present.
+            result.ReceiptResponse.ftSignatures.Should().NotContain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentNumber));
         }
 
         [Fact]

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptRequests/PosReceipts/0x0005_Cash_cbCustomer.json
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptRequests/PosReceipts/0x0005_Cash_cbCustomer.json
@@ -24,6 +24,6 @@
       "Amount": 107
     }
   ],
-  "cbCustomer": "{\r\n    \"CustomerName\": \"fiskaltrust\",\r\n    \"CustomerId\": \"0\",\r\n    \"CustomerType\": \"\",\r\n    \"CustomerStreet\": \"Alpenstra\u00DFe 99\",\r\n    \"CustomerZip\": \"5020\",\r\n    \"CustomerCity\": \"Salzburg\",\r\n    \"CustomerCountry\": \"AT\"  }",
+  "cbCustomer": "{\r\n    \"CustomerName\": \"fiskaltrust\",\r\n    \"CustomerId\": \"\",\r\n    \"CustomerType\": \"\",\r\n    \"CustomerStreet\": \"Alpenstra\u00DFe 99\",\r\n    \"CustomerZip\": \"5020\",\r\n    \"CustomerCity\": \"Salzburg\",\r\n    \"CustomerCountry\": \"AT\"  }",
   "ftReceiptCase": 5283883447184523269
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.UnitTest/IntegrationTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.UnitTest/IntegrationTests.cs
@@ -361,7 +361,7 @@ public class IntegrationTests
             ftReceiptCase = 0x4954_2000_0000_0005, // DeliveryNote0x0005
             cbReceiptMoment = DateTime.UtcNow,
             cbReceiptAmount = 5.00m,
-            cbCustomer = """{"CustomerId":"IT12345678901","CustomerName":"Mario Rossi","CustomerStreet":"Via Roma 1","CustomerZip":"00100","CustomerCity":"Roma"}""",
+            cbCustomer = """{"CustomerId":"RSSMRA80A01H501U","CustomerName":"Mario Rossi","CustomerStreet":"Via Roma 1","CustomerZip":"00100","CustomerCity":"Roma"}""",
             cbChargeItems = new[]
             {
                 new ChargeItem { Description = "Prodotto A", Amount = 3.00m, Quantity = 1, ftChargeItemCase = 0x4954_2000_0000_0011 },

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
@@ -7,6 +7,7 @@ using FluentAssertions.Execution;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
 using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.CustomRTServer.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
@@ -77,14 +78,15 @@ public class CustomRTServerSCUTests : IDisposable
         return new CustomRTServerSCU(_scuId, NullLogger<CustomRTServerSCU>.Instance, config, client, queue);
     }
 
-    private ProcessRequest CreateRequest(long ftReceiptCase) => new ProcessRequest
+    private ProcessRequest CreateRequest(long ftReceiptCase, string cbCustomer = null) => new ProcessRequest
     {
         ReceiptRequest = new ReceiptRequest
         {
             ftReceiptCase = ftReceiptCase,
             cbReceiptMoment = DateTime.UtcNow,
             cbChargeItems = Array.Empty<ChargeItem>(),
-            cbPayItems = Array.Empty<PayItem>()
+            cbPayItems = Array.Empty<PayItem>(),
+            cbCustomer = cbCustomer
         },
         ReceiptResponse = new ReceiptResponse
         {
@@ -161,6 +163,43 @@ public class CustomRTServerSCUTests : IDisposable
 
         result.ReceiptResponse.ftSignatures.Should().Contain(s => s.Caption == "rt-server-dailyclosing-error");
         result.ReceiptResponse.ftState.Should().Be(0x4954_2001_EEEE_EEEE);
+    }
+
+    [Theory]
+    [InlineData("""{"CustomerVATId":"12345"}""")]
+    [InlineData("""{"CustomerId":"RSSMRA80A01H501Z"}""")]
+    public async Task ProcessReceiptAsync_WithAnInvalidCustomerTaxId_FailsBeforeContactingTheServer(string cbCustomer)
+    {
+        var sut = CreateSut();
+        var result = await sut.ProcessReceiptAsync(CreateRequest((long) ITReceiptCases.PointOfSaleReceipt0x0001, cbCustomer));
+
+        using var scope = new AssertionScope();
+        result.ReceiptResponse.HasFailed().Should().BeTrue();
+        result.ReceiptResponse.ftState.Should().Be(0x4954_2001_EEEE_EEEE);
+        result.ReceiptResponse.ftSignatures.Should().ContainSingle()
+            .Which.Caption.Should().Be(CustomerTaxIdValidation.CustomerTaxIdErrorCaption);
+        // Proves the identifier is rejected by an explicit pre-check rather than by an exception, which the
+        // outer catch would have relabelled as rt-server-generic-error.
+        result.ReceiptResponse.ftSignatures.Should().NotContain(s => s.Caption == "rt-server-generic-error");
+    }
+
+    /// <summary>
+    /// A stale cbCustomer on a closing must never block the closing. Routing is proven the same way as
+    /// ProcessReceiptAsync_MonthlyAndYearlyClosing_RoutesToDailyClosingHandler: the daily closing handler has
+    /// its own catch emitting rt-server-dailyclosing-error, distinct from the validation caption.
+    /// </summary>
+    [Theory]
+    [InlineData(0x4954_2000_0000_2011L)]   // DailyClosing0x2011
+    [InlineData(0x4954_2000_0000_2012L)]   // MonthlyClosing0x2012
+    [InlineData(0x4954_2000_0000_2013L)]   // YearlyClosing0x2013
+    public async Task ProcessReceiptAsync_ClosingWithAnInvalidCustomerTaxId_StillReachesTheClosingHandler(long ftReceiptCase)
+    {
+        var sut = CreateSut(httpTimeoutMs: 100);
+        var result = await sut.ProcessReceiptAsync(CreateRequest(ftReceiptCase, """{"CustomerVATId":"12345"}"""));
+
+        using var scope = new AssertionScope();
+        result.ReceiptResponse.ftSignatures.Should().Contain(s => s.Caption == "rt-server-dailyclosing-error");
+        result.ReceiptResponse.ftSignatures.Should().NotContain(s => s.Caption == CustomerTaxIdValidation.CustomerTaxIdErrorCaption);
     }
 
     [Fact]
@@ -306,14 +345,17 @@ public class CustomRTServerSCUTests : IDisposable
         fiscalDocument.document.vatcode.Should().Be("01606720215");
     }
 
-    // Shape validation of partita IVA / codice fiscale is out of scope here: whatever the PoS sends is
-    // forwarded to the RT server, apart from trimming, upper-casing and stripping the IT country prefix.
+    // The mapper deliberately does not validate: CustomRTServerSCU.ProcessReceiptAsync rejects malformed
+    // identifiers upstream (CarriesCustomerTaxIds + TryValidateCustomerTaxIds). Reaching the mapper means the
+    // identifiers are either valid or intentionally exempt, so whatever arrives is forwarded to the RT server
+    // apart from trimming, upper-casing and stripping the IT country prefix. These rows are the acceptance
+    // criteria for ItalyValidationHelpers.NormalizeVatId.
     [Theory]
     [InlineData("12345", "12345")]                   // too short
     [InlineData("016067202151", "016067202151")]     // too long
     [InlineData("IT12345", "12345")]                 // too short once the prefix is stripped
     [InlineData("0160672021a", "0160672021A")]       // right length, not all digits
-    public void GenerateFiscalDocument_DoesNotValidateCustomerVATIdShape(string customerVATId, string expected)
+    public void GenerateFiscalDocument_ForwardsCustomerVATIdWithoutRevalidating(string customerVATId, string expected)
     {
         var receiptRequest = CreateReceiptRequest($$"""{"CustomerVATId":"{{customerVATId}}"}""");
 

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
@@ -368,7 +368,7 @@ public class CustomRTServerSCUTests : IDisposable
     [InlineData("RSSMRA80A01H501", "RSSMRA80A01H501")]        // too short
     [InlineData("RSSMRA80A01H501UU", "RSSMRA80A01H501UU")]    // too long
     [InlineData("  rssmra80a01h501u  ", "RSSMRA80A01H501U")]  // trimmed and upper-cased, not validated
-    public void GenerateFiscalDocument_DoesNotValidateCustomerIdShape(string customerId, string expected)
+    public void GenerateFiscalDocument_ForwardsCustomerIdWithoutRevalidating(string customerId, string expected)
     {
         var receiptRequest = CreateReceiptRequest($$"""{"CustomerId":"{{customerId}}"}""");
 

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/CustomerTaxIdDirectIOTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/CustomerTaxIdDirectIOTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    /// <summary>
+    /// The customer tax identifier is printed as a directIO ("scontrino parlante"): an 11 digit partita IVA
+    /// goes to command 1060, a 16 character codice fiscale to 1061. The three request builders used to carry
+    /// three byte-identical copies of this logic; they now share one helper, so these tests assert all three
+    /// behave the same.
+    /// </summary>
+    public class CustomerTaxIdDirectIOTests
+    {
+        private const string PartitaIva = "01606720215";
+        private const string CodiceFiscale = "RSSMRA80A01H501U";
+
+        private static readonly EpsonRTPrinterSCUConfiguration _configuration = new();
+
+        private static ReceiptRequest CreateReceiptRequest(string cbCustomer) => new ReceiptRequest
+        {
+            ftReceiptCase = 0x4954_2000_0000_0001,
+            cbReceiptMoment = new DateTime(2026, 7, 2, 12, 0, 0),
+            cbCustomer = cbCustomer,
+            cbChargeItems = new[] { new ChargeItem { Amount = 1.00m, Quantity = 1, Description = "TEST", VATRate = 22m, ftChargeItemCase = 0x4954_2000_0000_0003 } },
+            cbPayItems = new[] { new PayItem { Amount = 1.00m, Quantity = 1, Description = "CONTANTE", ftPayItemCase = 0x4954_2000_0000_0001 } }
+        };
+
+        /// <summary>The three builders that emit the customer tax identifier, as (name) rows.</summary>
+        public static IEnumerable<object[]> RequestBuilders()
+        {
+            yield return new object[] { "invoice" };
+            yield return new object[] { "refund" };
+            yield return new object[] { "void" };
+        }
+
+        private static List<DirectIO> BuildDirectIOCommands(string builder, string cbCustomer)
+        {
+            var receiptRequest = CreateReceiptRequest(cbCustomer);
+            var fiscalReceipt = builder switch
+            {
+                "invoice" => EpsonCommandFactory.CreateInvoiceRequestContent(_configuration, receiptRequest),
+                "refund" => EpsonCommandFactory.CreateRefundRequestContent(_configuration, receiptRequest, 1, 1, new DateTime(2026, 7, 1), "99SEA004010"),
+                "void" => EpsonCommandFactory.CreateVoidRequestContent(_configuration, receiptRequest, 1, 1, new DateTime(2026, 7, 1), "99SEA004010"),
+                _ => throw new ArgumentOutOfRangeException(nameof(builder))
+            };
+            return fiscalReceipt.DirectIOCommands;
+        }
+
+        private static void AssertSingleCommand(List<DirectIO> commands, string expectedCommand, string expectedValue)
+        {
+            Assert.Single(commands.Where(x => x.Command == expectedCommand && x.Data == "01" + expectedValue));
+            // The two commands are mutually exclusive: only one identifier is printed.
+            var other = expectedCommand == "1060" ? "1061" : "1060";
+            Assert.Empty(commands.Where(x => x.Command == other));
+        }
+
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithAPlainPartitaIva_EmitDirectIO1060(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerVATId\":\"" + PartitaIva + "\"}"), "1060", PartitaIva);
+        }
+
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithACountryPrefixedPartitaIva_StripThePrefix(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerVATId\":\"IT" + PartitaIva + "\"}"), "1060", PartitaIva);
+        }
+
+        /// <summary>Lower case and surrounding whitespace used to defeat the old ToUpper()/StartsWith check.</summary>
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithAnUntrimmedLowerCasePartitaIva_StillEmitDirectIO1060(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerVATId\":\"  it" + PartitaIva + "  \"}"), "1060", PartitaIva);
+        }
+
+        /// <summary>A codice fiscale is 16 alphanumeric characters, so it needs command 1061, not 1060.</summary>
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithACodiceFiscale_EmitDirectIO1061(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"" + CodiceFiscale + "\"}"), "1061", CodiceFiscale);
+        }
+
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithAnUntrimmedLowerCaseCodiceFiscale_StillEmitDirectIO1061(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"  rssmra80a01h501u \"}"), "1061", CodiceFiscale);
+        }
+
+        /// <summary>Same precedence rule as the Custom SCUs: the codice fiscale wins.</summary>
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithBothIdentifiers_PreferTheCodiceFiscale(string builder)
+        {
+            var cbCustomer = "{\"CustomerId\":\"" + CodiceFiscale + "\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
+
+            AssertSingleCommand(BuildDirectIOCommands(builder, cbCustomer), "1061", CodiceFiscale);
+        }
+
+        /// <summary>An Italian legal entity uses its partita IVA as codice fiscale, so it belongs on 1060.</summary>
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithAPartitaIvaInCustomerId_EmitDirectIO1060(string builder)
+        {
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"IT" + PartitaIva + "\"}"), "1060", PartitaIva);
+        }
+
+        /// <summary>An empty CustomerId must not suppress a usable partita IVA.</summary>
+        [Theory]
+        [MemberData(nameof(RequestBuilders))]
+        public void AllBuilders_WithAnEmptyCustomerId_FallBackToThePartitaIva(string builder)
+        {
+            var cbCustomer = "{\"CustomerId\":\"\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
+
+            AssertSingleCommand(BuildDirectIOCommands(builder, cbCustomer), "1060", PartitaIva);
+        }
+
+        [Theory]
+        [InlineData("{\"CustomerVATId\":\"12345\"}")]              // too short
+        [InlineData("{\"CustomerVATId\":\"0160672021A\"}")]        // right length, not all digits
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501\"}")]       // 15 characters
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U!\"}")]     // 16 characters, not alphanumeric
+        [InlineData("{\"CustomerVATId\":\"\"}")]
+        [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
+        [InlineData("")]
+        public void CreateInvoiceRequestContent_WithoutAUsableTaxId_EmitsNoDirectIO(string cbCustomer)
+        {
+            var commands = BuildDirectIOCommands("invoice", cbCustomer);
+
+            Assert.Empty(commands.Where(x => x.Command == "1060" || x.Command == "1061"));
+        }
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;
 using fiskaltrust.ifPOS.v1.it;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTServer.Models;
 using FluentAssertions;
@@ -421,6 +423,122 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
             finally
             {
                 queue.Dispose();
+                if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"CustomerVATId\":\"12345\"}")]
+        [InlineData("{\"CustomerVATId\":\"DE123456789\"}")]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501Z\"}")]
+        public async Task ProcessReceiptAsync_WithAnInvalidCustomerTaxId_FailsWithoutSendingAnyDocument(string cbCustomer)
+        {
+            var client = CreateClientMock();
+            var scu = CreateScu(client, out var configuration);
+            try
+            {
+                var request = SaleProcessRequest();
+                request.ReceiptRequest.cbCustomer = cbCustomer;
+
+                var result = await scu.ProcessReceiptAsync(request);
+
+                using var scope = new AssertionScope();
+                result.ReceiptResponse.HasFailed().Should().BeTrue();
+                result.ReceiptResponse.ftSignatures.Should().ContainSingle()
+                    .Which.Caption.Should().Be(CustomerTaxIdValidation.CustomerTaxIdErrorCaption);
+                client.Verify(x => x.CreateReceiptAsync(It.IsAny<string>()), Times.Never);
+            }
+            finally
+            {
+                if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"IT01606720215\"}")]
+        [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
+        [InlineData("")]
+        public async Task ProcessReceiptAsync_WithAValidOrAbsentCustomerTaxId_SendsTheDocument(string cbCustomer)
+        {
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>())).ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var scu = CreateScu(client, out var configuration);
+            try
+            {
+                var request = SaleProcessRequest();
+                request.ReceiptRequest.cbCustomer = cbCustomer;
+
+                var result = await scu.ProcessReceiptAsync(request);
+
+                using var scope = new AssertionScope();
+                result.ReceiptResponse.HasFailed().Should().BeFalse();
+                client.Verify(x => x.CreateReceiptAsync(It.IsAny<string>()), Times.Once);
+            }
+            finally
+            {
+                if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
+            }
+        }
+
+        /// <summary>The IT country prefix must not be forwarded to the server as part of the tax id.</summary>
+        [Fact]
+        public async Task ProcessReceiptAsync_WithACountryPrefixedCustomerVATId_SendsTheTaxIdWithoutThePrefix()
+        {
+            var sentDocuments = new List<string>();
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .Callback<string>(sentDocuments.Add)
+                .ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var scu = CreateScu(client, out var configuration);
+            try
+            {
+                var request = SaleProcessRequest();
+                request.ReceiptRequest.cbCustomer = "{\"CustomerVATId\":\"IT01606720215\"}";
+
+                await scu.ProcessReceiptAsync(request);
+
+                sentDocuments.Should().ContainSingle()
+                    .Which.Should().Contain("<printRecTaxID taxID=\"01606720215\" />");
+            }
+            finally
+            {
+                if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
+            }
+        }
+
+        /// <summary>
+        /// printRecTaxID has a single slot, so CustomerId (codice fiscale) takes precedence over
+        /// CustomerVATId, matching the Custom SCUs. An empty CustomerId must fall through to the partita IVA.
+        /// </summary>
+        [Theory]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\"}", "RSSMRA80A01H501U")]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}", "RSSMRA80A01H501U")]
+        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"01606720215\"}", "01606720215")]
+        [InlineData("{\"CustomerId\":\"IT01606720215\"}", "01606720215")]
+        public async Task ProcessReceiptAsync_WithACustomerId_SendsItAsTheTaxId(string cbCustomer, string expectedTaxId)
+        {
+            var sentDocuments = new List<string>();
+            var client = CreateClientMock();
+            client.Setup(x => x.CreateReceiptAsync(It.IsAny<string>()))
+                .Callback<string>(sentDocuments.Add)
+                .ReturnsAsync(Ok(("fingerPrint", "ignored")));
+            var scu = CreateScu(client, out var configuration);
+            try
+            {
+                var request = SaleProcessRequest();
+                request.ReceiptRequest.cbCustomer = cbCustomer;
+
+                var response = await scu.ProcessReceiptAsync(request);
+
+                sentDocuments.Should().ContainSingle()
+                    .Which.Should().Contain($"<printRecTaxID taxID=\"{expectedTaxId}\" />");
+                // The signature must report exactly what was sent to the server.
+                response.ReceiptResponse.ftSignatures
+                    .Should().ContainSingle(x => (x.ftSignatureType & 0xFF) == (long) SignatureTypesIT.RTCustomerID)
+                    .Which.Data.Should().Be(expectedTaxId);
+            }
+            finally
+            {
                 if (Directory.Exists(configuration.ServiceFolder!)) Directory.Delete(configuration.ServiceFolder!, recursive: true);
             }
         }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/CustomerTaxIdValidationTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/CustomerTaxIdValidationTests.cs
@@ -1,0 +1,124 @@
+using FluentAssertions;
+using FluentAssertions.Execution;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.IT.UnitTest
+{
+    public class CustomerTaxIdValidationTests
+    {
+        private const long PointOfSaleReceipt = 0x4954_2000_0000_0001;
+
+        private const string InvalidCustomer = "{\"CustomerVATId\":\"12345\"}";
+
+        private static ReceiptRequest CreateReceiptRequest(string cbCustomer, long ftReceiptCase = PointOfSaleReceipt) => new ReceiptRequest
+        {
+            ftReceiptCase = ftReceiptCase,
+            cbReceiptReference = "test-reference",
+            cbCustomer = cbCustomer
+        };
+
+        /// <summary>
+        /// The whole point of the gate: a PoS that leaves a stale cbCustomer on a management receipt must
+        /// never be prevented from closing the day or from recovering the till.
+        /// </summary>
+        [Theory]
+        [InlineData((long) ITReceiptCases.InitialOperationReceipt0x4001)]
+        [InlineData((long) ITReceiptCases.OutOfOperationReceipt0x4002)]
+        [InlineData((long) ITReceiptCases.ZeroReceipt0x2000)]
+        [InlineData((long) ITReceiptCases.DailyClosing0x2011)]
+        [InlineData((long) ITReceiptCases.MonthlyClosing0x2012)]
+        [InlineData((long) ITReceiptCases.YearlyClosing0x2013)]
+        [InlineData((long) ITReceiptCases.Reprint0x3010)]
+        public void CarriesCustomerTaxIds_ForAManagementReceiptWithAnInvalidCustomer_ReturnsFalse(long receiptCase)
+        {
+            var receiptRequest = CreateReceiptRequest(InvalidCustomer, ITConstants.BASE_STATE | receiptCase);
+
+            receiptRequest.CarriesCustomerTaxIds().Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not json at all")]
+        [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
+        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"\"}")]
+        [InlineData("{\"CustomerId\":\"   \"}")]
+        public void CarriesCustomerTaxIds_WithoutAnIdentifier_ReturnsFalse(string cbCustomer)
+        {
+            var receiptRequest = CreateReceiptRequest(cbCustomer);
+
+            receiptRequest.CarriesCustomerTaxIds().Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\"}")]
+        [InlineData("{\"CustomerVATId\":\"01606720215\"}")]
+        [InlineData(InvalidCustomer)]
+        public void CarriesCustomerTaxIds_ForASaleReceiptWithAnIdentifier_ReturnsTrue(string cbCustomer)
+        {
+            var receiptRequest = CreateReceiptRequest(cbCustomer);
+
+            receiptRequest.CarriesCustomerTaxIds().Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("not json at all")]
+        [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
+        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"\"}")]
+        [InlineData("{\"CustomerId\":\"   \",\"CustomerVATId\":\"   \"}")]
+        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}")]
+        [InlineData("{\"CustomerId\":\"01606720215\"}")]
+        [InlineData("{\"CustomerVATId\":\"IT01606720215\"}")]
+        public void TryValidateCustomerTaxIds_WithAbsentOrValidIdentifiers_ReturnsTrue(string cbCustomer)
+        {
+            var receiptRequest = CreateReceiptRequest(cbCustomer);
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeTrue();
+            errorMessage.Should().BeNull();
+        }
+
+        [Fact]
+        public void TryValidateCustomerTaxIds_WithAnInvalidCodiceFiscale_ReturnsFalseAndNamesTheField()
+        {
+            var receiptRequest = CreateReceiptRequest("{\"CustomerId\":\"RSSMRA80A01H501Z\"}");
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeFalse();
+            errorMessage.Should().Contain("RSSMRA80A01H501Z").And.Contain("cbCustomer.CustomerId");
+        }
+
+        [Fact]
+        public void TryValidateCustomerTaxIds_WithAForeignVatNumber_ReturnsFalseAndNamesTheField()
+        {
+            var receiptRequest = CreateReceiptRequest("{\"CustomerVATId\":\"DE123456789\"}");
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeFalse();
+            errorMessage.Should().Contain("DE123456789").And.Contain("cbCustomer.CustomerVATId");
+        }
+
+        [Fact]
+        public void TryValidateCustomerTaxIds_WithBothIdentifiersInvalid_ReportsTheCodiceFiscaleFirst()
+        {
+            var receiptRequest = CreateReceiptRequest("{\"CustomerId\":\"RSSMRA80A01H501Z\",\"CustomerVATId\":\"12345\"}");
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeFalse();
+            errorMessage.Should().Contain("cbCustomer.CustomerId").And.NotContain("cbCustomer.CustomerVATId");
+        }
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/ItalyValidationHelpersTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/ItalyValidationHelpersTests.cs
@@ -1,0 +1,140 @@
+using FluentAssertions;
+using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.IT.UnitTest
+{
+    public class ItalyValidationHelpersTests
+    {
+        [Theory]
+        // Real partite IVA; the check digit of each was verified by hand.
+        [InlineData("01606720215")]
+        [InlineData("01114601006")]
+        [InlineData("00905811006")]
+        [InlineData("00484960588")]
+        // The IT country prefix is accepted, as are surrounding whitespace and lower case.
+        [InlineData("IT01606720215")]
+        [InlineData("it01606720215")]
+        [InlineData("  IT01606720215  ")]
+        public void IsValidPartitaIva_WithValidValue_ReturnsTrue(string partitaIva)
+        {
+            ItalyValidationHelpers.IsValidPartitaIva(partitaIva).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("01606720216")]         // wrong check digit
+        [InlineData("0160672021")]          // 10 digits
+        [InlineData("016067202150")]        // 12 digits
+        [InlineData("0160672021A")]         // right length, not all digits
+        [InlineData("DE123456789")]         // 11 characters, but a foreign prefix is not tolerated
+        [InlineData("IT")]                  // prefix only
+        [InlineData("IT0160672021")]        // only 10 digits once the prefix is stripped
+        [InlineData("00000000000")]         // satisfies the checksum, but is a placeholder
+        [InlineData("016.067.202.15")]      // internal separators are not stripped
+        [InlineData("RSSMRA80A01H501U")]    // a codice fiscale is not a partita IVA
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void IsValidPartitaIva_WithInvalidValue_ReturnsFalse(string partitaIva)
+        {
+            ItalyValidationHelpers.IsValidPartitaIva(partitaIva).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("MRTMTT25D09F205Z")]        // sum 155 -> 25 -> 'Z'
+        [InlineData("RSSMRA80A01H501U")]        // sum 98 -> 20 -> 'U'
+        [InlineData("BNCNNA90A41F205W")]        // female, day 41; sum 100 -> 22 -> 'W'
+        [InlineData("  rssmra80a01h501u  ")]    // trimmed and upper-cased
+        // Omocodia: digits replaced by their substitute letters, with the CIN recalculated on the
+        // substituted code.
+        [InlineData("MRTMTT25D09F20RU")]
+        [InlineData("RSSMRA80A01H5LMX")]
+        // Legal entities use their partita IVA as codice fiscale.
+        [InlineData("01606720215")]
+        [InlineData("IT01606720215")]
+        public void IsValidCodiceFiscale_WithValidValue_ReturnsTrue(string codiceFiscale)
+        {
+            ItalyValidationHelpers.IsValidCodiceFiscale(codiceFiscale).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("MRTMTT25D09F205A")]        // wrong check character
+        [InlineData("RSSMRA80A01H501")]         // 15 characters
+        [InlineData("RSSMRA80A01H501UU")]       // 17 characters
+        [InlineData("RSS1RA80A01H501U")]        // digit inside the surname/name block
+        [InlineData("RSSMRA8OA01H501U")]        // 'O' is not an omocodia letter
+        [InlineData("RSSMRA80Z01H501U")]        // 'Z' is not a month letter
+        [InlineData("RSSMRA80A81H501U")]        // day 81 is out of range
+        [InlineData("RSSMRA80A00H501U")]        // day 00 is out of range
+        [InlineData("DE123456789")]
+        [InlineData("01606720216")]             // 11 digits, wrong check digit
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void IsValidCodiceFiscale_WithInvalidValue_ReturnsFalse(string codiceFiscale)
+        {
+            ItalyValidationHelpers.IsValidCodiceFiscale(codiceFiscale).Should().BeFalse();
+        }
+
+        /// <summary>
+        /// The check character of an omocode is recalculated on the substituted code, so the CIN must be
+        /// computed over the characters exactly as they are written. An implementation that decodes the
+        /// omocodia letter 'R' back to '5' before computing the CIN would wrongly accept this value,
+        /// because 'Z' is the check character of the base code MRTMTT25D09F205Z.
+        /// </summary>
+        [Fact]
+        public void IsValidCodiceFiscale_WithOmocodiaAndTheBaseCodeCheckCharacter_ReturnsFalse()
+        {
+            ItalyValidationHelpers.IsValidCodiceFiscale("MRTMTT25D09F20RZ").Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("  it01606720215 ", "IT01606720215")]
+        [InlineData("RSSMRA80A01H501U", "RSSMRA80A01H501U")]
+        public void Normalize_TrimsAndUpperCases(string value, string expected)
+        {
+            ItalyValidationHelpers.Normalize(value).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("  it01606720215 ", "01606720215")]
+        [InlineData("IT", "")]
+        [InlineData("12345", "12345")]                       // invalid input is not blanked out
+        [InlineData("IT12345", "12345")]                     // the prefix is stripped unconditionally
+        [InlineData("RSSMRA80A01H501U", "RSSMRA80A01H501U")]
+        public void NormalizeVatId_StripsTheCountryPrefixUnconditionally(string value, string expected)
+        {
+            ItalyValidationHelpers.NormalizeVatId(value).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("  it01606720215 ", "01606720215")]           // an IT prefixed partita IVA is stripped
+        [InlineData("IT12345678901", "12345678901")]              // 11 digits remain, so it is a partita IVA
+        [InlineData("RSSMRA80A01H501U", "RSSMRA80A01H501U")]
+        [InlineData("ITLMRA80A01H501U", "ITLMRA80A01H501U")]      // a surname starting with IT is left alone
+        [InlineData("IT12345", "IT12345")]                        // not 11 digits, so nothing is stripped
+        public void NormalizeTaxCode_StripsTheCountryPrefixOnlyForAPartitaIva(string value, string expected)
+        {
+            ItalyValidationHelpers.NormalizeTaxCode(value).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(null, null, "")]
+        [InlineData("RSSMRA80A01H501U", null, "RSSMRA80A01H501U")]
+        [InlineData(null, "01606720215", "01606720215")]
+        [InlineData(null, "IT01606720215", "01606720215")]
+        [InlineData("RSSMRA80A01H501U", "01606720215", "RSSMRA80A01H501U")]   // the codice fiscale wins
+        [InlineData("", "01606720215", "01606720215")]                        // an empty CustomerId falls through
+        [InlineData("   ", "01606720215", "01606720215")]                     // ... and so does a blank one
+        [InlineData("IT01606720215", null, "01606720215")]                    // CustomerId carrying a partita IVA
+        [InlineData("ITLMRA80A01H501U", null, "ITLMRA80A01H501U")]            // a surname starting with IT survives
+        public void SelectCustomerTaxId_PrefersTheCodiceFiscaleAndNormalizesBoth(string customerId, string customerVatId, string expected)
+        {
+            ItalyValidationHelpers.SelectCustomerTaxId(customerId, customerVatId).Should().Be(expected);
+        }
+    }
+}


### PR DESCRIPTION
Closes #735

No IT SCU checked the shape of cbCustomer.CustomerId (codice fiscale) or CustomerVATId (partita IVA), and each one handled them differently: the value was silently dropped, forwarded raw, or only caught by the device. The check now lives once in SCU.IT.Abstraction/Validation/ (format + checksum for both, IT prefix accepted). Both fields stay optional — absent or empty is valid.

## Behaviour changes

1. A malformed identifier fails the receipt before the printer or RT Server is contacted: ftState & 0xFFFF_FFFF == 0xEEEE_EEEE, signature 0x4954_2000_0000_3000, caption it-customer-taxid-invalid.
2. Identifiers are always validated as Italian — only IT is tolerated, so DE123456789 now fails. Most visible change for anyone selling to EU customers; needs a changelog line.
3. The codice fiscale is now sent to the Epson devices, which previously ignored CustomerId entirely (directIO 1061 on the printer, printRecTaxID on the server).
4. The RTCustomerID signature is populated — it was hardcoded empty on both Epson SCUs.

Management receipts (init, out of operation, zero, closings, reprint) are excluded from the check: a stale cbCustomer must never block a Z closing.

## Bugs fixed along the way

- EpsonRTServer sent printRecTaxID with the IT prefix (13 chars instead of 11)
- EpsonRTPrinter sent 11-char non-numeric values such as 0160672021A to the printer
- CustomerId ?? CustomerVATId doesn't fall through on "", so "CustomerId": "" plus a valid partita IVA printed nothing at all
- two fixtures carrying placeholder identifiers that would have gone red on all four SCUs

Also removes four pre-existing duplications, including the three identical VAT blocks in EpsonCommandFactory (−60 lines).