### PR TITLE
Extend PartyTypeOverride

### DIFF
--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/AADEFactory.cs
@@ -735,8 +735,23 @@ public class AADEFactory
         {
             party.address = new AddressType
             {
-                number = partyOverride.Address.Number ?? "0"
+                street = partyOverride.Address.Street,
+                number = partyOverride.Address.Number ?? "0",
+                postalCode = partyOverride.Address.PostalCode,
+                city = partyOverride.Address.City
             };
+        }
+        if(!string.IsNullOrEmpty(partyOverride.VatNumber))
+        {
+            party.vatNumber = partyOverride.VatNumber;
+        }
+        if(!string.IsNullOrEmpty(partyOverride.Country) && Enum.TryParse<CountryType>(partyOverride.Country, true, out var country))
+        {
+            party.country = country;
+        }
+        if (!string.IsNullOrEmpty(partyOverride.Name))
+        {
+            party.name = partyOverride.Name;
         }
     }
 

--- a/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/Overrides/PartyTypeOverride.cs
+++ b/scu-gr/src/fiskaltrust.Middleware.SCU.GR.MyData/Models/Overrides/PartyTypeOverride.cs
@@ -1,9 +1,19 @@
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace fiskaltrust.Middleware.SCU.GR.MyData;
 
 public class PartyTypeOverride
 {
+    // used for otherCorrelatedEntities entry (a correlated party has no cbCustomer to fill them in).
+    [JsonPropertyName("vatNumber")]
+    public string? VatNumber { get; set; }
+
+    [JsonPropertyName("country")]
+    public string? Country { get; set; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
     [JsonPropertyName("branch")]
     public int? Branch { get; set; }
 

--- a/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
+++ b/scu-gr/test/fiskaltrust.Middleware.SCU.GR.MyData.UnitTest/MyDataOverrideTests.cs
@@ -2816,4 +2816,67 @@ public class MyDataOverrideTests
         header.receivingNotePurpose.Should().Be(2);
         header.otherReceivingNotePurposeTitle.Should().Be("Λοιπή αιτία παραλαβής");
     }
+
+    [Fact]
+    public void MapToInvoicesDoc_WithOtherCorrelatedEntitiesOverride_ShouldMapEntityData()
+    {
+        var factory = CreateFactory();
+        var request = CreateBasicReceiptRequest();
+        request.ftReceiptCaseData = new
+        {
+            GR = new
+            {
+                mydataoverride = new
+                {
+                    invoice = new
+                    {
+                        invoiceHeader = new
+                        {
+                            otherCorrelatedEntities = new[]
+                            {
+                                new
+                                {
+                                    type = 3,
+                                    entityData = new
+                                    {
+                                        vatNumber = "997671770",
+                                        country = "GR",
+                                        name = "Μεταφορική Α.Ε.",
+                                        branch = 0,
+                                        address = new
+                                        {
+                                            street = "Λεωφόρος Αθηνών",
+                                            number = "100",
+                                            postalCode = "10442",
+                                            city = "Αθήνα"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        var response = CreateBasicReceiptResponse(request);
+
+        var (doc, error) = factory.MapToInvoicesDoc(request, response);
+
+        error.Should().BeNull();
+        doc.Should().NotBeNull();
+        var entities = doc!.invoice[0].invoiceHeader.otherCorrelatedEntities;
+        entities.Should().NotBeNull();
+        entities.Should().HaveCount(1);
+        var entity = entities[0];
+        entity.type.Should().Be(3);
+        entity.entityData.Should().NotBeNull();
+        entity.entityData.vatNumber.Should().Be("997671770");
+        entity.entityData.country.Should().Be(CountryType.GR);
+        entity.entityData.name.Should().Be("Μεταφορική Α.Ε.");
+        entity.entityData.address.Should().NotBeNull();
+        entity.entityData.address.street.Should().Be("Λεωφόρος Αθηνών");
+        entity.entityData.address.number.Should().Be("100");
+        entity.entityData.address.postalCode.Should().Be("10442");
+        entity.entityData.address.city.Should().Be("Αθήνα");
+    }
 }


### PR DESCRIPTION
## New Field in 2.0.2 XSD
OtherCorrelatedEntities = the myDATA field for declaring third parties involved in a transaction or goods movement who aren't the issuer or the counterpart (buyer/seller). A normal invoice has two parties; real-world flows often have more, and this is where you record them.

Real World examples: Carrier / recipient of sender ( maybe the goods are received by someone elsethan the invoiced counterpart ) etc.

## Requirement

Extended the PartyTypeOverridee in order to cover the new 2.0.2 requirements about the "OtherCorrelatedEntities" field

## Description

Before now the PartyTypeOverride did not cover the following fields: vatNumber, name, country + street, postalCode and city from the Address

The code adds these fields into the override capability + an extended test for the otherCorrelatedEntities

Fixes [#281](https://github.com/fiskaltrust/market-gr/issues/281)
