### PR TITLE
fix(be): sign the daily closing and refunds instead of accepting them unsigned

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueueBE/Processors/DailyOperationsCommandProcessorBE.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueBE/Processors/DailyOperationsCommandProcessorBE.cs
@@ -1,19 +1,67 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.be;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.Localization.QueueBE.Factories;
 using fiskaltrust.Middleware.Localization.v2;
 using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.storage.V0;
 
 namespace fiskaltrust.Middleware.Localization.QueueBE.Processors;
 
-public class DailyOperationsCommandProcessorBE : IDailyOperationsCommandProcessor
+public class DailyOperationsCommandProcessorBE(IBESSCD sscd) : IDailyOperationsCommandProcessor
 {
-    public async Task<ProcessCommandResponse> ZeroReceipt0x2000Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
+    private readonly IBESSCD _sscd = sscd;
+
+    /// <summary>
+    /// The zero receipt carries no fiscal content; it is handed to the SCU so that whatever
+    /// the SCU decides a BE zero receipt means stays in one place. Today the ZwarteDoos SCU
+    /// answers it locally without contacting the FDM.
+    /// </summary>
+    public async Task<ProcessCommandResponse> ZeroReceipt0x2000Async(ProcessCommandRequest request)
+    {
+        var response = await _sscd.ProcessReceiptAsync(new ProcessRequest
+        {
+            ReceiptRequest = request.ReceiptRequest,
+            ReceiptResponse = request.ReceiptResponse
+        });
+        return new ProcessCommandResponse(response.ReceiptResponse, []);
+    }
 
     public async Task<ProcessCommandResponse> OneReceipt0x2001Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
 
     public async Task<ProcessCommandResponse> ShiftClosing0x2010Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
 
-    public async Task<ProcessCommandResponse> DailyClosing0x2011Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
+    /// <summary>
+    /// The daily closing is the Belgian Z report: the SCU turns it into a REPORT_TURNOVER_Z
+    /// event on the FDM and returns its signature. The action journal entry is only written
+    /// when the FDM actually signed — an errored response must never look like a closed day.
+    /// </summary>
+    public async Task<ProcessCommandResponse> DailyClosing0x2011Async(ProcessCommandRequest request)
+    {
+        var (queue, receiptRequest, receiptResponse) = request;
+        var response = await _sscd.ProcessReceiptAsync(new ProcessRequest
+        {
+            ReceiptRequest = receiptRequest,
+            ReceiptResponse = receiptResponse
+        });
 
+        if (response.ReceiptResponse.ftState.IsState(State.Error))
+        {
+            return new ProcessCommandResponse(response.ReceiptResponse, []);
+        }
+
+        var actionJournal = ftActionJournalFactory.CreateDailyClosingActionJournal(queue, receiptRequest, response.ReceiptResponse);
+        return new ProcessCommandResponse(response.ReceiptResponse, [actionJournal]);
+    }
+
+    /// <remarks>
+    /// Deliberately still unimplemented: the ZwarteDoos SCU has no monthly/yearly closing
+    /// branch, so routing these here would return a clean state for a periodic closing that
+    /// never reached the FDM. Failing loudly is the honest answer until the FDM report type
+    /// for those periods is decided.
+    /// </remarks>
     public async Task<ProcessCommandResponse> MonthlyClosing0x2012Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
 
+    /// <inheritdoc cref="MonthlyClosing0x2012Async"/>
     public async Task<ProcessCommandResponse> YearlyClosing0x2013Async(ProcessCommandRequest request) => await FallBackOperations.NotYetImplemented(request);
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueBE/Processors/DailyOperationsCommandProcessorBE.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueBE/Processors/DailyOperationsCommandProcessorBE.cs
@@ -4,6 +4,7 @@ using fiskaltrust.ifPOS.v2.Cases;
 using fiskaltrust.Middleware.Localization.QueueBE.Factories;
 using fiskaltrust.Middleware.Localization.v2;
 using fiskaltrust.Middleware.Localization.v2.Helpers;
+using fiskaltrust.Middleware.Localization.v2.Interface;
 using fiskaltrust.storage.V0;
 
 namespace fiskaltrust.Middleware.Localization.QueueBE.Processors;
@@ -33,8 +34,9 @@ public class DailyOperationsCommandProcessorBE(IBESSCD sscd) : IDailyOperationsC
 
     /// <summary>
     /// The daily closing is the Belgian Z report: the SCU turns it into a REPORT_TURNOVER_Z
-    /// event on the FDM and returns its signature. The action journal entry is only written
-    /// when the FDM actually signed — an errored response must never look like a closed day.
+    /// event on the FDM and returns its signature. The action journal entry is only written when
+    /// the FDM actually signed — neither an errored response nor an unsigned one may look like a
+    /// closed day.
     /// </summary>
     public async Task<ProcessCommandResponse> DailyClosing0x2011Async(ProcessCommandRequest request)
     {
@@ -47,6 +49,16 @@ public class DailyOperationsCommandProcessorBE(IBESSCD sscd) : IDailyOperationsC
 
         if (response.ReceiptResponse.ftState.IsState(State.Error))
         {
+            return new ProcessCommandResponse(response.ReceiptResponse, []);
+        }
+
+        // Defence in depth, and the reason this is checked here rather than trusted from the SCU:
+        // the SCU is what talks to the FDM, but the QUEUE is what records the day as closed. A
+        // signed Z report always comes back carrying the FDM's signature, so a response with no
+        // signature at all closed nothing — however clean its state looks.
+        if (response.ReceiptResponse.ftSignatures.Count == 0)
+        {
+            response.ReceiptResponse.SetReceiptResponseError("The daily closing was not signed: the SCU returned no signature for the Z report.");
             return new ProcessCommandResponse(response.ReceiptResponse, []);
         }
 

--- a/queue/src/fiskaltrust.Middleware.Localization.QueueBE/QueueBEBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueueBE/QueueBEBootstrapper.cs
@@ -31,7 +31,7 @@ public class QueueBEBootstrapper : IV2QueueBootstrapper
 
 
         var queueStorageProvider = new QueueStorageProvider(id, storageProvider);
-        var signProcessorBE = new ReceiptProcessor(loggerFactory.CreateLogger<ReceiptProcessor>(), new ReceiptReferenceProvider(storageProvider.CreateMiddlewareQueueItemRepository()), new LifecycleCommandProcessorBE(queueStorageProvider), new ReceiptCommandProcessorBE(beSSCD, storageProvider.CreateMiddlewareQueueItemRepository()), new DailyOperationsCommandProcessorBE(), new InvoiceCommandProcessorBE(beSSCD, storageProvider.CreateMiddlewareQueueItemRepository()), new ProtocolCommandProcessorBE(beSSCD));
+        var signProcessorBE = new ReceiptProcessor(loggerFactory.CreateLogger<ReceiptProcessor>(), new ReceiptReferenceProvider(storageProvider.CreateMiddlewareQueueItemRepository()), new LifecycleCommandProcessorBE(queueStorageProvider), new ReceiptCommandProcessorBE(beSSCD, storageProvider.CreateMiddlewareQueueItemRepository()), new DailyOperationsCommandProcessorBE(beSSCD), new InvoiceCommandProcessorBE(beSSCD, storageProvider.CreateMiddlewareQueueItemRepository()), new ProtocolCommandProcessorBE(beSSCD));
         var signProcessor = new SignProcessor(loggerFactory.CreateLogger<SignProcessor>(), queueStorageProvider, signProcessorBE.ProcessAsync, cashBoxIdentification, middlewareConfiguration);
         var journalProcessor = new JournalProcessor(storageProvider, new JournalProcessorBE(storageProvider, GetFromConfig(configuration, storageProvider) ?? new MasterDataConfiguration { }), configuration, loggerFactory.CreateLogger<JournalProcessor>());
         _queue = new Queue(signProcessor, journalProcessor, loggerFactory)

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueBE.UnitTest/Processors/DailyOperationsCommandProcessorBETests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueBE.UnitTest/Processors/DailyOperationsCommandProcessorBETests.cs
@@ -1,0 +1,127 @@
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.be;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.Localization.QueueBE.Processors;
+using fiskaltrust.Middleware.Localization.v2;
+using fiskaltrust.storage.V0;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace fiskaltrust.Middleware.Localization.QueueBE.UnitTest.Processors
+{
+    public class DailyOperationsCommandProcessorBETests
+    {
+        private static ProcessCommandRequest CreateRequest(ReceiptCase receiptCase)
+        {
+            var receiptRequest = new ReceiptRequest
+            {
+                ftCashBoxID = Guid.NewGuid(),
+                ftReceiptCase = (ReceiptCase) (0x4245_2000_0000_0000 | (long) receiptCase)
+            };
+            var receiptResponse = new ReceiptResponse
+            {
+                ftState = (State) 0x4245_2000_0000_0000,
+                ftCashBoxIdentification = "cashBoxIdentification",
+                ftQueueID = Guid.NewGuid(),
+                ftQueueItemID = Guid.NewGuid(),
+                ftQueueRow = 42,
+                ftReceiptIdentification = "receiptIdentification",
+                ftReceiptMoment = DateTime.UtcNow,
+            };
+            return new ProcessCommandRequest(new ftQueue { ftQueueId = receiptResponse.ftQueueID }, receiptRequest, receiptResponse);
+        }
+
+        private static Mock<IBESSCD> CreateSscd(Action<ReceiptResponse>? mutateResponse = null)
+        {
+            var sscd = new Mock<IBESSCD>(MockBehavior.Strict);
+            sscd.Setup(x => x.ProcessReceiptAsync(It.IsAny<ProcessRequest>()))
+                .ReturnsAsync((ProcessRequest processRequest) =>
+                {
+                    mutateResponse?.Invoke(processRequest.ReceiptResponse);
+                    return new ProcessResponse { ReceiptResponse = processRequest.ReceiptResponse };
+                });
+            return sscd;
+        }
+
+        [Fact]
+        public async Task DailyClosing0x2011Async_SignedByTheSscd_ReturnsTheSignedResponseAndAnActionJournal()
+        {
+            var request = CreateRequest(ReceiptCase.DailyClosing0x2011);
+            var sscd = CreateSscd(response => response.ftSignatures.Add(new SignatureItem
+            {
+                Caption = "DigitalSignature",
+                Data = "a-zwartedoos-z-report-signature",
+                ftSignatureFormat = SignatureFormat.Text,
+                ftSignatureType = SignatureType.Unknown
+            }));
+
+            var sut = new DailyOperationsCommandProcessorBE(sscd.Object);
+            var result = await sut.DailyClosing0x2011Async(request);
+
+            sscd.Verify(x => x.ProcessReceiptAsync(It.Is<ProcessRequest>(r => r.ReceiptRequest == request.ReceiptRequest)), Times.Once);
+            result.receiptResponse.ftState.Should().Be((State) 0x4245_2000_0000_0000);
+            result.receiptResponse.ftSignatures.Should().ContainSingle(x => x.Caption == "DigitalSignature");
+            result.actionJournals.Should().ContainSingle();
+            result.actionJournals[0].ftQueueId.Should().Be(request.ReceiptResponse.ftQueueID);
+            result.actionJournals[0].ftQueueItemId.Should().Be(request.ReceiptResponse.ftQueueItemID);
+            result.actionJournals[0].Message.Should().Be("Daily-Closing receipt was processed.");
+        }
+
+        /// <summary>
+        /// A Z report the FDM refused must never look like a closed day: the errored response is
+        /// handed back untouched and no action journal entry is written for it.
+        /// </summary>
+        [Fact]
+        public async Task DailyClosing0x2011Async_RefusedByTheSscd_ReturnsNoActionJournal()
+        {
+            var request = CreateRequest(ReceiptCase.DailyClosing0x2011);
+            var sscd = CreateSscd(response => response.ftState = response.ftState.WithState(State.Error));
+
+            var sut = new DailyOperationsCommandProcessorBE(sscd.Object);
+            var result = await sut.DailyClosing0x2011Async(request);
+
+            result.receiptResponse.ftState.IsState(State.Error).Should().BeTrue();
+            result.actionJournals.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task ZeroReceipt0x2000Async_IsHandedToTheSscd()
+        {
+            var request = CreateRequest(ReceiptCase.ZeroReceipt0x2000);
+            var sscd = CreateSscd();
+
+            var sut = new DailyOperationsCommandProcessorBE(sscd.Object);
+            var result = await sut.ZeroReceipt0x2000Async(request);
+
+            sscd.Verify(x => x.ProcessReceiptAsync(It.IsAny<ProcessRequest>()), Times.Once);
+            result.receiptResponse.ftState.Should().Be((State) 0x4245_2000_0000_0000);
+            result.actionJournals.Should().BeEmpty();
+        }
+
+        /// <summary>
+        /// The remaining periodic closings have no ZwarteDoos counterpart yet. They must keep
+        /// failing loudly rather than reporting a clean state for a closing the FDM never saw.
+        /// </summary>
+        [Theory]
+        [InlineData(ReceiptCase.OneReceipt0x2001)]
+        [InlineData(ReceiptCase.ShiftClosing0x2010)]
+        [InlineData(ReceiptCase.MonthlyClosing0x2012)]
+        [InlineData(ReceiptCase.YearlyClosing0x2013)]
+        public async Task UnimplementedDailyOperations_Throw(ReceiptCase receiptCase)
+        {
+            var request = CreateRequest(receiptCase);
+            var sut = new DailyOperationsCommandProcessorBE(new Mock<IBESSCD>(MockBehavior.Strict).Object);
+
+            Func<Task> act = () => receiptCase switch
+            {
+                ReceiptCase.OneReceipt0x2001 => sut.OneReceipt0x2001Async(request),
+                ReceiptCase.ShiftClosing0x2010 => sut.ShiftClosing0x2010Async(request),
+                ReceiptCase.MonthlyClosing0x2012 => sut.MonthlyClosing0x2012Async(request),
+                _ => sut.YearlyClosing0x2013Async(request),
+            };
+
+            await act.Should().ThrowAsync<NotImplementedException>();
+        }
+    }
+}

--- a/queue/test/fiskaltrust.Middleware.Localization.QueueBE.UnitTest/Processors/DailyOperationsCommandProcessorBETests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueueBE.UnitTest/Processors/DailyOperationsCommandProcessorBETests.cs
@@ -85,6 +85,24 @@ namespace fiskaltrust.Middleware.Localization.QueueBE.UnitTest.Processors
             result.actionJournals.Should().BeEmpty();
         }
 
+        /// <summary>
+        /// The state alone is not proof: a Z report that came back with no signature closed
+        /// nothing, so the day must not be journalled as closed on the strength of a clean state.
+        /// </summary>
+        [Fact]
+        public async Task DailyClosing0x2011Async_CleanStateButNoSignature_FailsAndWritesNoActionJournal()
+        {
+            var request = CreateRequest(ReceiptCase.DailyClosing0x2011);
+            var sscd = CreateSscd();
+
+            var sut = new DailyOperationsCommandProcessorBE(sscd.Object);
+            var result = await sut.DailyClosing0x2011Async(request);
+
+            result.receiptResponse.ftState.IsState(State.Error).Should().BeTrue();
+            result.receiptResponse.ftSignatures.Should().ContainSingle(x => x.Caption == "FAILURE");
+            result.actionJournals.Should().BeEmpty();
+        }
+
         [Fact]
         public async Task ZeroReceipt0x2000Async_IsHandedToTheSscd()
         {

--- a/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/ZwarteDoosScuBe.cs
+++ b/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/ZwarteDoosScuBe.cs
@@ -220,9 +220,13 @@ public class ZwarteDoosScuBe : IBESSCD
                     Quantity = x.Quantity,
                     QuantityType = QuantityType.PIECE,
                     NegQuantityReason = GetNegQuantityReason(receiptRequest, x),
-                    // Deliberately the ABSOLUTE unit price: a refund line keeps a positive unit
-                    // price and expresses the reversal through the negative quantity/price. A
-                    // negative unitPrice is refused with VAT_PRICE_CHECK_FAILED.
+                    // The FDM wants the price of ONE unit and expresses a reversal through the
+                    // negative quantity and line total, so a refund line must still carry a
+                    // POSITIVE unit price — a negative one is refused with VAT_PRICE_CHECK_FAILED.
+                    // The quotient gives that for the well-formed case (amount and quantity share
+                    // a sign) and is deliberately not Abs()'d: a POS that sends a negative amount
+                    // against a positive quantity is describing something we should not silently
+                    // reinterpret, and the FDM refusal names the field.
                     UnitPrice = x.Amount / x.Quantity,
                     Vats = [GetVatInputForChargeItem(x)]
                 },

--- a/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/ZwarteDoosScuBe.cs
+++ b/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/ZwarteDoosScuBe.cs
@@ -122,8 +122,7 @@ public class ZwarteDoosScuBe : IBESSCD
             };
             if (apiResponse.Errors != null && apiResponse.Errors.Count > 0)
             {
-                var errorMessages = string.Join("; ", apiResponse.Errors.Select(e => e.Message));
-                receiptResponse.SetReceiptResponseErrored(errorMessages);
+                receiptResponse.SetReceiptResponseErrored(FormatApiErrors(apiResponse.Errors));
                 return receiptResponse;
             }
             else
@@ -163,6 +162,29 @@ public class ZwarteDoosScuBe : IBESSCD
         }
     }
 
