### PR TITLE
feat(scu-gr): support myDATA 11.3 simplified invoice

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Models/Cases/ReceiptCaseFlagsGR.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueGR/Models/Cases/ReceiptCaseFlagsGR.cs
@@ -4,7 +4,16 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.Models.Cases;
 
 public enum ReceiptCaseFlags : long
 {
-    HasTransportInformation = 0x0000_0000_0400_0000
+    HasTransportInformation = 0x0000_0000_0400_0000,
+
+    /// <summary>
+    /// local flag for:
+    /// Απλοποιημένο Τιμολόγιο — simplified invoice, myDATA document type 11.3.
+    /// An INVOICE to a business in legally simplified form (ΕΛΠ ν.4308/2014 άρθρο 10), not a retail
+    /// receipt: the buyer's details are omitted, which is why 11.3 is a
+    /// «Μη Αντικριζόμενο» / non-counterparty document.
+    /// </summary>
+    IsSimplifiedInvoice = 0x0000_0001_0000_0000
 }
 
 public static class ReceiptCaseFlagsExt

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -342,6 +342,14 @@ public class AADEFactory
             inv.invoiceSummary.incomeClassification = null;
         }
 
+        // A simplified invoice (11.3) is billed to a business, so its income is WHOLESALE — the base
+        // mapping produces the retail E3_561_003 (as for 11.1), which "11.3" does not permit for a
+        // provider sending its own characterizations. Correct it here, keyed off the resolved type
+        // (covers the invoiceType override) and off the IsSimplifiedInvoice flag (which also covers a
+        // refund that resolved to 11.4). Only E3_561_003 is remapped, so an explicit per-line
+        // incomeClassification override is left untouched.
+        NormalizeSimplifiedInvoiceClassification(inv, receiptRequest);
+
         // Set correlatedInvoices / multipleConnectedMarks based on the final invoice type
         // (after override, so the correct field is used for the resolved type).
         // Marks come from two sources:
@@ -408,6 +416,49 @@ public class AADEFactory
                 "When a classification override (incomeClassification or expensesClassification) is set on any charge item, every charge item must have a classification override.");
         }
 
