### PR TITLE
fix(scu-it/epson): redeem a multi-use voucher charge item as sconto a pagare

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/ReceiptCaseHelper.cs
@@ -64,6 +64,20 @@ public static class ReceiptCaseHelper
     public static bool IsSingleUseVoucher(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0000_00F0) == 0x40 && !IsMultiUseVoucher(chargeItem);
 
     public static bool IsMultiUseVoucher(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0000_0000_00FF) == 0x48;
+
+    /// <summary>
+    /// Multi-use voucher line that redeems (pays with) the voucher: negative on a sale, positive on a refund/void,
+    /// which mirror the sale. A positive line on a sale is the sale of the voucher itself.
+    /// </summary>
+    public static bool IsMultiUseVoucherRedeem(this ChargeItem chargeItem, ReceiptRequest receiptRequest)
+    {
+        if (!chargeItem.IsMultiUseVoucher() || chargeItem.Amount == 0)
+        {
+            return false;
+        }
+        var inverted = receiptRequest.IsRefund() || receiptRequest.IsVoid() || chargeItem.IsRefund() || chargeItem.IsVoid();
+        return inverted ? chargeItem.Amount > 0 : chargeItem.Amount < 0;
+    }
     
     public static bool IsSubtotalDiscount(this ChargeItem chargeItem) => (chargeItem.ftChargeItemCase & 0x0000_0FFF_0000_0000) == 0x0000_0100_0000_0000;
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -472,7 +472,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 Quantity = Math.Abs(p.Quantity),
                 UnitPrice = p.Quantity == 0 || p.Amount == 0 ? 0 : Math.Abs(p.Amount) / Math.Abs(p.Quantity),
                 Amount = Math.Abs(p.Amount),
-                Department = p.IsMultiUseVoucher() ? 11 : p.GetVatGroup()
+                Department = p.GetVatGroup()
             }).ToList();
         }
 
@@ -484,7 +484,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 Quantity = Math.Abs(p.Quantity),
                 UnitPrice = p.Quantity == 0 || p.Amount == 0 ? 0 : Math.Abs(p.Amount) / Math.Abs(p.Quantity),
                 Amount = Math.Abs(p.Amount),
-                Department = p.IsMultiUseVoucher() ? 11 : p.GetVatGroup()
+                Department = p.GetVatGroup()
             }).ToList();
         }
 
@@ -641,7 +641,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                         Description = i.Description,
                         Quantity = i.Quantity,
                         UnitPrice = i.Quantity == 0 || i.Amount == 0 ? 0 : i.Amount / i.Quantity,
-                        Department = 11,
+                        Department = _departmentNS,
                     };
                     itemAndMessages.Add(new() { PrintRecItem = printRecItem });
                 }
@@ -655,17 +655,6 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                         Department = i.GetVatGroup(),
                     };
                     itemAndMessages.Add(new() { PrintRecItemAdjustment = printRecItemAdjustment });