+    /// <summary>
+    /// The FDM's human-readable message is deliberately vague ("De aanvraag gedaan aan de zwarte
+    /// doos ... is ongeldig"); the actionable part is the <c>code</c> and the <c>SUBCODE</c> in the
+    /// error's extensions (e.g. EXPECTED_NEGQUANTITYREASON, KEY_FIELD_COMBINATION_ALREADY_USED).
+    /// Both are kept so the FAILURE signature names the rule the request broke.
+    /// </summary>
+    private static string FormatApiErrors(List<MessageItem> errors) => string.Join("; ", errors.Select(error =>
+    {
+        var details = new List<string>();
+        if (error.Extensions is { } extensions)
+        {
+            if (!string.IsNullOrEmpty(extensions.Code))
+            {
+                details.Add(extensions.Code);
+            }
+            foreach (var item in extensions.Data ?? new List<DataItem>())
+            {
+                details.Add($"{item.Name}={item.Value}");
+            }
+        }
+        return details.Count > 0 ? $"{error.Message} [{string.Join(", ", details)}]" : error.Message;
+    }));
+
     private static List<PaymentLineInput> GetFinancials(ReceiptRequest receiptRequest)
     {
         var payments = receiptRequest.cbPayItems.Select(x => new PaymentLineInput
@@ -181,7 +203,7 @@ public class ZwarteDoosScuBe : IBESSCD
         return payments.ToList();
     }
 
-    private TransactionInput GetTransactionInput(ReceiptRequest receiptRequest)
+    internal TransactionInput GetTransactionInput(ReceiptRequest receiptRequest)
     {
         return new TransactionInput
         {
@@ -197,7 +219,10 @@ public class ZwarteDoosScuBe : IBESSCD
                     DepartmentName = "Default",
                     Quantity = x.Quantity,
                     QuantityType = QuantityType.PIECE,
-                    NegQuantityReason = null,
+                    NegQuantityReason = GetNegQuantityReason(receiptRequest, x),
+                    // Deliberately the ABSOLUTE unit price: a refund line keeps a positive unit
+                    // price and expresses the reversal through the negative quantity/price. A
+                    // negative unitPrice is refused with VAT_PRICE_CHECK_FAILED.
                     UnitPrice = x.Amount / x.Quantity,
                     Vats = [GetVatInputForChargeItem(x)]
                 },
@@ -207,6 +232,34 @@ public class ZwarteDoosScuBe : IBESSCD
             }).ToList(),
             TransactionTotal = receiptRequest.cbChargeItems.Sum(x => x.Amount),
         };