+    }
+
+    /// <summary>
+    /// Remaps the retail income classification (E3_561_003) to the wholesale one (E3_561_001) on the
+    /// lines and the summary when the document is a simplified invoice (myDATA 11.3). "Simplified" is
+    /// recognized by the resolved invoice type being 11.3 (covers the invoiceType override) or by the
+    /// GR-local IsSimplifiedInvoice flag being set (covers a refund of a simplified invoice, which
+    /// resolves to 11.4 but must still be booked wholesale). Runs after the override layer so it sees
+    /// the final type; only the retail code is touched, so an explicit per-line classification
+    /// override is preserved.
+    /// </summary>
+    internal static void NormalizeSimplifiedInvoiceClassification(AadeBookInvoiceType invoice, ReceiptRequest receiptRequest)
+    {
+        var isSimplifiedInvoice = invoice.invoiceHeader.invoiceType == InvoiceType.Item113
+            || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.IsSimplifiedInvoice);
+        if (!isSimplifiedInvoice)
+        {
+            return;
+        }
+
+        static void Remap(IncomeClassificationType[]? classifications)
+        {
+            if (classifications == null)
+            {
+                return;
+            }
+            foreach (var ic in classifications)
+            {
+                if (ic.classificationTypeSpecified && ic.classificationType == IncomeClassificationValueType.E3_561_003)
+                {
+                    ic.classificationType = IncomeClassificationValueType.E3_561_001;
+                }
+            }
+        }
+
+        if (invoice.invoiceDetails != null)
+        {
+            foreach (var detail in invoice.invoiceDetails)
+            {
+                Remap(detail.incomeClassification);
+            }
+        }
+        Remap(invoice.invoiceSummary?.incomeClassification);
     }
 
     private static void ApplyMyDataOverride(AadeBookInvoiceType invoice, ReceiptRequestMyDataOverride overrideData)

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEMappings.cs
@@ -194,9 +194,17 @@ public static class AADEMappings
         {
             if(chargeItem.ftChargeItemCase.IsNatureOfVat(ChargeItemCaseNatureOfVatGR.NotTaxableArticle39a))
             {
+                // OPEN: 11.3 allows neither the retail (E3_561_004) nor wholesale (E3_561_002)
+                // reverse-charge value, since art. 39a needs the buyer's ΑΦΜ that a simplified invoice
+                // omits. Left as-is rather than throwing, so partners already overriding 39a to 11.3 keep working.
                 return IncomeClassificationValueType.E3_561_004;
             }
 
+            // Retail base. A simplified invoice (11.3) needs the WHOLESALE code E3_561_001 instead,
+            // but that depends on the resolved document type / the IsSimplifiedInvoice flag, so it is
+            // applied after mapping in AADEFactory (NormalizeSimplifiedInvoiceClassification) — the
+            // same layer that already handles invoiceType overrides — rather than here in the
+            // case-driven base mapping.
             return chargeItem.ftChargeItemCase.TypeOfService() switch
             {
                 ChargeItemCaseTypeOfService.UnknownService => IncomeClassificationValueType.E3_561_003,
@@ -351,6 +359,12 @@ public static class AADEMappings
             else if (hasOwnConsumption)
             {
                 return InvoiceType.Item61;
+            }
+            //evaluated before the 11.2 since 11.3 is a simplified invoice for good and services and should not be treated 
+            //like an 11.2 which is just for services
+            else if (receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlagsGR.IsSimplifiedInvoice))
+            {
+                return InvoiceType.Item113;
             }
             else if (receiptRequest.HasOnlyServiceItemsExcludingSpecialTaxes() || receiptRequest.HasAtLeastOneServiceItemAndOnlyUnknownsExcludingSpecialTaxes())
             {

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/ReceiptCaseFlagsGR.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/ReceiptCaseFlagsGR.cs
@@ -5,6 +5,14 @@ namespace fiskaltrust.Middleware.SCU.GR.Abstraction;
 public enum ReceiptCaseFlagsGR : long
 {
     HasTransportInformation = 0x0000_0000_0400_0000,
+
+    /// <summary>
+    /// local flag for:
+    /// Απλοποιημένο Τιμολόγιο — simplified invoice, myDATA document type 11.3.
+    /// An INVOICE to a business in legally simplified form (ΕΛΠ ν.4308/2014 άρθρο 10), not a retail
+    /// receipt: the buyer's details are omitted, which is why 11.3 is a non-counterparty document.
+    /// </summary>
+    IsSimplifiedInvoice = 0x0000_0001_0000_0000,
 }
 
 public static class ReceiptCaseFlagsGRExt

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SimplifiedInvoice113Tests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SimplifiedInvoice113Tests.cs
@@ -1,0 +1,447 @@
+﻿using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.GR.Abstraction;
+using fiskaltrust.Middleware.SCU.GR.MyData.Helpers;
+using fiskaltrust.Middleware.SCU.GR.MyData.Models;
+using fiskaltrust.storage.V0.MasterData;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest;
+
+/// <summary>
+/// Απλοποιημένο Τιμολόγιο / simplified invoice, myDATA document type 11.3.
+///
+/// 11.3 is an INVOICE to a business issued in legally simplified form (ΕΛΠ ν.4308/2014 άρθρο 10 §1:
+/// amount up to €100, €300 for fuel per ΠΟΛ.1003/2014, or an άρθρο 8 §3 corrective document). It is
+/// NOT a retail receipt to a consumer. Its mandatory content deliberately omits the buyer's details,
+/// which is why myDATA files it under A2 «Μη Αντικριζόμενα Παραστατικά Εκδότη» — no counterpart.
+///
+/// The classification, however, is WHOLESALE, because the buyer is a professional.
+///     category1_1 / category1_2 / category1_3  ->  E3_561_001   (χονδρικές — επιτηδευματιών)
+///     category1_4                              ->  E3_880_001
+///     category1_5                              ->  E3_561_007
+///     category1_6                              ->  E3_595
+///     category1_7                              ->  E3_881_001
+/// Sheet "11.3" lists E3_561_001 as the only permitted value for category1_1/1_2/1_3; sheet "11.1"
+/// lists E3_561_003 there instead. AADE's esend-myDATA guidance does separately assign a blanket
+/// category1_1 + E3_561_003 to 11.1/11.3/11.4, but only when a ΦΗΜ cannot characterize the lines or
+/// esend cannot carry the characterizations — a fallback for un-characterized cash-register traffic,
+/// not a rule for a provider that sends its own. That is why the old override transmissions were
+/// accepted with E3_561_003 rather than rejected.
+///
+/// Business cases: businesscase/example/SignRequestReceipt_GR_SimplifiedInvoice (265_A..265_E), all
+/// live-verified on myDATA dev 2026-08-19. Every one was ACCEPTED by AADE with a MARK, so AADE
+/// neither rejects the unrecognised lll bit nor enforces the classification matrix — the current
+/// behaviour is wrong in the merchant's books, not in transmission.
+///
+/// NOT COVERED HERE, intentional:
+///  * category1_4 / category1_7 on 11.3. GetIncomeClassificationCategoryType never produces
+///    category1_4, and category1_7 (NotOwnSales) is routed to 11.5 before the flag is reached, so
+///    E3_880_001 / E3_881_001 are unreachable through this trigger. They are stated above as the
+///    AADE rule, not as testable behaviour.
+///  * The 11.4 classification question (separate issue — affects all GR retail refunds).
+///  * άρθρο 39a on 11.3 (neither E3_561_004 nor E3_561_002 is permitted there; decision pending).
+///  * The fuel vehicle-registration plate (deferred).
+/// </summary>
+public class SimplifiedInvoice113Tests
+{
+    private const long GR_V2 = 0x4752_2000_0000_0000;
+
+    private static AADEFactory CreateFactory() => new AADEFactory(new MasterDataConfiguration
+    {
+        Account = new AccountMasterData { VatId = "123456789" },
+        Outlet = new OutletMasterData { LocationId = "0" }
+    }, "https://receipts.example.com");
+
+    private static ChargeItem CreateChargeItem(ChargeItemCaseTypeOfService typeOfService, decimal amount = 100)
+        => new ChargeItem
+        {
+            Position = 1,
+            Amount = amount,
+            VATRate = 24,
+            VATAmount = decimal.Round(amount / 124M * 24M, 2, MidpointRounding.ToEven),
+            ftChargeItemCase = ((ChargeItemCase) GR_V2)
+                .WithTypeOfService(typeOfService)
+                .WithVat(ChargeItemCase.NormalVatRate),
+            Quantity = 1,
+            Description = "Test Item"
+        };
+
+    /// <summary>POS receipt carrying the GR-local IsSimplifiedInvoice flag (lll = 0x001).</summary>
+    private static ReceiptRequest CreateSimplifiedInvoiceReceipt(
+        ChargeItemCaseTypeOfService typeOfService = ChargeItemCaseTypeOfService.Delivery,
+        bool isRefund = false,
+        bool withCustomer = false,
+        decimal amount = 100)
+    {
+        var ftReceiptCase = ((ReceiptCase) GR_V2)
+            .WithCase(ReceiptCase.PointOfSaleReceipt0x0001)
+            .WithFlag(ReceiptCaseFlagsGR.IsSimplifiedInvoice);
+
+        if (isRefund)
+        {
+            ftReceiptCase = ftReceiptCase.WithFlag(ReceiptCaseFlags.Refund);
+        }
+
+        var signedAmount = isRefund ? -amount : amount;
+
+        var request = new ReceiptRequest
+        {
+            cbTerminalID = "1",
+            Currency = Currency.EUR,
+            cbReceiptMoment = new DateTime(2026, 8, 19, 10, 15, 0, DateTimeKind.Utc),
+            cbReceiptReference = Guid.NewGuid().ToString(),
+            ftPosSystemId = Guid.NewGuid(),
+            ftReceiptCase = ftReceiptCase,
+            cbChargeItems = [CreateChargeItem(typeOfService, signedAmount)],
+            cbPayItems =
+            [
+                new PayItem
+                {
+                    Position = 1,
+                    Amount = signedAmount,
+                    ftPayItemCase = ((PayItemCase) GR_V2).WithCase(PayItemCase.CashPayment),
+                    Description = "Cash"
+                }
+            ]
+        };
+
+        if (withCustomer)
+        {
+            request.cbCustomer = new MiddlewareCustomer
+            {
+                CustomerVATId = "026883248",
+                CustomerName = "Πελάτης Α.Ε.",
+                CustomerStreet = "Κηφισίας 12",
+                CustomerZip = "12345",
+                CustomerCity = "Αθηνών",
+                CustomerCountry = "GR"
+            };
+        }
+
+        return request;
+    }
+
+    private static ReceiptResponse CreateResponse(ReceiptRequest request) => new ReceiptResponse
+    {
+        cbReceiptReference = request.cbReceiptReference,
+        ftReceiptIdentification = "ft123ABC#",
+        ftCashBoxIdentification = "TEST-001"
+    };
+
+    #region 1.THE TRIGGER — the flag must resolve the document type to 11.3
+
+    /// <summary>
+    /// άρθρο 10 covers goods AND services, so ONE flag has to serve both. That means
+    /// IsSimplifiedInvoice must be evaluated BEFORE the services-vs-goods split which otherwise
+    /// sends goods to 11.1 and a services-only receipt to 11.2.
+    /// </summary>
+    [Theory]
+    [InlineData(ChargeItemCaseTypeOfService.Delivery)]
+    [InlineData(ChargeItemCaseTypeOfService.OtherService)]
+    [InlineData(ChargeItemCaseTypeOfService.CatalogService)]
+    public void Item_11_3_GetInvoiceType_RetailReceipt_WithSimplifiedInvoiceFlag_ReturnsItem113(
+        ChargeItemCaseTypeOfService typeOfService)
+    {
+        var receiptRequest = CreateSimplifiedInvoiceReceipt(typeOfService);
+
+        var result = AADEMappings.GetInvoiceType(receiptRequest);
+
+        result.Should().Be(InvoiceType.Item113);
+    }
+
+    /// <summary>Without the flag nothing changes — goods stay 11.1.</summary>
+    [Fact]
+    public void Item_11_1_GetInvoiceType_RetailReceipt_WithoutSimplifiedInvoiceFlag_StaysItem111()
+    {
+        var receiptRequest = CreateSimplifiedInvoiceReceipt();
+        receiptRequest.ftReceiptCase = ((ReceiptCase) GR_V2).WithCase(ReceiptCase.PointOfSaleReceipt0x0001);
+
+        var result = AADEMappings.GetInvoiceType(receiptRequest);
+
+        result.Should().Be(InvoiceType.Item111);
+    }
+
+    #endregion
+
+    #region 2.PRECEDENCE — other document types must still win over the flag
+
+    /// <summary>
+    /// There is no "credit simplified invoice" type in myDATA, so Refund must WIN over the flag and
+    /// produce an 11.4 Πιστωτικό Στοιχείο Λιανικής.
+    /// Live: 265_D MARK 400001968026868 -> 11.4.
+    /// </summary>
+    [Fact]
+    public void Item_11_4_GetInvoiceType_RetailReceipt_RefundWithSimplifiedInvoiceFlag_ReturnsItem114()
+    {
+        var receiptRequest = CreateSimplifiedInvoiceReceipt(isRefund: true);
+
+        var result = AADEMappings.GetInvoiceType(receiptRequest);
+
+        result.Should().Be(InvoiceType.Item114);
+    }
+
+    /// <summary>Agency business keeps its own type — 11.5 wins over the flag.</summary>
+    [Fact]
+    public void Item_11_5_GetInvoiceType_RetailReceipt_NotOwnSalesWithSimplifiedInvoiceFlag_ReturnsItem115()
+    {
+        var receiptRequest = CreateSimplifiedInvoiceReceipt(ChargeItemCaseTypeOfService.NotOwnSales);
+
+        var result = AADEMappings.GetInvoiceType(receiptRequest);
+
+        result.Should().Be(InvoiceType.Item115);
+    }
+
+    /// <summary>Self-delivery keeps its own type — 6.1 wins over the flag.</summary>
+    [Fact]
+    public void Item_6_1_GetInvoiceType_RetailReceipt_OwnConsumptionWithSimplifiedInvoiceFlag_ReturnsItem61()
+    {
+        var receiptRequest = CreateSimplifiedInvoiceReceipt(ChargeItemCaseTypeOfService.OwnConsumption);
+
+        var result = AADEMappings.GetInvoiceType(receiptRequest);
+
+        result.Should().Be(InvoiceType.Item61);
+    }
+
+    #endregion
+
+    #region 3.INCOME CLASSIFICATION — a simplified invoice (11.3) is booked wholesale (E3_561_001)
+    
+    // The classification correction lives in AADEFactory (after the override layer), not in the
+    // case-driven base mapper — so it is asserted on the built document via MapToInvoicesDoc.
+
+    private static IncomeClassificationValueType? DetailType(InvoicesDoc doc)
+        => doc.invoice[0].invoiceDetails[0].incomeClassification?[0].classificationType;
+
+    private static IncomeClassificationValueType? SummaryType(InvoicesDoc doc)
+        => doc.invoice[0].invoiceSummary.incomeClassification?[0].classificationType;
+
+    /// <summary>
+    /// A simplified invoice is billed to a business, so its income is wholesale (E3_561_001), not the
+    /// retail E3_561_003 the base mapping produces. Holds for goods and services (both resolve to 11.3).
+    /// </summary>
+    [Theory]
+    [InlineData(ChargeItemCaseTypeOfService.Delivery)]       // category1_1
+    [InlineData(ChargeItemCaseTypeOfService.CatalogService)] // category1_2
+    [InlineData(ChargeItemCaseTypeOfService.OtherService)]   // category1_3
+    public void MapToInvoicesDoc_SimplifiedInvoiceFlag_ClassifiesWholesale(
+        ChargeItemCaseTypeOfService typeOfService)
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(typeOfService);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item113);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_561_001);
+        SummaryType(doc).Should().Be(IncomeClassificationValueType.E3_561_001);
+    }
+
+    /// <summary>
+    /// The override route to 11.3 (invoiceType override, no flag) is corrected the same way — this is
+    /// the pre-existing defect where a header-only override transmitted the retail classification.
+    /// A correctly-built override that also sets a per-line incomeClassification is untouched, because
+    /// only the retail E3_561_003 is remapped (guarded by the existing override test suites).
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_InvoiceTypeOverriddenTo113_ClassifiesWholesale()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt();
+        request.ftReceiptCase = ((ReceiptCase) GR_V2).WithCase(ReceiptCase.PointOfSaleReceipt0x0001);
+        request.ftReceiptCaseData = new
+        {
+            GR = new { mydataoverride = new { invoice = new { invoiceHeader = new { invoiceType = "11.3" } } } }
+        };
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item113);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_561_001);
+        SummaryType(doc).Should().Be(IncomeClassificationValueType.E3_561_001);
+    }
+
+    /// <summary>
+    /// Crediting a simplified invoice resolves to 11.4, but the reversed revenue was wholesale, so the
+    /// credit must be wholesale too — otherwise a wholesale sale is cancelled by a retail credit and
+    /// the two never net out. Scoped to the flag, so ordinary 11.1 refunds are unaffected (next test).
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_SimplifiedInvoiceRefund_ClassifiesWholesaleAndIs114()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(isRefund: true);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item114);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_561_001);
+    }
+
+    /// <summary>An ordinary POS refund (no flag) stays retail — the wholesale rule must not leak to 11.4 in general.</summary>
+    [Fact]
+    public void MapToInvoicesDoc_PlainRefund_StaysRetail()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(isRefund: true);
+        request.ftReceiptCase = ((ReceiptCase) GR_V2)
+            .WithCase(ReceiptCase.PointOfSaleReceipt0x0001)
+            .WithFlag(ReceiptCaseFlags.Refund);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item114);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_561_003);
+    }
+
+    /// <summary>An ordinary POS receipt (no flag, no override) keeps the retail code — 11.1 behaviour.</summary>
+    [Fact]
+    public void MapToInvoicesDoc_PlainRetailReceipt_StaysRetail()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt();
+        request.ftReceiptCase = ((ReceiptCase) GR_V2).WithCase(ReceiptCase.PointOfSaleReceipt0x0001);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item111);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_561_003);
+    }
+
+    /// <summary>
+    /// Own consumption resolves to 6.1 with E3_595 — the wholesale remap only touches E3_561_003, so
+    /// it must leave a flagged own-consumption receipt alone.
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_OwnConsumptionWithFlag_StaysSelfDeliveryE3_595()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(ChargeItemCaseTypeOfService.OwnConsumption, withCustomer: true);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc!.invoice[0].invoiceHeader.invoiceType.Should().Be(InvoiceType.Item61);
+        DetailType(doc).Should().Be(IncomeClassificationValueType.E3_595);
+    }
+
+    #endregion
+
+    #region 4.NO COUNTERPART — 11.3 is «Μη Αντικριζόμενο»; these pin CORRECT existing behaviour
+
+    /// <summary>
+    /// A supplied cbCustomer must NOT reach the transmitted document. Live proof: 265_E
+    /// (MARK 400001968027108) produced a document identical to 265_A's — the customer had zero
+    /// effect. That must remain true once the type becomes 11.3.
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_SimplifiedInvoiceWithCustomer_HasNoCounterpartAndIs113()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(withCustomer: true);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var invoice = doc!.invoice[0];
+        invoice.invoiceHeader.invoiceType.Should().Be(InvoiceType.Item113);
+        invoice.counterpart.Should().BeNull("11.3 is a «Μη Αντικριζόμενο» document — ΕΛΠ άρθρο 10 §2 omits the buyer's details");
+    }
+
+    /// <summary>11.3 must never demand customer info — the document type exists to avoid it.</summary>
+    [Fact]
+    public void RequiresCustomerInfo_Item113_IsFalse()
+        => AADEMappings.RequiresCustomerInfo(InvoiceType.Item113).Should().BeFalse();
+
+    /// <summary>
+    /// Confirms the retracted "counterpart is being dropped" reading: dropping it is CORRECT for
+    /// 11.3, per the ERP spec ("Non-Mirrored"), the provider spec ("Non-Counterparty Documents")
+    /// and the A.1138/2020 A2 grouping.
+    /// </summary>
+    [Fact]
+    public void SupportsCounterpart_Item113_IsFalse()
+        => AADEMappings.SupportsCounterpart(InvoiceType.Item113).Should().BeFalse();
+
+    #endregion
+
+    #region 5.CORRELATED INVOICES — ΕΛΠ άρθρο 10 §1(b): a corrective 11.3 references the original
+
+    /// <summary>
+    /// A simplified invoice is not only the ≤€100 case: άρθρο 10 §1(b) also covers an άρθρο 8 §3
+    /// document that amends and refers specifically to an ORIGINAL invoice. So an 11.3 must be able
+    /// to carry a reference to the document it corrects, otherwise that whole leg of άρθρο 10 is
+    /// unreachable.
+    ///
+    /// The spec puts the reference in multipleConnectedMarks, not correlatedInvoices: the ERP spec
+    /// says multipleConnectedMarks "is not acceptable for documents of type 1.6, 2.4 and 5.1" —
+    /// 11.3 is not excluded — which is exactly what SupportsMultipleConnectedMarks already encodes.
+    /// SupportsCorrelatedInvoices(Item113) = false therefore costs nothing here: the non-refund
+    /// branch of AADEFactory reaches multipleConnectedMarks first, so no reference is lost.
+    ///
+    /// Consequence for this test: only the invoiceType is red. The mark handling is already correct
+    /// today (a POS receipt with a previous mark carries it), and must stay correct once the type
+    /// becomes 11.3.
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_SimplifiedInvoiceWithPreviousMark_CarriesMultipleConnectedMarksAndIs113()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt();
+        // MARK supplied directly — the route for an original invoice this middleware did not issue.
+        request.ftReceiptCaseData = new
+        {
+            GR = new { PreviousReceiptReference = new { invoiceMark = "400001968025746" } }
+        };
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var header = doc!.invoice[0].invoiceHeader;
+        header.invoiceType.Should().Be(InvoiceType.Item113);
+        header.multipleConnectedMarks.Should().BeEquivalentTo(new[] { 400001968025746L });
+        header.correlatedInvoices.Should().BeNull("the non-refund branch uses multipleConnectedMarks for retail-family types");
+    }
+
+    /// <summary>
+    /// Crediting a simplified invoice: Refund still wins the type (11.4), and the reference to the
+    /// corrected document must survive. Green today — guard against the type change breaking it.
+    /// </summary>
+    [Fact]
+    public void MapToInvoicesDoc_SimplifiedInvoiceRefundWithPreviousMark_CarriesMultipleConnectedMarksAndIs114()
+    {
+        var factory = CreateFactory();
+        var request = CreateSimplifiedInvoiceReceipt(isRefund: true);
+        request.ftReceiptCaseData = new
+        {
+            GR = new { PreviousReceiptReference = new { invoiceMark = "400001968025746" } }
+        };
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, CreateResponse(request));
+
+        error.Should().BeNull();
+        var header = doc!.invoice[0].invoiceHeader;
+        header.invoiceType.Should().Be(InvoiceType.Item114);
+        header.multipleConnectedMarks.Should().BeEquivalentTo(new[] { 400001968025746L });
+    }
+
+    /// <summary>
+    /// Spec check, not a behaviour change: multipleConnectedMarks is unacceptable only for 1.6, 2.4
+    /// and 5.1, so 11.3 must remain permitted. Pins why SupportsCorrelatedInvoices(Item113)=false is
+    /// harmless.
+    /// </summary>
+    [Fact]
+    public void SupportsMultipleConnectedMarks_Item113_IsTrue()
+        => AADEMappings.SupportsMultipleConnectedMarks(InvoiceType.Item113).Should().BeTrue();
+
+    #endregion
+}


