### PR TITLE
normalize apostrophe/dash variants in special tax description lookups

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
@@ -239,9 +239,14 @@ public static class SpecialTaxMappings
         // Code 8: Ξενοδοχεία 4 αστέρων 3,00 € (fixed amount)
         // Code 8: Hotels 4 stars 3.00 € (fixed amount)
         ["Ξενοδοχεία 4 αστέρων 3,00 €"] = new(8, "Ξενοδοχεία 4 αστέρων 3,00 €", null, true),
-        // Code 9: Ξενοδοχεία 5 αστέρων 4,00 € (fixed amount)
-        // Code 9: Hotels 5 stars 4.00 € (fixed amount)
-        ["Ξενοδοχεία 4 αστέρων 4,00 €"] = new(9, "Ξενοδοχεία 4 αστέρων 4, 00 €", null, true),
+        // Code 9: Ξενοδοχεία 4 αστέρων 4,00 € (fixed amount)
+        // Official text per myDATA API Documentation v2.0.2, Appendix 8.5 (codes table p. 96-97).
+        // AADE publishes code 9 as "4 αστέρων" even though it logically covers 5-star hotels
+        // (code 8 is already 4 stars at 3,00 €), so the official string is kept as the key.
+        ["Ξενοδοχεία 4 αστέρων 4,00 €"] = new(9, "Ξενοδοχεία 4 αστέρων 4,00 €", null, true),
+        // Alias for code 9: the logically correct "5 αστέρων" wording, which AADE uses in its
+        // announcements for this fee, so both spellings resolve.
+        ["Ξενοδοχεία 5 αστέρων 4,00 €"] = new(9, "Ξενοδοχεία 4 αστέρων 4,00 €", null, true),
         // Code 10: Ενοικιαζόμενα – επιπλωμένα δωμάτια – διαμερίσματα 0,50 € (fixed amount)
         // Code 10: Rental furnished rooms - apartments 0.50 € (fixed amount)
         ["Ενοικιαζόμενα - επιπλωμένα δωμάτια - διαμερίσματα 0,50 €"] = new(10, "Ενοικιαζόμενα - επιπλωμένα δωμάτια - διαμερίσματα 0,50 €", null, true),