+    }
+
+    /// <summary>
+    /// The FDM refuses a negative quantity that does not say WHY it is negative
+    /// (INVALID_REQUEST / EXPECTED_NEGQUANTITYREASON) — <see cref="ProductInput.NegQuantityReason"/>:
+    /// "When the quantity is a negative amount the reason has to be specified."
+    /// <para>
+    /// Only the reason the fiskaltrust receipt model states outright is mapped: a charge item — or
+    /// the whole receipt — flagged as a refund is a Belgian <c>REFUND</c>. The other Belgian reasons
+    /// (<c>CORRECTION</c>, <c>WASTE</c>, <c>DAMAGE</c>) have no ft counterpart today, so an
+    /// unflagged negative line is sent WITHOUT a reason and the FDM rejects it. That is on purpose:
+    /// booking it under a guessed reason would misstate the negative-quantity totals of the Z
+    /// report. Mapping the remaining reasons needs a product/fiscal decision.
+    /// </para>
+    /// </summary>
+    private static string? GetNegQuantityReason(ReceiptRequest receiptRequest, ChargeItem chargeItem)
+    {
+        if (chargeItem.Quantity >= 0)
+        {
+            return null;
+        }
+
+        if (chargeItem.ftChargeItemCase.IsFlag(ChargeItemCaseFlags.Refund) || receiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund))
+        {
+            return NegQuantityReason.REFUND.ToString();
+        }
+
+        return null;
     }
 
     public VatInput GetVatInputForChargeItem(ChargeItem chargeItem)