### PR DESCRIPTION
## Problem

Adds first-class support for myDATA document type **11.3 – Απλοποιημένο Τιμολόγιο
(Simplified Invoice)**. 11.3 is an invoice to a *business* in legally simplified
form (ΕΛΠ ν.4308/2014 άρθρο 10): the buyer's details are omitted, so myDATA files
it as non-counterparty, but because the buyer is a business, the revenue is
classified as **wholesale**, not retail.

Previously the type could only be reached through a `mydataoverride`, and even then
the income classification stayed on the retail branch (`E3_561_003`), producing a
document AADE accepts but books incorrectly.

## Solution

- **New GR-local flag** `IsSimplifiedInvoice = 0x0000_0001_0000_0000` (lll region),
  added to both `ReceiptCaseFlagsGR` copies.
- **`GetInvoiceType`** resolves a POS receipt carrying the flag to `Item113`,
  evaluated *before* the goods/services split so it applies to both. Refund still
  wins (→ `11.4`), as do agency (`11.5`) and own-consumption (`6.1`).
- **Wholesale income classification.** The base mapping stays a pure function of the
  receipt case, it produces the retail `E3_561_003`, as for 11.1. A single
  normalization step in `AADEFactory`, applied *after* the override layer, remaps it
  to the wholesale `E3_561_001` when the resolved document is a simplified invoice:
  recognized by the invoice type being `11.3` (covers the override route) or by the
  `IsSimplifiedInvoice` flag (covers a refund that resolves to `11.4`). Only the
  retail code is remapped, so an explicit per-line `incomeClassification` override is
  preserved. This keeps the override out of the case-driven base mapper (matching the
  existing `GetInvoiceType` design) and also fixes the pre-existing override path,
  which had been transmitting the retail code.
- **No counterpart:** `SupportsCounterpart(Item113)` / `RequiresCustomerInfo(Item113)`
  stay `false`, a supplied `cbCustomer` is not transmitted, matching the
  non-counterparty nature of the type.
- **Tests:** `SimplifiedInvoice113Tests` covers the trigger (goods + services),
  precedence (refund/agency/own-consumption), the wholesale classification asserted on
  the built document for both the flag and the override routes (and that plain retail
  and plain refunds stay retail), the dropped customer, and correlation via
  `multipleConnectedMarks`.

## Behaviour notes

- **Thresholds** (€100 general, €300 fuel, none for corrective documents) are the
  POS's legal responsibility and are not enforced by the middleware.
- **Reverse charge (άρθρο 39a) on 11.3** is not a supported combination and is left
  unmapped for now (documented inline).
- **Viva:** no gateway change needed

Fixes: [#265](https://github.com/fiskaltrust/market-gr/issues/265)