@@ -330,24 +335,28 @@ public static class SpecialTaxMappings
         {
             switch (c)
             {
-                // Apostrophe variants become the plain ASCII apostrophe.
-                // Escapes, not literal glyphs, since these are easy to confuse by eye.
-                case '\u2019': // right single quotation mark (the form AADE uses)
-                case '\u2018': // left single quotation mark
-                case '\u02BC': // modifier letter apostrophe
-                case '\u00B4': // acute accent
-                case '`': // grave accent
+                // Apostrophe variants -> ASCII apostrophe
+                case '\u2019': // ’ right single quotation mark (the form AADE publishes)
+                case '\u2018': // ‘ left single quotation mark
+                case '\u201B': // ‛ single high-reversed-9 quotation mark
+                case '\u02BC': // ʼ modifier letter apostrophe
+                case '\u02B9': // ʹ modifier letter prime
+                case '\u0374': // ʹ Greek numeral sign (dexia keraia, the proper mark for δʹ)
+                case '\u0384': // ΄ Greek tonos (what a Greek keyboard emits for a lone accent)
+                case '\u00B4': // ´ acute accent
+                case '\u2032': // ′ prime
+                case '`':      // grave accent
                     sb.Append('\'');
                     break;
-                // Dash variants become the plain ASCII hyphen
-                case '\u2013': // en dash (used by a few table entries)
-                case '\u2014': // em dash
-                case '\u2212': // minus sign
+                // Dash variants -> ASCII hyphen-minus
+                case '\u2010': // ‐ hyphen
+                case '\u2011': // ‑ non-breaking hyphen
+                case '\u2012': // ‒ figure dash
+                case '\u2013': // – en dash (used by other-tax codes 24/27/30)
+                case '\u2014': // — em dash
+                case '\u2015': // ― horizontal bar
+                case '\u2212': // − minus sign
                     sb.Append('-');
-                    break;
-                // Non-breaking space becomes a normal space
-                case '\u00A0':
-                    sb.Append(' ');
                     break;
                 default:
                     sb.Append(c);
@@ -360,10 +369,30 @@ public static class SpecialTaxMappings
     }
 
     /// <summary>
-    /// Shared lookup for all four special tax tables. Compares the normalised description against
-    /// the normalised keys: exact match first, then the substring fallback, case-insensitive.
+    /// Builds the lookup companion of a mapping table: same values, keys normalised with
+    /// <see cref="NormalizeForLookup"/> so lookups do not have to re-normalise the table.
     /// </summary>
-    private static T? LookupSpecialTax<T>(Dictionary<string, T> table, string description) where T : class
+    private static Dictionary<string, T> BuildNormalizedLookup<T>(Dictionary<string, T> table)
+    {
+        var normalized = new Dictionary<string, T>(table.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in table)
+        {
+            normalized[NormalizeForLookup(kvp.Key)] = kvp.Value;
+        }
+        return normalized;
+    }
+
+    private static readonly Dictionary<string, WithholdingTaxMapping> _normalizedWithholdingTaxMappings = BuildNormalizedLookup(_withholdingTaxMappings);
+    private static readonly Dictionary<string, FeeMapping> _normalizedFeeMappings = BuildNormalizedLookup(_feeMappings);
+    private static readonly Dictionary<string, StampDutyMapping> _normalizedStampDutyMappings = BuildNormalizedLookup(_stampDutyMappings);
+    private static readonly Dictionary<string, OtherTaxMapping> _normalizedOtherTaxMappings = BuildNormalizedLookup(_otherTaxMappings);
+
+    /// <summary>
+    /// Shared lookup used by all four special tax tables. Matches the normalised description
+    /// against the normalised table keys: an exact match first, then the original substring
+    /// fallback, both apostrophe/dash/whitespace-insensitive and case-insensitive.
+    /// </summary>
+    private static T? LookupSpecialTax<T>(Dictionary<string, T> normalizedTable, string description) where T : class
     {
         if (string.IsNullOrWhiteSpace(description))
         {
@@ -372,23 +401,18 @@ public static class SpecialTaxMappings
 
         var normalized = NormalizeForLookup(description);
 
-        // Try exact match first (on the normalised key)
-        foreach (var kvp in table)
+        // Try exact match first
+        if (normalizedTable.TryGetValue(normalized, out var exactMapping))
         {
-            if (string.Equals(NormalizeForLookup(kvp.Key), normalized, StringComparison.OrdinalIgnoreCase))
-            {
-                return kvp.Value;
-            }
+            return exactMapping;
         }
 
         // Try partial matching for more flexible description matching
-        foreach (var kvp in table)
+        foreach (var kvp in normalizedTable)
         {
-            var key = NormalizeForLookup(kvp.Key);
-
             // Check if the description contains the key or key contains the description
-            if (normalized.Contains(key, StringComparison.OrdinalIgnoreCase) ||
-                key.Contains(normalized, StringComparison.OrdinalIgnoreCase))
+            if (normalized.Contains(kvp.Key, StringComparison.OrdinalIgnoreCase) ||
+                kvp.Key.Contains(normalized, StringComparison.OrdinalIgnoreCase))
             {
                 return kvp.Value;
             }
@@ -403,7 +427,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Withholding tax mapping if found, null otherwise</returns>
     public static WithholdingTaxMapping? GetWithholdingTaxMapping(string description)
-        => LookupSpecialTax(_withholdingTaxMappings, description);
+        => LookupSpecialTax(_normalizedWithholdingTaxMappings, description);
 
     /// <summary>
     /// Gets fee mapping for a given charge item description.
@@ -411,7 +435,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Fee mapping if found, null otherwise</returns>
     public static FeeMapping? GetFeeMapping(string description)
-        => LookupSpecialTax(_feeMappings, description);
+        => LookupSpecialTax(_normalizedFeeMappings, description);
 
     /// <summary>
     /// Gets stamp duty mapping for a given charge item description.
@@ -419,7 +443,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Stamp duty mapping if found, null otherwise</returns>
     public static StampDutyMapping? GetStampDutyMapping(string description)
-        => LookupSpecialTax(_stampDutyMappings, description);
+        => LookupSpecialTax(_normalizedStampDutyMappings, description);
 
     /// <summary>
     /// Gets other tax mapping for a given charge item description.
@@ -427,7 +451,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Other tax mapping if found, null otherwise</returns>
     public static OtherTaxMapping? GetOtherTaxMapping(string description)
-        => LookupSpecialTax(_otherTaxMappings, description);
+        => LookupSpecialTax(_normalizedOtherTaxMappings, description);
 
     public static bool IsSpecialTaxItem(ChargeItem chargeItem)
     {

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/SpecialTaxMappings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using fiskaltrust.ifPOS.v2;
 using fiskaltrust.ifPOS.v2.Cases;
 
@@ -307,39 +308,102 @@ public static class SpecialTaxMappings
     };
 
     /// <summary>
-    /// Gets withholding tax mapping for a given charge item description.
+    /// Normalises a description so lookups ignore punctuation codepoint differences. The AADE
+    /// tables use the curly apostrophe and en dash, but POS systems often send the plain ASCII
+    /// apostrophe and hyphen, and a few table entries use the en dash themselves. Same category,
+    /// different bytes, so a plain match fails. Comparison only: the stored strings and anything
+    /// sent to AADE are left exactly as they are.
     /// </summary>
-    /// <param name="description">The description of the charge item</param>
-    /// <returns>Withholding tax mapping if found, null otherwise</returns>
-    public static WithholdingTaxMapping? GetWithholdingTaxMapping(string description)
+    /// <param name="description">The raw description.</param>
+    /// <returns>The description with apostrophe and dash variants folded to ASCII, non-breaking
+    /// spaces turned into normal spaces, whitespace collapsed and trimmed. Empty string for
+    /// null/whitespace input.</returns>
+    public static string NormalizeForLookup(string? description)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(description.Length);
+        foreach (var c in description)
+        {
+            switch (c)
+            {
+                // Apostrophe variants become the plain ASCII apostrophe.
+                // Escapes, not literal glyphs, since these are easy to confuse by eye.
+                case '\u2019': // right single quotation mark (the form AADE uses)
+                case '\u2018': // left single quotation mark
+                case '\u02BC': // modifier letter apostrophe
+                case '\u00B4': // acute accent
+                case '`': // grave accent
+                    sb.Append('\'');
+                    break;
+                // Dash variants become the plain ASCII hyphen
+                case '\u2013': // en dash (used by a few table entries)
+                case '\u2014': // em dash
+                case '\u2212': // minus sign
+                    sb.Append('-');
+                    break;
+                // Non-breaking space becomes a normal space
+                case '\u00A0':
+                    sb.Append(' ');
+                    break;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+
+        // Collapse any run of whitespace to a single space and trim the ends.
+        return string.Join(' ', sb.ToString().Split((char[]?) null, StringSplitOptions.RemoveEmptyEntries));
+    }
+
+    /// <summary>
+    /// Shared lookup for all four special tax tables. Compares the normalised description against
+    /// the normalised keys: exact match first, then the substring fallback, case-insensitive.
+    /// </summary>
+    private static T? LookupSpecialTax<T>(Dictionary<string, T> table, string description) where T : class
     {
         if (string.IsNullOrWhiteSpace(description))
         {
             return null;
         }
 
-        // Try exact match first
-        if (_withholdingTaxMappings.TryGetValue(description.Trim(), out var exactMapping))
+        var normalized = NormalizeForLookup(description);
+
+        // Try exact match first (on the normalised key)
+        foreach (var kvp in table)
         {
-            return exactMapping;
+            if (string.Equals(NormalizeForLookup(kvp.Key), normalized, StringComparison.OrdinalIgnoreCase))
+            {
+                return kvp.Value;
+            }
         }
 
         // Try partial matching for more flexible description matching
-        foreach (var kvp in _withholdingTaxMappings)
+        foreach (var kvp in table)
         {
-            var key = kvp.Key;
-            var mapping = kvp.Value;
+            var key = NormalizeForLookup(kvp.Key);
 
             // Check if the description contains the key or key contains the description
-            if (description.Contains(key, StringComparison.OrdinalIgnoreCase) ||
-                key.Contains(description, StringComparison.OrdinalIgnoreCase))
+            if (normalized.Contains(key, StringComparison.OrdinalIgnoreCase) ||
+                key.Contains(normalized, StringComparison.OrdinalIgnoreCase))
             {
-                return mapping;
+                return kvp.Value;
             }
         }
 
         return null;
     }
+
+    /// <summary>
+    /// Gets withholding tax mapping for a given charge item description.
+    /// </summary>
+    /// <param name="description">The description of the charge item</param>
+    /// <returns>Withholding tax mapping if found, null otherwise</returns>
+    public static WithholdingTaxMapping? GetWithholdingTaxMapping(string description)
+        => LookupSpecialTax(_withholdingTaxMappings, description);
 
     /// <summary>
     /// Gets fee mapping for a given charge item description.
@@ -347,34 +411,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Fee mapping if found, null otherwise</returns>
     public static FeeMapping? GetFeeMapping(string description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-        {
-            return null;
-        }
-
-        // Try exact match first
-        if (_feeMappings.TryGetValue(description.Trim(), out var exactMapping))
-        {
-            return exactMapping;
-        }
-
-        // Try partial matching for more flexible description matching
-        foreach (var kvp in _feeMappings)
-        {
-            var key = kvp.Key;
-            var mapping = kvp.Value;
-
-            // Check if the description contains the key or key contains the description
-            if (description.Contains(key, StringComparison.OrdinalIgnoreCase) ||
-                key.Contains(description, StringComparison.OrdinalIgnoreCase))
-            {
-                return mapping;
-            }
-        }
-
-        return null;
-    }
+        => LookupSpecialTax(_feeMappings, description);
 
     /// <summary>
     /// Gets stamp duty mapping for a given charge item description.
@@ -382,34 +419,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Stamp duty mapping if found, null otherwise</returns>
     public static StampDutyMapping? GetStampDutyMapping(string description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-        {
-            return null;
-        }
-
-        // Try exact match first
-        if (_stampDutyMappings.TryGetValue(description.Trim(), out var exactMapping))
-        {
-            return exactMapping;
-        }
-
-        // Try partial matching for more flexible description matching
-        foreach (var kvp in _stampDutyMappings)
-        {
-            var key = kvp.Key;
-            var mapping = kvp.Value;
-
-            // Check if the description contains the key or key contains the description
-            if (description.Contains(key, StringComparison.OrdinalIgnoreCase) ||
-                key.Contains(description, StringComparison.OrdinalIgnoreCase))
-            {
-                return mapping;
-            }
-        }
-
-        return null;
-    }
+        => LookupSpecialTax(_stampDutyMappings, description);
 
     /// <summary>
     /// Gets other tax mapping for a given charge item description.
@@ -417,34 +427,7 @@ public static class SpecialTaxMappings
     /// <param name="description">The description of the charge item</param>
     /// <returns>Other tax mapping if found, null otherwise</returns>
     public static OtherTaxMapping? GetOtherTaxMapping(string description)
-    {
-        if (string.IsNullOrWhiteSpace(description))
-        {
-            return null;
-        }
-
-        // Try exact match first
-        if (_otherTaxMappings.TryGetValue(description.Trim(), out var exactMapping))
-        {
-            return exactMapping;
-        }
-
-        // Try partial matching for more flexible description matching
-        foreach (var kvp in _otherTaxMappings)
-        {
-            var key = kvp.Key;
-            var mapping = kvp.Value;
-
-            // Check if the description contains the key or key contains the description
-            if (description.Contains(key, StringComparison.OrdinalIgnoreCase) ||
-                key.Contains(description, StringComparison.OrdinalIgnoreCase))
-            {
-                return mapping;
-            }
-        }
-
-        return null;
-    }
+        => LookupSpecialTax(_otherTaxMappings, description);
 
     public static bool IsSpecialTaxItem(ChargeItem chargeItem)
     {

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
@@ -1509,8 +1509,9 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest.SCU.MyData
         // a lookup key here: a non-vatable special tax line becomes a document level tax total and
         // is left out of the invoice rows, so its text is never sent to AADE.
         [Theory]
-        [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%")]   // plain ASCII apostrophe, the form our table stores
-        [InlineData("Περιπτ. δ’ - Τεχνικά Έργα - 3%")]   // curly apostrophe, the form AADE uses
+        [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%")]   // U+0027, the form the mapping table stores
+        [InlineData("Περιπτ. δ’ - Τεχνικά Έργα - 3%")]   // U+2019, the form AADE publishes and Viva sent
+        [InlineData("Περιπτ. δ΄ - Τεχνικά Έργα - 3%")]   // U+0384 Greek tonos, what a Greek keyboard emits
         public void MapToInvoicesDoc_ShouldMapTechnicalWorksWithholdingTax_ForEitherApostropheCodepoint(string withholdingDescription)
         {
             // Arrange

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxHandlingTests.cs
@@ -1499,5 +1499,106 @@ namespace fiskaltrust.Middleware.SCU.GR.MyData.UnitTest.SCU.MyData
 
         }
         #endregion IsVatableSpecialTaxItemTests
+
+        #region WithholdingTaxDescriptionApostrophe
+
+        // End to end check for the two apostrophe forms of the same withholding description.
+        // They differ at one position: the apostrophe after δ is the plain ASCII one in the
+        // control and the curly one in the AADE form a partner copies from the spec. Both must map
+        // to withholding category 4 and give an identical document, because the description is only
+        // a lookup key here: a non-vatable special tax line becomes a document level tax total and
+        // is left out of the invoice rows, so its text is never sent to AADE.
+        [Theory]
+        [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%")]   // plain ASCII apostrophe, the form our table stores
+        [InlineData("Περιπτ. δ’ - Τεχνικά Έργα - 3%")]   // curly apostrophe, the form AADE uses
+        public void MapToInvoicesDoc_ShouldMapTechnicalWorksWithholdingTax_ForEitherApostropheCodepoint(string withholdingDescription)
+        {
+            // Arrange
+            var factory = new AADEFactory(_masterDataConfiguration, "https://test.receipts.example.com");
+
+            var receiptRequest = new ReceiptRequest
+            {
+                ftCashBoxID = Guid.NewGuid(),
+                ftPosSystemId = Guid.NewGuid(),
+                cbTerminalID = "T001",
+                cbReceiptReference = "gr-withholding-apostrophe-001",
+                cbReceiptMoment = DateTime.UtcNow,
+                ftReceiptCase = (ReceiptCase) 0x4752_2000_0000_1002, // B2B invoice
+                cbCustomer = new MiddlewareCustomer
+                {
+                    CustomerVATId = "026883248",
+                    CustomerName = "Πελάτης A.E.",
+                    CustomerStreet = "Κηφισίας 12",
+                    CustomerZip = "12345",
+                    CustomerCity = "Αθηνών",
+                    CustomerCountry = "GR"
+                },
+                cbChargeItems =
+                [
+                    new ChargeItem
+                    {
+                        ftChargeItemCase = (ChargeItemCase) 0x4752_2000_0000_0023, // other service @ 24%
+                        Description = "Τεχνικά έργα - εργολαβία κατασκευής",
+                        Amount = 1240m,
+                        VATRate = 24m,
+                        VATAmount = 240m,
+                        Position = 1
+                    },
+                    new ChargeItem
+                    {
+                        ftChargeItemCase = (ChargeItemCase) 0x4752_2000_0000_00F8, // special tax, not taxable
+                        Description = withholdingDescription,
+                        Amount = -30m, // 3% of the 1000.00 net
+                        VATRate = 0m,
+                        Position = 2
+                    }
+                ],
+                cbPayItems =
+                [
+                    new PayItem
+                    {
+                        ftPayItemCase = (PayItemCase) 0x4752_2000_0000_0001,
+                        Amount = 1210m // 1240.00 gross less the 30.00 withheld
+                    }
+                ]
+            };
+
+            var receiptResponse = new ReceiptResponse
+            {
+                ftReceiptIdentification = "ft123456789",
+                ftCashBoxIdentification = "CB001",
+                ftState = (State) 0x4752000000000000,
+                ftSignatures = []
+            };
+
+            // Act
+            var (invoiceDoc, error) = factory.MapToInvoicesDoc(receiptRequest, receiptResponse);
+
+            // Assert
+            error.Should().BeNull($"'{withholdingDescription}' is withholding category 4; the apostrophe codepoint must not make the mapping fail");
+            invoiceDoc.Should().NotBeNull();
+
+            var invoice = invoiceDoc.invoice[0];
+
+            invoice.taxesTotals.Should().NotBeNullOrEmpty();
+            invoice.taxesTotals.Length.Should().Be(1);
+
+            var withholdingTax = invoice.taxesTotals[0];
+            withholdingTax.taxType.Should().Be(1, "withheld taxes are tax type 1");
+            withholdingTax.taxCategory.Should().Be(4, "Περιπτ. δ' - Τεχνικά Έργα - 3% is withholding category 4");
+            withholdingTax.taxAmount.Should().Be(30m);
+
+            invoice.invoiceSummary.totalWithheldAmount.Should().Be(30m);
+            invoice.invoiceSummary.totalNetValue.Should().Be(1000m);
+            invoice.invoiceSummary.totalVatAmount.Should().Be(240m);
+            invoice.invoiceSummary.totalGrossValue.Should().Be(1210m, "gross is the 1240.00 invoice total less the 30.00 withheld");
+
+            // The withholding line is a document level tax total only, so it must not appear as an
+            // invoice row and its description is never transmitted to AADE.
+            invoice.invoiceDetails.Length.Should().Be(1, "only the service line is an invoice row");
+            invoice.invoiceDetails[0].netValue.Should().Be(1000m);
+        }
+
+        #endregion WithholdingTaxDescriptionApostrophe
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
@@ -276,5 +276,61 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
             result.Should().Be(expected, $"serviceType={serviceType}, vatCode={vatCode}, description='{description ?? "null"}'");
         }
         #endregion IsVatableSpecialTaxItemTests
+
+        #region PunctuationCodepointVariants
+
+        // Special tax descriptions are matched by string, so a description that differs only in the
+        // codepoint of its punctuation used to be rejected. The AADE table uses the curly apostrophe
+        // ("Περιπτ. δ’ - Τεχνικά Έργα - 3%"), while our table has the plain ASCII apostrophe. A
+        // partner copying the description from the AADE spec could not be matched.
+
+        [Theory]
+        // Control: the plain ASCII form our table stores. Matches today and must keep matching.
+        [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%", 4)]
+        // The AADE form. Same as the control except the apostrophe is the curly one.
+        [InlineData("Περιπτ. δ’ - Τεχνικά Έργα - 3%", 4)]
+        // The other three withholding categories whose official description carries an apostrophe.
+        [InlineData("Περιπτ. β’- Τόκοι - 15%", 1)]
+        [InlineData("Περιπτ. γ’ - Δικαιώματα - 20%", 2)]
+        [InlineData("Περιπτ. δ’ - Αμοιβές Συμβουλών Διοίκησης - 20%", 3)]
+        public void GetWithholdingTaxMapping_ShouldResolve_RegardlessOfApostropheCodepoint(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetWithholdingTaxMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is withholding category {expectedCode}; the apostrophe codepoint must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to withholding category {expectedCode}");
+        }
+
+        // The same problem the other way round. A few entries in the other tax table are stored
+        // with the en dash, so a partner sending the plain hyphen was rejected. This is why the
+        // normalisation has to run on the table keys too, not just on the incoming description.
+
+        [Theory]
+        // Control: the en dash form our table stores. Matches today and must keep matching.
+        [InlineData("Ενοικιαζόμενα επιπλωμένα δωμάτια – διαμερίσματα 1,50€ (ανά Δωμ./Διαμ.)", 24)]
+        // The same description typed with a plain hyphen.
+        [InlineData("Ενοικιαζόμενα επιπλωμένα δωμάτια - διαμερίσματα 1,50€ (ανά Δωμ./Διαμ.)", 24)]
+        [InlineData("Αυτοεξυπηρετούμενα καταλύματα – τουριστικές επιπλωμένες επαύλεις (βίλες) 10,00€", 27)]
+        [InlineData("Αυτοεξυπηρετούμενα καταλύματα - τουριστικές επιπλωμένες επαύλεις (βίλες) 10,00€", 27)]
+        public void GetOtherTaxMapping_ShouldResolve_RegardlessOfDashCodepoint(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetOtherTaxMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is other tax category {expectedCode}; the dash codepoint must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to other tax category {expectedCode}");
+        }
+
+        // A description that is not in any table must still be rejected. Normalising punctuation
+        // must not widen the match so far that an unknown description resolves to some category
+        // through the substring fallback.
+        [Theory]
+        [InlineData("Unknown withholding tax")]
+        [InlineData("Περιπτ. ζ’ - Ανύπαρκτη Κατηγορία - 7%")]
+        public void GetWithholdingTaxMapping_ShouldStillReturnNull_ForDescriptionsNotInTheTable(string description)
+        {
+            SpecialTaxMappings.GetWithholdingTaxMapping(description).Should().BeNull($"'{description}' is not a real withholding category");
+        }
+
+        #endregion PunctuationCodepointVariants
     }
 }

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/SpecialTaxMappingsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
 using Xunit;
@@ -161,7 +162,8 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
         [InlineData("Ξενοδοχεία 1-2 αστέρων 0,50 €", 6, null, true)]
         [InlineData("Ξενοδοχεία 3 αστέρων 1,50 €", 7, null, true)]
         [InlineData("Ξενοδοχεία 4 αστέρων 3,00 €", 8, null, true)]
-        [InlineData("Ξενοδοχεία 4 αστέρων 4,00 €", 9, null, true)]
+        [InlineData("Ξενοδοχεία 4 αστέρων 4,00 €", 9, null, true)] // official AADE wording (Appendix 8.5), despite the apparent "4 αστέρων" typo
+        [InlineData("Ξενοδοχεία 5 αστέρων 4,00 €", 9, null, true)] // alias: the logically correct 5-star wording
         [InlineData("Ενοικιαζόμενα - επιπλωμένα δωμάτια - διαμερίσματα 0,50 €", 10, null, true)]
         [InlineData("Ειδικός Φόρος στις διαφημίσεις που προβάλλονται από την τηλεόραση (ΕΦΤΔ) 5%", 11, 5, false)]
         [InlineData("3.1 Φόρος πολυτελείας 10% επί της φορολογητέας αξίας για τα ενδοκοινοτικώς αποκτούμενα και εισαγόμενα από τρίτες χώρες 10%", 12, 10, false)]
@@ -285,7 +287,7 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
         // partner copying the description from the AADE spec could not be matched.
 
         [Theory]
-        // Control: the plain ASCII form our table stores. Matches today and must keep matching.
+        // Control: the exact ASCII form the table stores. Matches today and must keep matching.
         [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%", 4)]
         // The AADE form. Same as the control except the apostrophe is the curly one.
         [InlineData("Περιπτ. δ’ - Τεχνικά Έργα - 3%", 4)]
@@ -306,9 +308,9 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
         // normalisation has to run on the table keys too, not just on the incoming description.
 
         [Theory]
-        // Control: the en dash form our table stores. Matches today and must keep matching.
+        // Control: the exact en dash form the table stores. Matches today and must keep matching.
         [InlineData("Ενοικιαζόμενα επιπλωμένα δωμάτια – διαμερίσματα 1,50€ (ανά Δωμ./Διαμ.)", 24)]
-        // The same description typed with a plain hyphen.
+        // The same description typed with an ordinary hyphen.
         [InlineData("Ενοικιαζόμενα επιπλωμένα δωμάτια - διαμερίσματα 1,50€ (ανά Δωμ./Διαμ.)", 24)]
         [InlineData("Αυτοεξυπηρετούμενα καταλύματα – τουριστικές επιπλωμένες επαύλεις (βίλες) 10,00€", 27)]
         [InlineData("Αυτοεξυπηρετούμενα καταλύματα - τουριστικές επιπλωμένες επαύλεις (βίλες) 10,00€", 27)]
@@ -330,6 +332,302 @@ namespace fiskaltrust.Middleware.Localization.QueueGR.UnitTest.SCU.MyData
         {
             SpecialTaxMappings.GetWithholdingTaxMapping(description).Should().BeNull($"'{description}' is not a real withholding category");
         }
+
+        #region NormalizeForLookup
+
+        [Theory]
+        [InlineData(null, "")]
+        [InlineData("", "")]
+        [InlineData("   ", "")]
+        [InlineData("\t \u00A0", "")]
+        // Apostrophe variants all fold to the ASCII apostrophe U+0027.
+        [InlineData("δ\u2019", "δ'")] // ’ right single quotation mark (AADE)
+        [InlineData("δ\u2018", "δ'")] // ‘ left single quotation mark
+        [InlineData("δ\u201B", "δ'")] // ‛ single high-reversed-9 quotation mark
+        [InlineData("δ\u02BC", "δ'")] // ʼ modifier letter apostrophe
+        [InlineData("δ\u02B9", "δ'")] // ʹ modifier letter prime
+        [InlineData("δ\u0374", "δ'")] // ʹ Greek numeral sign (dexia keraia)
+        [InlineData("δ\u0384", "δ'")] // ΄ Greek tonos
+        [InlineData("δ\u00B4", "δ'")] // ´ acute accent
+        [InlineData("δ\u2032", "δ'")] // ′ prime
+        [InlineData("δ`", "δ'")]      // grave accent
+        // Dash variants all fold to the ASCII hyphen-minus U+002D.
+        [InlineData("α\u2010β", "α-β")] // ‐ hyphen
+        [InlineData("α\u2011β", "α-β")] // ‑ non-breaking hyphen
+        [InlineData("α\u2012β", "α-β")] // ‒ figure dash
+        [InlineData("α\u2013β", "α-β")] // – en dash
+        [InlineData("α\u2014β", "α-β")] // — em dash
+        [InlineData("α\u2015β", "α-β")] // ― horizontal bar
+        [InlineData("α\u2212β", "α-β")] // − minus sign
+        // Whitespace: non-breaking and repeated whitespace collapses, ends are trimmed.
+        [InlineData("α\u00A0β", "α β")]
+        [InlineData("α  β", "α β")]
+        [InlineData(" α \t β ", "α β")]
+        // The issue 279 payload folds to the exact form the mapping table stores.
+        [InlineData("Περιπτ. δ\u2019 - Τεχνικά Έργα - 3%", "Περιπτ. δ' - Τεχνικά Έργα - 3%")]
+        // Already-normal input passes through unchanged.
+        [InlineData("Περιπτ. δ' - Τεχνικά Έργα - 3%", "Περιπτ. δ' - Τεχνικά Έργα - 3%")]
+        public void NormalizeForLookup_ShouldFoldPunctuationAndWhitespace(string? input, string expected)
+        {
+            SpecialTaxMappings.NormalizeForLookup(input).Should().Be(expected);
+        }
+
+        #endregion NormalizeForLookup
+
+        #region FullTableVariantCoverage
+
+        // Every single description of all four AADE tables, in the exact form the mapping table
+        // stores it. These catalogs intentionally duplicate the production tables: a silent change
+        // to a description or code in SpecialTaxMappings must fail here.
+        public static readonly (string Description, int Code)[] AllWithholdingTaxDescriptions =
+        [
+            ("Περιπτ. β'- Τόκοι - 15%", 1),
+            ("Περιπτ. γ' - Δικαιώματα - 20%", 2),
+            ("Περιπτ. δ' - Αμοιβές Συμβουλών Διοίκησης - 20%", 3),
+            ("Περιπτ. δ' - Τεχνικά Έργα - 3%", 4),
+            ("Υγρά καύσιμα και προϊόντα καπνοβιομηχανίας 1%", 5),
+            ("Λοιπά Αγαθά 4%", 6),
+            ("Παροχή Υπηρεσιών 8%", 7),
+            ("Προκαταβλητέος Φόρος Αρχιτεκτόνων και Μηχανικών επί Συμβατικών Αμοιβών, για Εκπόνηση Μελετών και Σχεδίων 4%", 8),
+            ("Προκαταβλητέος Φόρος Αρχιτεκτόνων και Μηχανικών επί Συμβατικών Αμοιβών, που αφορούν οποιασδήποτε άλλης φύσης έργα 10%", 9),
+            ("Προκαταβλητέος Φόρος στις Αμοιβές Δικηγόρων 15%", 10),
+            ("Παρακράτηση Φόρου Μισθωτών Υπηρεσιών παρ. 1 αρ. 15 ν. 4172/2013", 11),
+            ("Παρακράτηση Φόρου Μισθωτών Υπηρεσιών παρ. 2 αρ. 15 ν. 4172/2013 - Αξιωματικών Εμπορικού Ναυτικού", 12),
+            ("Παρακράτηση Φόρου Μισθωτών Υπηρεσιών παρ. 2 αρ. 15 ν. 4172/2013 - Κατώτερο Πλήρωμα Εμπορικού Ναυτικού", 13),
+            ("Παρακράτηση Ειδικής Εισφοράς Αλληλεγγύης", 14),
+            ("Παρακράτηση Φόρου Αποζημίωσης λόγω Διακοπής Σχέσης Εργασίας παρ. 3 αρ. 15 ν. 4172/2013", 15),
+            ("Παρακρατήσεις συναλλαγών αλλοδαπής βάσει συμβάσεων αποφυγής διπλής φορολογίας (Σ.Α.Δ.Φ.)", 16),
+            ("Λοιπές Παρακρατήσεις Φόρου", 17),
+            ("Παρακράτηση Φόρου Μερίσματα περ.α παρ. 1 αρ. 64 ν. 4172/2013", 18),
+        ];
+
+        public static readonly (string Description, int Code)[] AllFeeDescriptions =
+        [
+            ("Για μηνιαίο λογαριασμό μέχρι και 50 ευρώ 12%", 1),
+            ("Για μηνιαίο λογαριασμό από 50,01 μέχρι και 100 ευρώ 15%", 2),
+            ("Για μηνιαίο λογαριασμό από 100,01 μέχρι και 150 ευρώ 18%", 3),
+            ("Για μηνιαίο λογαριασμό από 150,01 ευρώ και άνω 20%", 4),
+            ("Τέλος καρτοκινητής επί της αξίας του χρόνου ομιλίας (12%)", 5),
+            ("Τέλος στη συνδρομητική τηλεόραση 10%", 6),
+            ("Τέλος συνδρομητών σταθερής τηλεφωνίας 5%", 7),
+            ("Περιβαλλοντικό Τέλος & πλαστικής σακούλας ν. 2339/2001 αρ. 6α 0,07 ευρώ ανά τεμάχιο", 8),
+            ("Εισφορά δακοκτονίας 2%", 9),
+            ("Λοιπά τέλη", 10),
+            ("Τέλη Λοιπών Φόρων", 11),
+            ("Εισφορά δακοκτονίας", 12),
+            ("Για μηνιαίο λογαριασμό κάθε σύνδεσης (10%)", 13),
+            ("Τέλος καρτοκινητής επί της αξίας του χρόνου ομιλίας (10%)", 14),
+            ("Τέλος κινητής και καρτοκινητής για φυσικά πρόσωπα ηλικίας 15 έως και 29 ετών (0%)", 15),
+            ("Εισφορά προστασίας περιβάλλοντος πλαστικών προϊόντων 0,04 λεπτά ανά τεμάχιο [άρθρο 4 ν. 4736/2020]", 16),
+            ("Τέλος ανακύκλωσης 0,08 λεπτά ανά τεμάχιο [άρθρο 80 ν. 4819/2021]", 17),
+            ("Τέλος διαμονής παρεπιδημούντων", 18),
+            ("Τέλος επί των ακαθάριστων εσόδων των εστιατορίων και συναφών καταστημάτων", 19),
+            ("Τέλος επί των ακαθάριστων εσόδων των κέντρων διασκέδασης", 20),
+            ("Τέλος επί των ακαθάριστων εσόδων των καζίνο", 21),
+            ("Λοιπά τέλη επί των ακαθάριστων εσόδων", 22),
+        ];
+
+        public static readonly (string Description, int Code)[] AllStampDutyDescriptions =
+        [
+            ("Συντελεστής 1,2 %", 1),
+            ("Συντελεστής 2,4 %", 2),
+            ("Συντελεστής 3,6 %", 3),
+            ("Λοιπές περιπτώσεις Χαρτοσήμου", 4),
+        ];
+
+        public static readonly (string Description, int Code)[] AllOtherTaxDescriptions =
+        [
+            ("α1) ασφάλιστρα κλάδου πυρός 20%", 1),
+            ("α2) ασφάλιστρα κλάδου πυρός 20%", 2),
+            ("β) ασφάλιστρα κλάδου ζωής 4%", 3),
+            ("γ) ασφάλιστρα λοιπών κλάδων 15%", 4),
+            ("δ) απαλλασσόμενα φόρου ασφαλίστρων 0%", 5),
+            ("Ξενοδοχεία 1-2 αστέρων 0,50 €", 6),
+            ("Ξενοδοχεία 3 αστέρων 1,50 €", 7),
+            ("Ξενοδοχεία 4 αστέρων 3,00 €", 8),
+            ("Ξενοδοχεία 4 αστέρων 4,00 €", 9), // official AADE wording (Appendix 8.5), despite the apparent "4 αστέρων" typo
+            ("Ξενοδοχεία 5 αστέρων 4,00 €", 9), // alias: the logically correct 5-star wording
+            ("Ενοικιαζόμενα - επιπλωμένα δωμάτια - διαμερίσματα 0,50 €", 10),
+            ("Ειδικός Φόρος στις διαφημίσεις που προβάλλονται από την τηλεόραση (ΕΦΤΔ) 5%", 11),
+            ("3.1 Φόρος πολυτελείας 10% επί της φορολογητέας αξίας για τα ενδοκοινοτικώς αποκτούμενα και εισαγόμενα από τρίτες χώρες 10%", 12),
+            ("3.2 Φόρος πολυτελείας 10% επί της τιμής πώλησης προ Φ.Π.Α. για τα εγχωρίως παραγόμενα είδη 10%", 13),
+            ("Δικαίωμα του Δημοσίου στα εισιτήρια των καζίνο (80% επί του εισιτηρίου)", 14),
+            ("ασφάλιστρα κλάδου πυρός 20%", 15),
+            ("Λοιποί Τελωνειακοί Δασμοί-Φόροι", 16),
+            ("Λοιποί Φόροι", 17),
+            ("Επιβαρύνσεις Λοιπών Φόρων", 18),
+            ("ΕΦΚ", 19),
+            ("Ξενοδοχεία 1-2 αστέρων 1,50€ (ανά Δωμ./Διαμ.)", 20),
+            ("Ξενοδοχεία 3 αστέρων 3,00€ (ανά Δωμ./Διαμ.)", 21),
+            ("Ξενοδοχεία 4 αστέρων 7,00€ (ανά Δωμ./Διαμ.)", 22),
+            ("Ξενοδοχεία 5 αστέρων 10,00€ (ανά Δωμ./Διαμ.)", 23),
+            ("Ενοικιαζόμενα επιπλωμένα δωμάτια – διαμερίσματα 1,50€ (ανά Δωμ./Διαμ.)", 24),
+            ("Ακίνητα βραχυχρόνιας μίσθωσης 1,50€", 25),
+            ("Ακίνητα βραχυχρόνιας μίσθωσης μονοκατοικίες άνω των 80 τ.μ. 10,00€", 26),
+            ("Αυτοεξυπηρετούμενα καταλύματα – τουριστικές επιπλωμένες επαύλεις (βίλες) 10,00€", 27),
+            ("Ακίνητα βραχυχρόνιας μίσθωσης 0,50€", 28),
+            ("Ακίνητα βραχυχρόνιας μίσθωσης μονοκατοικίες άνω των 80 τ.μ. 4,00€", 29),
+            ("Αυτοεξυπηρετούμενα καταλύματα – τουριστικές επιπλωμένες επαύλεις (βίλες) 4,00€", 30),
+        ];
+
+        /// <summary>
+        /// Produces the punctuation, whitespace, and casing variants a real POS or partner system
+        /// might send for a stored description. The first variant is the description itself.
+        /// </summary>
+        private static IEnumerable<string> PunctuationVariants(string description)
+        {
+            yield return description;                            // exactly as stored
+            yield return description.Replace('\'', '\u2019');    // ’ the form AADE publishes (issue 279)
+            yield return description.Replace('\'', '\u2018');    // ‘ left single quotation mark
+            yield return description.Replace('\'', '\u0384');    // ΄ Greek tonos, produced by Greek keyboards
+            yield return description.Replace('\'', '\u0374');    // ʹ Greek numeral sign, the typographically correct mark
+            yield return description.Replace('\'', '\u00B4');    // ´ acute accent
+            yield return description.Replace('\'', '`');         // grave accent
+            yield return description.Replace('-', '\u2013');     // every hyphen as an en dash
+            yield return description.Replace('-', '\u2014');     // every hyphen as an em dash
+            yield return description.Replace('\u2013', '-');     // stored en dashes typed as plain hyphens
+            yield return description.Replace(' ', '\u00A0');     // non-breaking spaces
+            yield return description.Replace(" ", "  ");         // doubled internal whitespace
+            yield return "  " + description + " \t";             // stray surrounding whitespace
+            yield return description.ToUpperInvariant();         // case-insensitivity
+            yield return description.ToLowerInvariant();
+        }
+
+        private static IEnumerable<object[]> GenerateVariantCases((string Description, int Code)[] entries)
+        {
+            foreach (var (description, code) in entries)
+            {
+                foreach (var variant in PunctuationVariants(description).Distinct())
+                {
+                    yield return new object[] { variant, code };
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> WithholdingTaxVariantCases => GenerateVariantCases(AllWithholdingTaxDescriptions);
+        public static IEnumerable<object[]> FeeVariantCases => GenerateVariantCases(AllFeeDescriptions);
+        public static IEnumerable<object[]> StampDutyVariantCases => GenerateVariantCases(AllStampDutyDescriptions);
+        public static IEnumerable<object[]> OtherTaxVariantCases => GenerateVariantCases(AllOtherTaxDescriptions);
+
+        [Theory]
+        [MemberData(nameof(WithholdingTaxVariantCases))]
+        public void GetWithholdingTaxMapping_ShouldResolveEveryDescription_InAllPunctuationVariants(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetWithholdingTaxMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is withholding category {expectedCode}; punctuation, whitespace, or casing must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to withholding category {expectedCode}");
+        }
+
+        [Theory]
+        [MemberData(nameof(FeeVariantCases))]
+        public void GetFeeMapping_ShouldResolveEveryDescription_InAllPunctuationVariants(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetFeeMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is fee category {expectedCode}; punctuation, whitespace, or casing must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to fee category {expectedCode}");
+        }
+
+        [Theory]
+        [MemberData(nameof(StampDutyVariantCases))]
+        public void GetStampDutyMapping_ShouldResolveEveryDescription_InAllPunctuationVariants(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetStampDutyMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is stamp duty category {expectedCode}; punctuation, whitespace, or casing must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to stamp duty category {expectedCode}");
+        }
+
+        [Theory]
+        [MemberData(nameof(OtherTaxVariantCases))]
+        public void GetOtherTaxMapping_ShouldResolveEveryDescription_InAllPunctuationVariants(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetOtherTaxMapping(description);
+
+            mapping.Should().NotBeNull($"'{description}' is other tax category {expectedCode}; punctuation, whitespace, or casing must not decide whether the category is found");
+            mapping.Code.Should().Be(expectedCode, $"'{description}' must resolve to other tax category {expectedCode}");
+        }
+
+        // Normalisation must never collapse two different table entries into the same lookup key,
+        // otherwise one of them would silently become unreachable.
+        [Fact]
+        public void NormalizeForLookup_ShouldKeepEveryTableEntryDistinct()
+        {
+            foreach (var catalog in new[] { AllWithholdingTaxDescriptions, AllFeeDescriptions, AllStampDutyDescriptions, AllOtherTaxDescriptions })
+            {
+                var normalizedKeys = catalog
+                    .Select(entry => SpecialTaxMappings.NormalizeForLookup(entry.Description).ToUpperInvariant())
+                    .ToList();
+
+                normalizedKeys.Should().OnlyHaveUniqueItems("normalising descriptions must not merge distinct tax categories");
+            }
+        }
+
+        #endregion FullTableVariantCoverage
+
+        #region ExactMatchPrecedence
+
+        // Several table entries are substrings of one another ("Εισφορά δακοκτονίας" is contained
+        // in "Εισφορά δακοκτονίας 2%", "Λοιπά τέλη" in "Λοιπά τέλη επί των ακαθάριστων εσόδων",
+        // "ασφάλιστρα κλάδου πυρός 20%" in "α1) ασφάλιστρα κλάδου πυρός 20%"). The exact-match pass
+        // must win before the substring fallback gets a chance to return the wrong category.
+        [Theory]
+        [InlineData("Εισφορά δακοκτονίας", 12)]
+        [InlineData("Εισφορά δακοκτονίας 2%", 9)]
+        [InlineData("Λοιπά τέλη", 10)]
+        [InlineData("Λοιπά τέλη επί των ακαθάριστων εσόδων", 22)]
+        public void GetFeeMapping_ShouldPreferExactMatch_OverSubstringFallback(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetFeeMapping(description);
+
+            mapping.Should().NotBeNull();
+            mapping.Code.Should().Be(expectedCode, $"the exact entry '{description}' exists and must win over any substring match");
+        }
+
+        [Theory]
+        [InlineData("ασφάλιστρα κλάδου πυρός 20%", 15)]
+        [InlineData("α1) ασφάλιστρα κλάδου πυρός 20%", 1)]
+        [InlineData("α2) ασφάλιστρα κλάδου πυρός 20%", 2)]
+        public void GetOtherTaxMapping_ShouldPreferExactMatch_OverSubstringFallback(string description, int expectedCode)
+        {
+            var mapping = SpecialTaxMappings.GetOtherTaxMapping(description);
+
+            mapping.Should().NotBeNull();
+            mapping.Code.Should().Be(expectedCode, $"the exact entry '{description}' exists and must win over any substring match");
+        }
+
+        #endregion ExactMatchPrecedence
+
+        #region NullEmptyAndUnknownInput
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        [InlineData("\u00A0\t")]
+        public void AllLookups_ShouldReturnNull_ForNullOrWhitespaceDescriptions(string? description)
+        {
+            SpecialTaxMappings.GetWithholdingTaxMapping(description!).Should().BeNull();
+            SpecialTaxMappings.GetFeeMapping(description!).Should().BeNull();
+            SpecialTaxMappings.GetStampDutyMapping(description!).Should().BeNull();
+            SpecialTaxMappings.GetOtherTaxMapping(description!).Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("Some random product description")]
+        [InlineData("Φόρος που δεν υπάρχει 99%")]
+        [InlineData("’’’’")]
+        [InlineData("---")]
+        public void AllLookups_ShouldReturnNull_ForUnknownDescriptions_EvenWithSpecialCharacters(string description)
+        {
+            SpecialTaxMappings.GetWithholdingTaxMapping(description).Should().BeNull();
+            SpecialTaxMappings.GetFeeMapping(description).Should().BeNull();
+            SpecialTaxMappings.GetStampDutyMapping(description).Should().BeNull();
+            SpecialTaxMappings.GetOtherTaxMapping(description).Should().BeNull();
+        }
+
+        #endregion NullEmptyAndUnknownInput
 
         #endregion PunctuationCodepointVariants
     }


### PR DESCRIPTION
## Problem
Viva reported that a fiscalization request with the withholding tax line `Περιπτ. δ’ - Τεχνικά Έργα - 3%` (AADE Appendix 8.4, category 4) was rejected with:


`No withholding tax, fee, stamp duty, or other tax mapping found for description: 'Περιπτ. δ’ - Τεχνικά Έργα - 3%'`

The description differs from our mapping table at exactly one codepoint: the apostrophe after `δ` is U+2019 (right single quotation mark which is the form AADE publishes in its spec), while the table stores the ASCII apostrophe U+0027. The ordinal string match rejected it even though the tax category is identical. The same defect exists in the opposite direction: three other-tax entries (codes 24/27/30) are stored with an en dash U+2013, so a partner sending a plain ASCII hyphen could never match them.

## Solution
- Added `SpecialTaxMappings.NormalizeForLookup`, which folds punctuation codepoint variants before comparison:

- **Apostrophes** → ASCII `'`: U+2019, U+2018, U+201B, U+02BC, U+02B9, U+0374 (Greek numeral sign), U+0384 (what Greek keyboards emit), U+00B4, U+2032, backtick

- **Dashes** → ASCII `-`: U+2010–U+2015, U+2212

- **Whitespace**: non-breaking/exotic spaces and runs of whitespace collapse to a single space; ends trimmed

- Normalization is applied to **both** the incoming description and the table keys (precomputed once into normalized dictionaries so that exact match stays O(1)). It affects the comparison only; the charge item description is never mutated, and nothing sent to AADE changes (these lines are transmitted as numeric category codes, not text).

- Consolidated the four duplicated lookup methods into one shared `LookupSpecialTax`, keeping the existing behavior: exact match first, then substring fallback, case-insensitive.

- **Data fix (other-tax code 9)**: the stored value had a stray space (`"4, 00 €"`). The key keeps the official spec wording `Ξενοδοχεία 4 αστέρων 4,00 €` (myDATA API Documentation v2.0.2, Appendix 8.5 published that way despite being the 5-star tier per ν. 4389/2016 art. 53), and an alias `Ξενοδοχεία 5 αστέρων 4,00 €` was added so the legally correct wording also resolves to code 9.

## Tests
- **Full-catalog variant coverage**: every description in all four tables (withholding, fees, stamp duty and other taxes) is tested in ~15 variants each — curly/tonos/numeral-sign/acute/backtick apostrophes, en/em dashes in both directions, non-breaking spaces, doubled/stray whitespace, upper/lower case.

- `NormalizeForLookup` unit tests per codepoint, incl. null/empty/whitespace input.

- Exact-match precedence tests for entries that are substrings of one another (e.g. `Εισφορά δακοκτονίας` needs to be 12, not 9; `ασφάλιστρα κλάδου πυρός 20%` needs 15, not 1).

- Uniqueness guard: normalization must never collapse two distinct table entries into one key.

- Negative tests: unknown descriptions still return `null` for all four lookups.

- End-to-end `MapToInvoicesDoc` test reproducing the exact issue-279 payload with `'`, `’`, and `΄`, asserting taxCategory 4, correct totals, and that the withholding line stays out of the invoice rows.

Fixes [#279](https://github.com/fiskaltrust/market-gr/issues/279)