@@ -333,6 +386,51 @@ public class ZwarteDoosScuBe : IBESSCD
                     }
                 }
             };
+            if (apiResponse.Errors != null && apiResponse.Errors.Count > 0)
+            {
+                receiptResponse.SetReceiptResponseErrored(FormatApiErrors(apiResponse.Errors));
+                return receiptResponse;
+            }
+
+            // A Z report the FDM did not sign is a failed daily closing, never a silent success.
+            var signResult = apiResponse.Data?.SignResult;
+            if (signResult == null)
+            {
+                receiptResponse.SetReceiptResponseErrored("The ZwarteDoos FDM returned no signResult for the daily closing (REPORT_TURNOVER_Z).");
+                return receiptResponse;
+            }
+
+            var signatures = new List<SignatureItem>
+            {
+                new SignatureItem
+                {
+                    Caption = "DigitalSignature",
+                    Data = signResult.DigitalSignature,
+                    ftSignatureFormat = SignatureFormat.Text,
+                    ftSignatureType = SignatureType.Unknown
+                }
+            };
+            if (!string.IsNullOrEmpty(signResult.ShortSignature))
+            {
+                signatures.Add(new SignatureItem
+                {
+                    Caption = "ShortSignature",
+                    Data = signResult.ShortSignature!,
+                    ftSignatureFormat = SignatureFormat.Text,
+                    ftSignatureType = SignatureType.Unknown
+                });
+            }
+            if (!string.IsNullOrEmpty(signResult.VerificationUrl))
+            {
+                signatures.Add(new SignatureItem
+                {
+                    Caption = "VerificationUrl",
+                    Data = signResult.VerificationUrl!,
+                    ftSignatureFormat = SignatureFormat.QRCode,
+                    ftSignatureType = SignatureType.Unknown
+                });
+            }
+            receiptResponse.ftSignatures.AddRange(signatures);
             return receiptResponse;
         }
         catch (Exception e)