-                }
-                else if (i.IsMultiUseVoucher())
-                {
-                    var printRecItem = new PrintRecItem
-                    {
-                        Description = i.Description,
-                        Quantity = i.Quantity,
-                        UnitPrice = i.Quantity == 0 || i.Amount == 0 ? 0 : i.Amount / i.Quantity,
-                        Department = 11,
-                    };
-                    itemAndMessages.Add(new() { PrintRecItem = printRecItem });
                 }
                 else if (i.Amount < 0)
                 {
@@ -725,9 +714,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         {
             var totalAndMessages = new List<TotalAndMessage>();
 
-            // A multi-use voucher redeemed as a charge item is paid like pay item 0x06: "sconto a pagare" for
-            // buoni multiuso (payment type 6, index 1; Epson protocol 7.00 §9.13). It goes before the other
-            // payments because a type 6 payment above the amount still due is rejected with error 21.
+            // A multi-use voucher redeemed as a charge item is paid like pay item 0x06. It goes before the other
+            // payments because a "sconto a pagare" above the amount still due is rejected with error 21.
             foreach (var voucher in request.cbChargeItems.Where(x => x.IsMultiUseVoucherRedeem(request)))
             {
                 totalAndMessages.Add(new()
@@ -735,8 +723,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                     PrintRecTotal = new PrintRecTotal
                     {
                         Description = voucher.Description,
-                        PaymentType = 6,
-                        Index = 1,
+                        PaymentType = _multiUseVoucherPayment.PaymentType,
+                        Index = _multiUseVoucherPayment.Index,
                         Payment = Math.Abs(voucher.Amount)
                     }
                 });
@@ -781,6 +769,9 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             public int Index;
         }
 
+        /// <summary>"Sconto a pagare" for buoni multiuso (Epson protocol 7.00 §9.13): pay item 0x06 and a redeemed multi-use voucher charge item.</summary>
+        private static readonly EpsonPaymentType _multiUseVoucherPayment = new() { PaymentType = 6, Index = 1 };
+
         public static EpsonPaymentType GetEpsonPaymentType(PayItem payItem)
         {
             return (payItem.ftPayItemCase & 0xFF) switch
@@ -791,7 +782,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 0x03 => new EpsonPaymentType() { PaymentType = 1, Index = 0 },
                 0x04 => new EpsonPaymentType() { PaymentType = 2, Index = 1 },
                 0x05 => new EpsonPaymentType() { PaymentType = 2, Index = 1 },
-                0x06 => new EpsonPaymentType() { PaymentType = 6, Index = 1 },
+                0x06 => _multiUseVoucherPayment,
                 0x07 => new EpsonPaymentType() { PaymentType = 5, Index = 0 },
                 0x08 => new EpsonPaymentType() { PaymentType = 5, Index = 0 },
                 0x09 => new EpsonPaymentType() { PaymentType = 5, Index = 3 },
@@ -816,18 +807,32 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         private static int _vatRateSuperReduced2;
         private static int _vatRateParking;
 
+        // Departments pre-programmed with the non-VAT natures (see GetVatInfo for the printed captions).
+        private static readonly int _departmentEE = 10;
+        private static readonly int _departmentNS = 11;
+        private static readonly int _departmentNI = 12;
+        private static readonly int _departmentES = 13;
+        private static readonly int _departmentRM = 14;
+        private static readonly int _departmentAL = 15;
+
         public static int GetVatGroup(this ChargeItem chargeItem)
         {
+            if (chargeItem.IsMultiUseVoucher())
+            {
+                // A buono multiuso is outside the VAT scope (natura N2 "non soggetta"), whatever the nature bits say.
+                return _departmentNS;
+            }
+
             if ((chargeItem.ftChargeItemCase & 0xF) == 0x8)
             {
                 return (chargeItem.ftChargeItemCase & 0xF000) switch
                 {
-                    0x8000 => 10,
-                    0x2000 => 11,
-                    0x1000 => 12,
-                    0x3000 => 13,
-                    0x4000 => 14,
-                    0x5000 => 15,
+                    0x8000 => _departmentEE,
+                    0x2000 => _departmentNS,
+                    0x1000 => _departmentNI,
+                    0x3000 => _departmentES,
+                    0x4000 => _departmentRM,
+                    0x5000 => _departmentAL,
                     _ => _vatRateUnknown // ?
                 };
             }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -465,34 +465,37 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
 
         public static List<PrintRecRefund> GetRecRefunds(ReceiptRequest receiptRequest)
         {
-            return receiptRequest.cbChargeItems?.Select(p => new PrintRecRefund
+            // A redeemed multi-use voucher is a "sconto a pagare" payment, not a line item (see GetTotalAndMessages).
+            return receiptRequest.cbChargeItems?.Where(p => !p.IsMultiUseVoucherRedeem(receiptRequest)).Select(p => new PrintRecRefund
             {
                 Description = p.Description,
                 Quantity = Math.Abs(p.Quantity),
                 UnitPrice = p.Quantity == 0 || p.Amount == 0 ? 0 : Math.Abs(p.Amount) / Math.Abs(p.Quantity),
                 Amount = Math.Abs(p.Amount),
-                Department = p.GetVatGroup()
+                Department = p.IsMultiUseVoucher() ? 11 : p.GetVatGroup()
             }).ToList();
         }
 
         public static List<PrintRecVoid> GetRecvoids(ReceiptRequest receiptRequest)
         {
-            return receiptRequest.cbChargeItems?.Select(p => new PrintRecVoid
+            return receiptRequest.cbChargeItems?.Where(p => !p.IsMultiUseVoucherRedeem(receiptRequest)).Select(p => new PrintRecVoid
             {
                 Description = p.Description,
                 Quantity = Math.Abs(p.Quantity),
                 UnitPrice = p.Quantity == 0 || p.Amount == 0 ? 0 : Math.Abs(p.Amount) / Math.Abs(p.Quantity),
                 Amount = Math.Abs(p.Amount),
-                Department = p.GetVatGroup()
+                Department = p.IsMultiUseVoucher() ? 11 : p.GetVatGroup()
             }).ToList();
         }
 
         public static List<ItemAndMessage> GetItemAndMessages(ReceiptRequest receiptRequest)
         {
             var itemAndMessages = new List<ItemAndMessage>();
+            // A redeemed multi-use voucher is a "sconto a pagare" payment, not a line item (see GetTotalAndMessages).
+            var chargeItems = receiptRequest.cbChargeItems.Where(x => !x.IsMultiUseVoucherRedeem(receiptRequest)).ToList();
             if (receiptRequest.IsGroupingRequest())
             {
-                var chargeItemGroups = receiptRequest.cbChargeItems.GroupBy(x => x.Position / 100);
+                var chargeItemGroups = chargeItems.GroupBy(x => x.Position / 100);
                 foreach (var chargeItemGroup in chargeItemGroups)
                 {
                     var mainItem = chargeItemGroup.FirstOrDefault(x => x.Position % 100 == 0);
@@ -606,7 +609,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
             else
             {
                 // Todo handle payment adjustments / discounts
-                foreach (var i in receiptRequest.cbChargeItems)
+                foreach (var i in chargeItems)
                 {
                     if (i.IsSubtotalDiscount() || i.IsSubtotalSurcharge())
                         continue;
@@ -721,6 +724,24 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         public static List<TotalAndMessage> GetTotalAndMessages(ReceiptRequest request)
         {
             var totalAndMessages = new List<TotalAndMessage>();
+
+            // A multi-use voucher redeemed as a charge item is paid like pay item 0x06: "sconto a pagare" for
+            // buoni multiuso (payment type 6, index 1; Epson protocol 7.00 §9.13). It goes before the other
+            // payments because a type 6 payment above the amount still due is rejected with error 21.
+            foreach (var voucher in request.cbChargeItems.Where(x => x.IsMultiUseVoucherRedeem(request)))
+            {
+                totalAndMessages.Add(new()
+                {
+                    PrintRecTotal = new PrintRecTotal
+                    {
+                        Description = voucher.Description,
+                        PaymentType = 6,
+                        Index = 1,
+                        Payment = Math.Abs(voucher.Amount)
+                    }
+                });
+            }
+
             foreach (var pay in request.cbPayItems)
             {
                 var paymentType = GetEpsonPaymentType(pay);

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -723,10 +723,12 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         public static List<TotalAndMessage> GetTotalAndMessages(ReceiptRequest request)
         {
             var totalAndMessages = new List<TotalAndMessage>();
+            var redeemLines = request.cbChargeItems.Where(x => x.IsMultiUseVoucherRedeem(request)).ToList();
+            var payItems = request.cbPayItems ?? Array.Empty<PayItem>();
 
             // A multi-use voucher redeemed as a charge item is paid like pay item 0x06. It goes before the other
             // payments because a "sconto a pagare" above the amount still due is rejected with error 21.
-            foreach (var voucher in request.cbChargeItems.Where(x => x.IsMultiUseVoucherRedeem(request)))
+            foreach (var voucher in redeemLines)
             {
                 totalAndMessages.Add(new()
                 {
@@ -740,7 +742,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 });
             }
 
-            foreach (var pay in request.cbPayItems)
+            foreach (var pay in payItems)
             {
                 var paymentType = GetEpsonPaymentType(pay);
                 var printRecTotal = new PrintRecTotal
@@ -758,7 +760,11 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 });
             }
 
-            if (totalAndMessages.Count == 0)
+            // No pay items: the rest is paid in cash (payment 0 = the whole amount still due on the Epson), unless
+            // the redeemed vouchers already cover the receipt, in which case the payment phase is complete.
+            var redeemed = redeemLines.Sum(x => Math.Abs(x.Amount));
+            var receiptTotal = Math.Abs(request.cbChargeItems.Where(x => !x.IsMultiUseVoucherRedeem(request)).Sum(x => x.Amount));
+            if (payItems.Length == 0 && (redeemed == 0 || redeemed < receiptTotal))
             {
                 totalAndMessages.Add(new()
                 {

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -824,18 +824,19 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         private static int _vatRateParking;
 
         // Departments pre-programmed with the non-VAT natures (see GetVatInfo for the printed captions).
-        private static readonly int _departmentEE = 10;
-        private static readonly int _departmentNS = 11;
-        private static readonly int _departmentNI = 12;
-        private static readonly int _departmentES = 13;
-        private static readonly int _departmentRM = 14;
-        private static readonly int _departmentAL = 15;
+        private const int _departmentEE = 10;
+        private const int _departmentNS = 11;
+        private const int _departmentNI = 12;
+        private const int _departmentES = 13;
+        private const int _departmentRM = 14;
+        private const int _departmentAL = 15;
 
         public static int GetVatGroup(this ChargeItem chargeItem)
         {
             if (chargeItem.IsMultiUseVoucher())
             {
-                // A buono multiuso is outside the VAT scope (natura N2 "non soggetta"), whatever the nature bits say.
+                // The nature bits are deliberately ignored: a buono multiuso is outside the VAT scope
+                // (natura N2 "non soggetta") whatever the POS puts there.
                 return _departmentNS;
             }
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -499,6 +499,16 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
                 foreach (var chargeItemGroup in chargeItemGroups)
                 {
                     var mainItem = chargeItemGroup.FirstOrDefault(x => x.Position % 100 == 0);
+                    if (mainItem is null)
+                    {
+                        // No head item in this group: the head was a redeemed voucher (filtered above) or the POS sent none.
+                        // Print the members as plain items so nothing that was sold is dropped.
+                        foreach (var chargeItem in chargeItemGroup)
+                        {
+                            GenerateItems(itemAndMessages, chargeItem);
+                        }
+                        continue;
+                    }
                     if (mainItem.Quantity == 0 || mainItem.Amount == 0)
                     {
                         itemAndMessages.Add(new()

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ITSSCDTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ITSSCDTests.cs
@@ -553,6 +553,24 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
         }
 
         [Fact]
+        public async Task ProcessPosReceipt_0x4954_2000_0000_0001_MultiUseVoucher_Redeem_AsChargeItem()
+        {
+            var itsscd = GetSUT();
+            var result = await itsscd.ProcessReceiptAsync(new ProcessRequest
+            {
+                ReceiptRequest = ReceiptExamples.CashWithMultiUseVoucherRedeem_AsChargeItem(),
+                ReceiptResponse = _receiptResponse
+            });
+
+            using var scope = new AssertionScope();
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTSerialNumber));
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTZNumber));
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentNumber));
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentMoment));
+            result.ReceiptResponse.ftSignatures.Should().Contain(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) SignatureTypesIT.RTDocumentType));
+        }
+
+        [Fact]
         public async Task ProcessPosReceipt_0x4954_2000_0000_0001_MultiUseVoucher_Purchase()
         {
             var itsscd = GetSUT();

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptExamples.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptExamples.cs
@@ -110,6 +110,14 @@ namespace fiskaltrust.Middleware.SCU.IT.AcceptanceTests
             return JsonConvert.DeserializeObject<ReceiptRequest>(receipt);
         }
 
+        /// <summary>#514: the same redemption, but with the voucher as a negative 0x..48 charge item instead of pay item 0x06.</summary>
+        public static ReceiptRequest CashWithMultiUseVoucherRedeem_AsChargeItem()
+        {
+            var current_moment = DateTime.UtcNow.ToString("o");
+            var receipt = File.ReadAllText(Path.Combine("ReceiptRequests", "PosReceipts", "0x0001_CashWithMultiUseVoucherRedeem_AsChargeItem.json")).Replace("{{current_moment}}", current_moment);
+            return JsonConvert.DeserializeObject<ReceiptRequest>(receipt);
+        }
+
         public static ReceiptRequest CashWithMutliUseVoucherPurchase()
         {
             var current_moment = DateTime.UtcNow.ToString("o");

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptRequests/PosReceipts/0x0001_CashWithMultiUseVoucherRedeem_AsChargeItem.json
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.AcceptanceTests/ReceiptRequests/PosReceipts/0x0001_CashWithMultiUseVoucherRedeem_AsChargeItem.json
@@ -1,0 +1,36 @@
+{
+  "ftCashBoxID": "{{cashbox_id}}",
+  "ftPosSystemId": "{{possystem_id}}",
+  "cbTerminalID": "00010001",
+  "cbReceiptReference": "0001-0002",
+  "cbUser": "user1234",
+  "cbReceiptMoment": "{{current_moment}}",
+  "cbChargeItems": [
+    {
+      "Quantity": 1,
+      "Amount": 100,
+      "VATRate": 10,
+      "ftChargeItemCase": 5283883447184523265,
+      "Description": "Food/Beverage - Item VAT 10%",
+      "Moment": "{{current_moment}}"
+    },
+    {
+      "Quantity": 1,
+      "Amount": -20,
+      "VATRate": 0,
+      "ftChargeItemCase": 5283883447184523336,
+      "Description": "Gutschein",
+      "Moment": "{{current_moment}}"
+    }
+  ],
+  "cbPayItems": [
+    {
+      "Quantity": 1,
+      "Description": "Cash",
+      "ftPayItemCase": 5283883447184523265,
+      "Moment": "{{current_moment}}",
+      "Amount": 80
+    }
+  ],
+  "ftReceiptCase": 5283883447184523265
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
@@ -43,6 +43,16 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
             ftChargeItemCase = 0x4954_2000_0000_0048 | flags
         };
 
+        private static ChargeItem Coperto(int position) => new()
+        {
+            Position = position,
+            Quantity = 1,
+            Description = "Coperto",
+            Amount = 2m,
+            VATRate = 22m,
+            ftChargeItemCase = 0x4954_2000_0000_0003
+        };
+
         private static PayItem Cash(decimal amount, long flags = 0) => new()
         {
             Quantity = 1,
@@ -181,6 +191,69 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
             line.Amount.Should().Be(100m);
             content.RecTotalAndMessages.Should().ContainSingle();
             ShouldBeCashPayment(content.RecTotalAndMessages[0], 100m);
+        }
+
+        /// <summary>The redeem filter runs before the grouping, so a group can lose its head: its members must still be printed.</summary>
+        [Fact]
+        public void Sale_GroupingRequest_VoucherAsGroupHead_PrintsTheChildrenAsItems()
+        {
+            var request = CreateReceipt(SaleReceipt | GroupingFlag, new[] { Food(100m), Voucher(-20m), Coperto(201) }, Cash(82m));
+
+            var content = Sale(request);
+
+            content.ItemAndMessages.Where(x => x.PrintRecItem != null).Select(x => x.PrintRecItem!.Description).Should().Equal("Food", "Coperto");
+            content.ItemAndMessages.Should().OnlyContain(x => x.PrintRecVoidItem == null && x.PrintRecItemAdjustment == null);
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 82m);
+        }
+
+        /// <summary>Without pay items the rest is paid in cash: payment 0 means "the whole amount still due" on the Epson.</summary>
+        [Fact]
+        public void Sale_NoPayItems_VoucherBelowTheTotal_PaysTheRestInCash()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m), Voucher(-20m) });
+
+            var content = Sale(request);
+
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 0m);
+        }
+
+        [Fact]
+        public void Sale_NoPayItems_NoVoucher_StillPaysInCash()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m) });
+
+            var content = Sale(request);
+
+            content.RecTotalAndMessages.Should().ContainSingle();
+            ShouldBeCashPayment(content.RecTotalAndMessages[0], 0m);
+        }
+
+        /// <summary>Without pay items the rest is paid in cash: payment 0 means "the whole amount still due" on the Epson.</summary>
+        [Fact]
+        public void Sale_NoPayItems_VoucherBelowTheTotal_PaysTheRestInCash()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m), Voucher(-20m) });
+
+            var content = Sale(request);
+
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 0m);
+        }
+
+        [Fact]
+        public void Sale_NoPayItems_NoVoucher_StillPaysInCash()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m) });
+
+            var content = Sale(request);
+
+            content.RecTotalAndMessages.Should().ContainSingle();
+            ShouldBeCashPayment(content.RecTotalAndMessages[0], 0m);
         }
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
@@ -231,29 +231,5 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
             content.RecTotalAndMessages.Should().ContainSingle();
             ShouldBeCashPayment(content.RecTotalAndMessages[0], 0m);
         }
