### PR TITLE
fix(scu-it): stop printing ftChargeItemCaseData verbatim on Epson RT Printer receipts

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -640,16 +640,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                         UnitPrice = i.Quantity == 0 || i.Amount == 0 ? 0 : i.Amount / i.Quantity,
                         Department = 11,
                     };
-                    PrintRecMessage? printRecMessage = null;
-                    if (!string.IsNullOrEmpty(i.ftChargeItemCaseData))
-                    {
-                        printRecMessage = new PrintRecMessage()
-                        {
-                            Message = i.ftChargeItemCaseData,
-                            MessageType = 4
-                        };
-                    }
-                    itemAndMessages.Add(new() { PrintRecItem = printRecItem, PrintRecMessage = printRecMessage });
+                    itemAndMessages.Add(new() { PrintRecItem = printRecItem });
                 }
                 else if (i.IsSingleUseVoucher() && i.Amount < 0)
                 {
@@ -693,16 +684,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                         UnitPrice = i.Quantity == 0 || i.Amount == 0 ? 0 : i.Amount / i.Quantity,
                         Department = i.GetVatGroup(),
                     };
-                    PrintRecMessage? printRecMessage = null;
-                    if (!string.IsNullOrEmpty(i.ftChargeItemCaseData))
-                    {
-                        printRecMessage = new PrintRecMessage()
-                        {
-                            Message = i.ftChargeItemCaseData,
-                            MessageType = 4
-                        };
-                    }
-                    itemAndMessages.Add(new() { PrintRecItem = printRecItem, PrintRecMessage = printRecMessage });
+                    itemAndMessages.Add(new() { PrintRecItem = printRecItem });
                 }
             }
         }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ChargeItemCaseDataPrintingTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ChargeItemCaseDataPrintingTests.cs
@@ -1,0 +1,65 @@
+using System.Linq;
+using FluentAssertions;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    public class ChargeItemCaseDataPrintingTests
+    {
+        private static ReceiptRequest CreateReceipt(params ChargeItem[] chargeItems) => new()
+        {
+            cbReceiptReference = "20260830000950400038",
+            cbChargeItems = chargeItems,
+            cbPayItems = new[]
+            {
+                new PayItem
+                {
+                    Quantity = 1,
+                    Description = "Mastercard",
+                    Amount = chargeItems.Sum(x => x.Amount),
+                    ftPayItemCase = 0x4954_0000_0000_0004
+                }
+            },
+            ftReceiptCase = 0x4954_2000_0000_0001,
+            cbReceiptAmount = chargeItems.Sum(x => x.Amount)
+        };
+
+        private static ChargeItem CreateChargeItem(string caseData, long ftChargeItemCase = 0x4954_0000_0000_0003) => new()
+        {
+            Quantity = 1,
+            Description = "Gonna a ruota in cotone",
+            Amount = 80.1m,
+            VATRate = 22m,
+            ftChargeItemCase = ftChargeItemCase,
+            ftChargeItemCaseData = caseData
+        };
+
+        [Theory]
+        [InlineData("{\"netAmount\":65.66,\"discount\":8.90}")]
+        [InlineData("plain text note")]
+        [InlineData("")]
+        [InlineData(null)]
+        public void CreateInvoiceRequestContent_Should_Not_Print_ftChargeItemCaseData(string caseData)
+        {
+            var request = CreateReceipt(CreateChargeItem(caseData));
+
+            var content = EpsonCommandFactory.CreateInvoiceRequestContent(new EpsonRTPrinterSCUConfiguration(), request);
+
+            content.ItemAndMessages.Should().NotBeEmpty();
+            content.ItemAndMessages.Where(x => x.PrintRecItem != null).Should().OnlyContain(x => x.PrintRecMessage == null);
+        }
+
+        [Fact]
+        public void CreateInvoiceRequestContent_Should_Not_Print_ftChargeItemCaseData_For_Tips()
+        {
+            var tip = CreateChargeItem("{\"netAmount\":65.66}", ftChargeItemCase: 0x4954_0000_0000_0033);
+            var request = CreateReceipt(tip);
+
+            var content = EpsonCommandFactory.CreateInvoiceRequestContent(new EpsonRTPrinterSCUConfiguration(), request);
+
+            content.ItemAndMessages.Should().NotBeEmpty();
+            content.ItemAndMessages.Where(x => x.PrintRecItem != null).Should().OnlyContain(x => x.PrintRecMessage == null);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #757.

The EpsonRTPrinter SCU attached the raw content of `ftChargeItemCaseData` as a `PrintRecMessage` (MessageType 4) to every sale item and tip item. POS systems that fill the field with structured metadata (e.g. `{"netAmount":65.66,"discount":8.90}`, as seen in the H&M/StoreLens pilot) ended up with raw JSON printed as free-text lines on the documento commerciale.

## Why removal (and not content sniffing)

- The interface defines the field as a JSON data container to be interpreted ("Additional data about the service, currently accepted only in JSON format"; in v2 it can be a JSON object directly).
- No other market prints it: GR deserializes it (myDATA overrides, silently ignoring unparsable content), ME deserializes it (`InvoiceItemRequest`), ES/PT treat it as opaque for refund validation, DE/AT/BE don't read it. Within SCU-IT, CustomRTPrinter/CustomRTServer/EpsonRTServer never print it.
- Nothing in the businesscase repo documents any printing behavior for the field; the documented channels for extra printed lines are `ftReceiptCaseData.cbReceiptLines` (receipt level) and `PayItemCaseData.Receipt` (payments).

## Changes

- `EpsonCommandFactory.GenerateItems`: removed the two blocks (regular items and tips) that emitted `ftChargeItemCaseData` as a `PrintRecMessage`.
- Typed usages are unaffected: graphic coupons (BMP/Raster base64, gated behind dedicated `ftChargeItemCase` flags `0x0000_0010/0020_0000_0000`) keep working.
- Added regression tests (`ChargeItemCaseDataPrintingTests`) covering JSON, plain-text, empty and null content, plus the tip branch.

## Backward compatibility

Any PosCreator relying on the (undocumented) verbatim printing to get extra text under an item will silently lose those lines — the receipt itself is unaffected. Should be called out in the release notes; if per-item extra text is a desired feature, it should come back as an explicit `ftChargeItemCase` flag, consistent with the graphic-coupon pattern.

## Checklist
- [x] Unit tests pass (48/48 EpsonRTPrinter.UnitTest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)