--- a/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/fiskaltrust.Middleware.SCU.BE.ZwarteDoos.csproj
+++ b/scu-be/src/fiskaltrust.Middleware.SCU.BE.ZwarteDoos/fiskaltrust.Middleware.SCU.BE.ZwarteDoos.csproj
@@ -9,6 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="fiskaltrust.Middleware.SCU.BE.UnitTest" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="fiskaltrust.interface" Version="1.3.78-rc1-25294-86170" />
         <PackageReference Include="fiskaltrust.Middleware.Abstractions" Version="1.3.3" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.4" />

--- a/scu-be/test/fiskaltrust.Middleware.SCU.BE.AcceptanceTests/IBESSCDAcceptanceTests.cs
+++ b/scu-be/test/fiskaltrust.Middleware.SCU.BE.AcceptanceTests/IBESSCDAcceptanceTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v2;
 using fiskaltrust.ifPOS.v2.be;
@@ -15,6 +16,19 @@ namespace fiskaltrust.Middleware.SCU.BE.AcceptanceTests;
 
 public abstract class IBESSCDAcceptanceTests
 {
+    /// <summary>
+    /// The FDM refuses a repeated ticket number with KEY_FIELD_COMBINATION_ALREADY_USED:
+    /// <c>posFiscalTicketNo</c> is specified as "an uninterrupted sequence from 1 to 999999999"
+    /// (<see cref="ZwarteDoos.Models.Shared.BaseInputData.PosFiscalTicketNo"/>) and the SCU derives
+    /// it from <c>ftQueueRow</c>. A hard-coded row number therefore made every test that signs the
+    /// same event type a second time fail against the shared sandbox box, so each response gets its
+    /// own row. Seeded from the millisecond of the day so re-runs and parallel jobs get their own
+    /// range too.
+    /// </summary>
+    private static long _queueRow = (long) DateTime.UtcNow.TimeOfDay.TotalMilliseconds;
+
+    protected static long NextQueueRow() => Interlocked.Increment(ref _queueRow);
+
     protected readonly ITestOutputHelper _output;
     protected readonly ILogger _logger;
 
@@ -76,7 +90,7 @@ public abstract class IBESSCDAcceptanceTests
             ftCashBoxID = request.ftCashBoxID,
             ftQueueID = request.ftQueueID ?? Guid.NewGuid(),
             ftQueueItemID = Guid.NewGuid(),
-            ftQueueRow = 1,
+            ftQueueRow = NextQueueRow(),
             cbTerminalID = request.cbTerminalID,
             cbReceiptReference = request.cbReceiptReference,
             ftCashBoxIdentification = "CPOS0031234567",
@@ -213,6 +227,33 @@ public abstract class IBESSCDAcceptanceTests
         result.Should().NotBeNull();
         result.ReceiptResponse.Should().NotBeNull();
         ((ulong) result.ReceiptResponse.ftState & 0xEEEE_EEEE).Should().Be(0);
+    }
+
+    /// <summary>
+    /// A total refund: the receipt carries the refund flag and the line is negative. The FDM needs a
+    /// negQuantityReason for the negative quantity, so this is the case that used to come back
+    /// accepted-but-unsigned.
+    /// </summary>
+    [Fact]
+    public virtual async Task ProcessReceiptAsync_RefundReceipt_ShouldSucceed()
+    {
+        var scu = GetSystemUnderTest();
+        var request = CreateBasicReceiptRequest((ReceiptCase) 0x4245_2000_0100_0001);
+        request.cbChargeItems[0].Quantity = -1.0m;
+        request.cbChargeItems[0].Amount = -10.00m;
+        request.cbChargeItems[0].ftChargeItemCase = (ChargeItemCase) 0x4245_2000_0002_0001;
+        request.cbPayItems[0].Amount = -10.00m;
+        request.cbPayItems[0].ftPayItemCase = (PayItemCase) 0x4245_2000_0002_0001;
+        var response = CreateBasicReceiptResponse(request);
+        var processRequest = new ProcessRequest { ReceiptRequest = request, ReceiptResponse = response };
+
+        var result = await scu.ProcessReceiptAsync(processRequest);
+
+        result.Should().NotBeNull();
+        result.ReceiptResponse.Should().NotBeNull();
+        ((ulong) result.ReceiptResponse.ftState & 0xEEEE_EEEE).Should().Be(0,
+            because: "Expected 0 but got 0x" + result.ReceiptResponse.ftState.ToString("x") + " - " + string.Join("; ", result.ReceiptResponse.ftSignatures.Select(x => $"{x.Caption}: {x.Data}")));
+        result.ReceiptResponse.ftSignatures.Should().Contain(x => x.Caption == "DigitalSignature");
     }
 
     [Fact]