-
-        /// <summary>Without pay items the rest is paid in cash: payment 0 means "the whole amount still due" on the Epson.</summary>
-        [Fact]
-        public void Sale_NoPayItems_VoucherBelowTheTotal_PaysTheRestInCash()
-        {
-            var request = CreateReceipt(SaleReceipt, new[] { Food(100m), Voucher(-20m) });
-
-            var content = Sale(request);
-
-            content.RecTotalAndMessages.Should().HaveCount(2);
-            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
-            ShouldBeCashPayment(content.RecTotalAndMessages[1], 0m);
-        }
-
-        [Fact]
-        public void Sale_NoPayItems_NoVoucher_StillPaysInCash()
-        {
-            var request = CreateReceipt(SaleReceipt, new[] { Food(100m) });
-
-            var content = Sale(request);
-
-            content.RecTotalAndMessages.Should().ContainSingle();
-            ShouldBeCashPayment(content.RecTotalAndMessages[0], 0m);
-        }
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/MultiUseVoucherRedeemTests.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    /// <summary>
+    /// #514: a multi-use voucher redeemed as a negative charge item (0x..48) used to become a printRecItem with a
+    /// negative unit price, which the printer rejects. It is now a "sconto a pagare" payment (type 6, index 1),
+    /// the same command pay item 0x06 produces, in sale, refund and void documents alike.
+    /// </summary>
+    public class MultiUseVoucherRedeemTests
+    {
+        private const long SaleReceipt = 0x4954_2000_0000_0001;
+        private const long RefundReceipt = 0x4954_2000_0100_0001;
+        private const long VoidReceipt = 0x4954_2000_0004_0001;
+        private const long GroupingFlag = 0x0000_0000_0800_0000;
+        private const long RefundItem = 0x0000_0000_0002_0000;
+        private const long VoidItem = 0x0000_0000_0001_0000;
+
+        private static readonly EpsonRTPrinterSCUConfiguration _configuration = new();
+        private static readonly DateTime _referenceDate = new(2026, 9, 8);
+
+        private static ChargeItem Food(decimal amount, long flags = 0) => new()
+        {
+            Position = 100,
+            Quantity = 1,
+            Description = "Food",
+            Amount = amount,
+            VATRate = 10m,
+            ftChargeItemCase = 0x4954_2000_0000_0001 | flags
+        };
+
+        private static ChargeItem Voucher(decimal amount, long flags = 0, int position = 200) => new()
+        {
+            Position = position,
+            Quantity = 1,
+            Description = "Gutschein",
+            Amount = amount,
+            ftChargeItemCase = 0x4954_2000_0000_0048 | flags
+        };
+
+        private static PayItem Cash(decimal amount, long flags = 0) => new()
+        {
+            Quantity = 1,
+            Description = "Contanti",
+            Amount = amount,
+            ftPayItemCase = 0x4954_2000_0000_0001 | flags
+        };
+
+        private static ReceiptRequest CreateReceipt(long receiptCase, ChargeItem[] chargeItems, params PayItem[] payItems) => new()
+        {
+            ftReceiptCase = receiptCase,
+            cbReceiptReference = "514",
+            cbReceiptMoment = new DateTime(2026, 9, 8, 12, 0, 0),
+            cbChargeItems = chargeItems,
+            cbPayItems = payItems,
+            cbReceiptAmount = chargeItems.Sum(x => x.Amount)
+        };
+
+        private static FiscalReceipt Sale(ReceiptRequest request) => EpsonCommandFactory.CreateInvoiceRequestContent(_configuration, request);
+        private static FiscalReceipt Refund(ReceiptRequest request) => EpsonCommandFactory.CreateRefundRequestContent(_configuration, request, 12, 97, _referenceDate, "99IEB077964");
+        private static FiscalReceipt Void(ReceiptRequest request) => EpsonCommandFactory.CreateVoidRequestContent(_configuration, request, 12, 97, _referenceDate, "99IEB077964");
+
+        private static void ShouldBeVoucherPayment(TotalAndMessage total, decimal amount)
+        {
+            total.PrintRecTotal.Should().NotBeNull();
+            total.PrintRecTotal!.PaymentType.Should().Be(6);
+            total.PrintRecTotal.Index.Should().Be(1);
+            total.PrintRecTotal.Payment.Should().Be(amount);
+            total.PrintRecTotal.Description.Should().Be("Gutschein");
+        }
+
+        private static void ShouldBeCashPayment(TotalAndMessage total, decimal amount)
+        {
+            total.PrintRecTotal.Should().NotBeNull();
+            total.PrintRecTotal!.PaymentType.Should().Be(0);
+            total.PrintRecTotal.Index.Should().Be(0);
+            total.PrintRecTotal.Payment.Should().Be(amount);
+        }
+
+        [Fact]
+        public void Sale_RedeemAsChargeItem_IsAScontoAPagarePaymentBeforeTheCash()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m), Voucher(-20m) }, Cash(80m));
+
+            var content = Sale(request);
+
+            content.ItemAndMessages.Where(x => x.PrintRecItem != null).Should().ContainSingle().Which.PrintRecItem!.Description.Should().Be("Food");
+            content.ItemAndMessages.Should().OnlyContain(x => x.PrintRecVoidItem == null && x.PrintRecItemAdjustment == null);
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 80m);
+
+            var xml = SoapSerializer.Serialize(content);
+            xml.Should().NotContain("unitPrice=\"-").And.NotContain("quantity=\"-");
+            xml.Should().Contain("paymentType=\"6\"");
+        }
+
+        [Fact]
+        public void Sale_GroupingRequest_RedeemIsNeitherAVoidItemNorAnAdjustment()
+        {
+            var request = CreateReceipt(SaleReceipt | GroupingFlag, new[] { Food(100m), Voucher(-20m), Voucher(-10m, position: 101) }, Cash(70m));
+
+            var content = Sale(request);
+
+            content.ItemAndMessages.Where(x => x.PrintRecItem != null).Should().ContainSingle().Which.PrintRecItem!.Description.Should().Be("Food");
+            content.ItemAndMessages.Should().OnlyContain(x => x.PrintRecVoidItem == null && x.PrintRecItemAdjustment == null);
+            content.RecTotalAndMessages.Should().HaveCount(3);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[1], 10m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[2], 70m);
+        }
+
+        [Fact]
+        public void Sale_VoucherCoversTheWholeReceipt_NeedsNoZeroCashFallback()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Food(100m), Voucher(-100m) });
+
+            var content = Sale(request);
+
+            content.RecTotalAndMessages.Should().ContainSingle();
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 100m);
+        }
+
+        [Fact]
+        public void Refund_MirrorsTheSale_VoucherIsAScontoAPagarePayment()
+        {
+            var request = CreateReceipt(RefundReceipt, new[] { Food(-100m, RefundItem), Voucher(20m, RefundItem) }, Cash(-80m, RefundItem));
+
+            var content = Refund(request);
+
+            content.PrintRecRefund.Should().ContainSingle().Which.Description.Should().Be("Food");
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 80m);
+        }
+
+        [Fact]
+        public void Void_MirrorsTheSale_VoucherIsAScontoAPagarePayment()
+        {
+            var request = CreateReceipt(VoidReceipt, new[] { Food(-100m, VoidItem), Voucher(20m, VoidItem) }, Cash(-80m, VoidItem));
+
+            var content = Void(request);
+
+            content.PrintRecVoid.Should().ContainSingle().Which.Description.Should().Be("Food");
+            content.RecTotalAndMessages.Should().HaveCount(2);
+            ShouldBeVoucherPayment(content.RecTotalAndMessages[0], 20m);
+            ShouldBeCashPayment(content.RecTotalAndMessages[1], 80m);
+        }
+
+        /// <summary>The sale of the voucher itself (positive line) is unchanged: an item on the NS department 11.</summary>
+        [Fact]
+        public void Sale_VoucherSaleLine_IsStillAnItemOnDepartment11()
+        {
+            var request = CreateReceipt(SaleReceipt, new[] { Voucher(100m) }, Cash(100m));
+
+            var content = Sale(request);
+
+            var item = content.ItemAndMessages.Should().ContainSingle().Which.PrintRecItem;
+            item.Should().NotBeNull();
+            item!.Department.Should().Be(11);
+            item.UnitPrice.Should().Be(100m);
+            content.RecTotalAndMessages.Should().ContainSingle();
+            ShouldBeCashPayment(content.RecTotalAndMessages[0], 100m);
+        }
+
+        /// <summary>Refunding a voucher sale used to put the line on department -1 (GetVatGroup of 0x48).</summary>
+        [Fact]
+        public void Refund_OfAVoucherSale_IsARefundLineOnDepartment11()
+        {
+            var request = CreateReceipt(RefundReceipt, new[] { Voucher(-100m, RefundItem) }, Cash(-100m, RefundItem));
+
+            var content = Refund(request);
+
+            var line = content.PrintRecRefund.Should().ContainSingle().Which;
+            line.Department.Should().Be(11);
+            line.Amount.Should().Be(100m);
+            content.RecTotalAndMessages.Should().ContainSingle();
+            ShouldBeCashPayment(content.RecTotalAndMessages[0], 100m);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #514

## Why

A multi-use voucher (buono multiuso) can be redeemed in two spellings of the fiskaltrust API: as pay item `0x06`, or as a negative charge item `0x…0048` (type of service 4, VAT nibble 8). The Epson RT Printer SCU handled only the first. `EpsonCommandFactory.GenerateItems` mapped *every* `0x…48` line to a `printRecItem` on department 11 with the **signed** quantity and unit price, so a redeem produced

```xml
<printRecItem description="Gutschein" quantity="1" unitPrice="-20" department="11" />
```

Item amounts carry no sign on the Epson protocol, and the printer refuses the command (`success="false" code="PRINTER ERROR" status="16"`, `lastCommand` 80), so the whole receipt failed. In grouping requests the same line became a `printRecVoidItem` (a void of an item that was never sold), and in refund/void documents it went out on department `-1`.

On the RT a multi-use voucher redemption is neither an item nor money received: the Agenzia delle Entrate XML puts it into `ScontoApagare` ("va indicato anche l'importo dei pagamenti effettuati con buono multiuso", gross of VAT, no effect on IVA). The Epson protocol 7.00 (§9.13) implements this as payment **type 6, index 01** ("Increments Sconto a pagare. Does not increment Importo pagato"), which is exactly what pay item `0x06` already produces.

## What changes

- **`ReceiptCaseHelper.IsMultiUseVoucherRedeem(chargeItem, request)`** (shared Abstraction): a `0x…48` line with a negative amount on a sale, or a positive amount on a refund/void (which mirror the sale). A positive line on a sale stays what it is: the sale of the voucher itself.
- **`EpsonCommandFactory.GetTotalAndMessages`** emits one `printRecTotal paymentType="6" index="1"` for `|Amount|` per redeem line, **before** the pay items (protocol note [2]: a type 6 payment above the amount still due is refused with error 21). The method is shared by the invoice, refund and void builders, so one change covers all three documents. A voucher that covers the whole receipt completes the payment phase on its own; the zero-cash fallback no longer fires.
- **`GetItemAndMessages`, `GetRecRefunds`, `GetRecvoids`** skip the redeem line. A refund/void of a voucher **sale** line now uses the NS department 11 like the sale (was `GetVatGroup()` = `-1`).
- **Tests:** `MultiUseVoucherRedeemTests` (10 cases: sale, grouping request, voucher covers the whole receipt, refund, void, and two regression guards for the voucher sale line). New acceptance example `0x0001_CashWithMultiUseVoucherRedeem_AsChargeItem.json` with helper and fact for the hardware suite.

## Validation on hardware

Sandbox Epson RT `99IEB077964` (training mode), driven with the XML the SCU generates:

| Step | Document | Printer response |
|---|---|---|
| Pre-fix XML (item with `unitPrice="-20"` on dept 11) | Z 98, doc 2 aborted | `PRINTER ERROR`, status 16 |
| Sale: Food 100 @10 %, voucher −20 as charge item, cash 80 | Z 98, doc 1 | accepted, amount 100,00 |
| Refund referencing doc 1 (voucher as type 6, cash 80) | Z 98, doc 3 | accepted |
| Second sale, then void referencing it | Z 98, docs 4 and 5 | accepted |
| Sale paid 100 % by the voucher (no pay items) | Z 98, doc 6 | accepted |
| Sale: Food 100, voucher −20, **no pay items** → voucher 20 + cash `payment="0"` (review round 2) | Z 98, doc 7 | accepted, amount 100,00 |

Unit tests: all 58 Epson unit tests pass; the other scu-it unit test projects stay green; the scu-it solution builds.

## Release note

Epson RT Printer: a multi-use voucher redeemed as a negative charge item (`…0048`) is now sent to the printer as a "sconto a pagare" payment (type 6, index 1) in sale, refund and void documents, instead of a negative item line the printer rejected. Refunds and voids of a multi-use voucher sale line now use the NS department 11 like the sale.

## Out of scope (separate tickets)

- **Sibling SCUs → #771.** `EpsonRTServerMapping` and `CustomRTPrinterSCU` print a negative `0x…48` line as a *positive* NS sale line (`Math.Abs`), so the total is wrong there instead of erroring; `CustomRTPrinterSCU.GetPaymentType` maps pay item `0x06` to cash; `CustomRTServerMapping` has no `0x…48` rule at all. (The `scu-it-epsonrtserver` / `scu-it-customrt*` labels on this PR come from `.github/labeler.yml`, which maps the shared Abstraction folder to all four SCU labels.)
- **Tips in refund/void** also land on department `-1`; not touched here.
- **Refund requests with non-mirrored signs** (positive amounts under the refund flag) still take the old path.