--- a/scu-be/test/fiskaltrust.Middleware.SCU.BE.UnitTest/NegQuantityReasonTests.cs
+++ b/scu-be/test/fiskaltrust.Middleware.SCU.BE.UnitTest/NegQuantityReasonTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using fiskaltrust.ifPOS.v2;
+using fiskaltrust.ifPOS.v2.Cases;
+using fiskaltrust.Middleware.SCU.BE.ZwarteDoos;
+using fiskaltrust.Middleware.SCU.BE.ZwarteDoos.Models;
+using fiskaltrust.Middleware.SCU.BE.ZwarteDoos.Models.Enums;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace fiskaltrust.Middleware.SCU.BE.UnitTest;
+
+/// <summary>
+/// The FDM refuses a negative quantity that carries no reason (INVALID_REQUEST /
+/// EXPECTED_NEGQUANTITYREASON), which is what made every Belgian refund come back
+/// accepted-but-unsigned. Only the reason the fiskaltrust receipt model states outright is mapped;
+/// an unflagged negative line must stay reason-less so the FDM rejects it instead of it being
+/// booked under a guessed reason.
+/// </summary>
+public class NegQuantityReasonTests
+{
+    private const long ChargeItemNormalVat = 0x4245_2000_0000_0013;
+    private const long ChargeItemNormalVatRefund = 0x4245_2000_0002_0013;
+    private const long PointOfSaleReceipt = 0x4245_2000_0000_0001;
+    private const long PointOfSaleReceiptRefund = 0x4245_2000_0100_0001;
+
+    private static ZwarteDoosScuBe CreateSut() => new ZwarteDoosScuBe(
+        NullLogger<ZwarteDoosScuBe>.Instance,
+        NullLoggerFactory.Instance,
+        new ZwarteDoosScuConfiguration
+        {
+            BaseUrl = "https://sdk.zwartedoos.be",
+            DeviceId = "FDM00000000",
+            SharedSecret = "not-used-in-this-test",
+            TimeoutSeconds = 1,
+            Language = Language.NL,
+            VatNo = "BE0000000097",
+            EstNo = "2000000042",
+        });
+
+    private static ReceiptRequest CreateReceiptRequest(long receiptCase, long chargeItemCase, decimal quantity, decimal amount) => new ReceiptRequest
+    {
+        ftCashBoxID = Guid.NewGuid(),
+        cbReceiptReference = Guid.NewGuid().ToString(),
+        cbReceiptMoment = DateTime.UtcNow,
+        ftReceiptCase = (ReceiptCase) receiptCase,
+        cbChargeItems = new List<ChargeItem>
+        {
+            new ChargeItem
+            {
+                ftChargeItemId = Guid.NewGuid(),
+                Position = 1,
+                Description = "E2E test article",
+                Quantity = quantity,
+                Amount = amount,
+                VATRate = 21.0m,
+                ftChargeItemCase = (ChargeItemCase) chargeItemCase
+            }
+        },
+        cbPayItems = new List<PayItem>()
+    };
+
+    [Theory]
+    // a charge item flagged as a return
+    [InlineData(PointOfSaleReceipt, ChargeItemNormalVatRefund)]
+    // a whole receipt flagged as a refund (what a total refund looks like)
+    [InlineData(PointOfSaleReceiptRefund, ChargeItemNormalVat)]
+    [InlineData(PointOfSaleReceiptRefund, ChargeItemNormalVatRefund)]
+    public void GetTransactionInput_NegativeQuantityOnARefund_IsReportedAsREFUND(long receiptCase, long chargeItemCase)
+    {
+        var transaction = CreateSut().GetTransactionInput(CreateReceiptRequest(receiptCase, chargeItemCase, -1m, -10m));
+
+        transaction.TransactionLines[0].MainProduct.NegQuantityReason.Should().Be(nameof(NegQuantityReason.REFUND));
+    }
+
+    [Fact]
+    public void GetTransactionInput_NegativeQuantityWithoutARefundFlag_IsLeftWithoutAReason()
+    {
+        var transaction = CreateSut().GetTransactionInput(CreateReceiptRequest(PointOfSaleReceipt, ChargeItemNormalVat, -1m, -10m));
+
+        transaction.TransactionLines[0].MainProduct.NegQuantityReason.Should().BeNull(
+            because: "CORRECTION/WASTE/DAMAGE have no fiskaltrust counterpart yet and guessing one would misstate the Z report");
+    }
+
+    [Fact]
+    public void GetTransactionInput_PositiveQuantity_CarriesNoReason()
+    {
+        var transaction = CreateSut().GetTransactionInput(CreateReceiptRequest(PointOfSaleReceipt, ChargeItemNormalVat, 1m, 10m));
+
+        transaction.TransactionLines[0].MainProduct.NegQuantityReason.Should().BeNull();
+    }
+
+    /// <summary>
+    /// A refund line keeps a POSITIVE unit price and expresses the reversal through the negative
+    /// quantity and line total; a negative unit price is refused with VAT_PRICE_CHECK_FAILED.
+    /// </summary>
+    [Fact]
+    public void GetTransactionInput_RefundLine_KeepsAPositiveUnitPrice()
+    {
+        var transaction = CreateSut().GetTransactionInput(CreateReceiptRequest(PointOfSaleReceiptRefund, ChargeItemNormalVatRefund, -1m, -10m));
+
+        transaction.TransactionLines[0].MainProduct.UnitPrice.Should().Be(10m);
+        transaction.TransactionLines[0].LineTotal.Should().Be(-10m);
+        transaction.TransactionTotal.Should().Be(-10m);
+    }
+}


### PR DESCRIPTION
Belgium could not complete a receipt chain. The developer-sample scenario
(start → sale → refund → daily closing) died twice, and both failures looked like a
healthy HTTP 201 — the queue accepted the receipt and answered `ftState 0x42452000eeeeeeee`.

Closes part of #759 (the "daily operations are not implemented" half). The `cbUser`/INSZ half of
that issue is already fixed harness-side.

## 1 — Daily closing: wire QueueBE to the SCU that already implements it

Every command on `DailyOperationsCommandProcessorBE` was `FallBackOperations.NotYetImplemented`, so
a daily closing threw before it ever reached the SCU — even though `ZwarteDoosScuBe` already routes
`DailyClosing0x2011` to a `REPORT_TURNOVER_Z` event and implements it
(`ZwarteDoosScuBe.cs:64` / `PerformDailyCosing`). The hole was purely the queue-side wiring.

`DailyClosing0x2011Async` now hands the receipt to the SCU (the same idiom as
`ReceiptCommandProcessorBE`) and writes the daily-closing action journal that
`ftActionJournalFactory` already had but nobody called. The action journal is written **only when
the FDM actually signed** — an errored response must never look like a closed day.

`ZeroReceipt0x2000Async` is handed to the SCU too, so whatever a BE zero receipt means stays in one
place (today the SCU answers it locally, without contacting the FDM).

`OneReceipt0x2001`, `ShiftClosing0x2010`, `MonthlyClosing0x2012` and `YearlyClosing0x2013` stay
`NotYetImplemented` **on purpose**: the ZwarteDoos SCU has no branch for them, so routing them
through would return a clean state for a periodic closing that never reached the FDM. Which FDM
report a Belgian monthly/yearly closing must emit is a fiscal decision, not a wiring one.

## 2 — A refused Z report is no longer a silent success

`PerformDailyCosing` ignored `apiResponse.Errors` entirely and added no signature item, so a Z
report the FDM refused came back with a clean state and an empty signature list. It now surfaces the
error and carries the FDM's `DigitalSignature` (plus `ShortSignature`/`VerificationUrl` when the FDM
returns them, which it does not for a Z report today).

This mattered immediately: without it, wiring §1 would have made a refused daily closing look green.

## 3 — Refunds: the mandatory `negQuantityReason`

Found while verifying the chain end to end — a third BE blocker, independent of #759.

The refund step was refused with `INVALID_REQUEST` / `EXPECTED_NEGQUANTITYREASON`.
`ProductInput.negQuantityReason` is mandatory for a negative quantity — *"When the quantity is a
negative amount the reason has to be specified"* — and `GetTransactionInput` hard-coded it to
`null`, so **every Belgian refund was accepted-but-unsigned.**

A charge item — or the whole receipt — flagged as a refund is now reported as the Belgian `REFUND`
reason. The other Belgian reasons (`CORRECTION`, `WASTE`, `DAMAGE`) have no fiskaltrust counterpart
today, so an **unflagged** negative line is still sent without a reason and is still rejected:
booking it under a guessed reason would misstate the negative-quantity totals of the Z report.
Mapping those three needs a product/fiscal decision and is deliberately left open.

Also verified and now documented in code: the unit price must stay **positive** on a refund line
(the reversal is carried by the negative quantity/line total) — a negative `unitPrice` is refused
with `VAT_PRICE_CHECK_FAILED`.

## 4 — Readable FDM errors

The FDM's human-readable message is deliberately vague (*"De aanvraag gedaan aan de zwarte doos
FDM02030462 is ongeldig"*); the actionable part is the `code` and the `SUBCODE` in the error's
extensions. Both are now kept in the `FAILURE` signature, so the next BE failure names the rule the
request broke instead of just saying "invalid".

## 5 — Tests

- **QueueBE unit tests** for the new processor: the SCU is called and the action journal written on
  success, **no action journal on a refused Z report**, the zero receipt is handed to the SCU, and
  the four unimplemented closings still throw.
- **First unit tests for `scu-be`** — the `UnitTest` project existed but was empty, while CI already
  runs it. They cover the `negQuantityReason` mapping and the positive-unit-price rule without
  touching the network (via `InternalsVisibleTo`).
- A **refund acceptance test** alongside the existing sale/daily-closing ones.
- **Acceptance fixture fix.** `CreateBasicReceiptResponse` hard-coded `ftQueueRow = 1` and the SCU
  derives `posFiscalTicketNo` from it — a value the Belgian spec defines as *"an uninterrupted
  sequence from 1 to 999999999"*. Repeating it makes the FDM answer
  `KEY_FIELD_COMBINATION_ALREADY_USED`. That was **already failing three sale tests on `main`**
  (37/40) and would have started failing the daily-closing ones now that the error is no longer
  swallowed. Each response now gets its own row, seeded from the millisecond of the day so re-runs
  and parallel jobs get their own range.

## Verification

Against the ZwarteDoos SDK sandbox (`FDM02030462`), driving the SCU with the exact bodies the e2e
harness sends (`test/e2e-agent/runner/tools/posApi.ts`, BE market):

| step | before | after |
|---|---|---|
| start | ok | ok |
| sale | signed | signed |
| refund | **FAILED** `…eeeeeeee` | **signed** |
| daily closing | **NotYetImplemented** (threw) | **signed** |
| zero receipt | NotYetImplemented (threw) | ok |
| negative line, no refund flag | FAILED (opaque) | FAILED — `[INVALID_REQUEST, SUBCODE=EXPECTED_NEGQUANTITYREASON]` |

Suites: `scu-be` 6 unit + 41 acceptance + 14 integration green (was 37/40 acceptance on `main`);
`QueueBE` 9 unit green.

The e2e run itself is **not** part of this PR — it needs a middleware release and a BE cashbox
pinned to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
