### PR TITLE
Set Portuguese software certificate number to 3535 (sandbox keeps 9999)

### DIFF
--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Factories/SignatureItemFactoryPT.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Factories/SignatureItemFactoryPT.cs
@@ -83,12 +83,12 @@ public static class SignatureItemFactoryPT
         };
     }
 
-    public static SignatureItem AddCertificateSignature(string printHash)
+    public static SignatureItem AddCertificateSignature(string printHash, bool sandbox)
     {
         return new SignatureItem
         {
             Caption = $"-----",
-            Data = $"{printHash} - Processado por programa certificado " + $" n.º {fiskaltrust.Middleware.Localization.QueuePT.Logic.Exports.SAFTPT.SAFTSchemaPT10401.PTMappings.CertificationPosSystem.SoftwareCertificateNumber}/AT",
+            Data = $"{printHash} - Processado por programa certificado " + $" n.º {fiskaltrust.Middleware.Localization.QueuePT.Logic.Exports.SAFTPT.SAFTSchemaPT10401.PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(sandbox)}/AT",
             ftSignatureFormat = SignatureFormat.Text,
             ftSignatureType = SignatureTypePT.CertificationNo.As<SignatureType>(),
         };

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/PTMappings.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/PTMappings.cs
@@ -157,7 +157,7 @@ public static class PTMappings
     public static class CertificationPosSystem
     {
         public const string ProductCompanyTaxID = "980833310";
-        public const string SoftwareCertificateNumber = "9999";
+        public const string SoftwareCertificateNumber = "3535";
         public const string ProductID = "fiskaltrust.CloudCashBox/FISKALTRUST CONSULTING GMBH - Sucursal em Portugal";
         public const string ProductVersion = "2.0";
     }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/PTMappings.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/PTMappings.cs
@@ -157,7 +157,17 @@ public static class PTMappings
     public static class CertificationPosSystem
     {
         public const string ProductCompanyTaxID = "980833310";
+        /// <summary>
+        /// Certificate number assigned by the AT to the fiskaltrust.CloudCashBox. Used in production.
+        /// </summary>
         public const string SoftwareCertificateNumber = "3535";
+
+        /// <summary>
+        /// Placeholder certificate number used in the sandbox environment, as required for non-productive documents.
+        /// </summary>
+        public const string SandboxSoftwareCertificateNumber = "9999";
+
+        public static string GetSoftwareCertificateNumber(bool sandbox) => sandbox ? SandboxSoftwareCertificateNumber : SoftwareCertificateNumber;
         public const string ProductID = "fiskaltrust.CloudCashBox/FISKALTRUST CONSULTING GMBH - Sucursal em Portugal";
         public const string ProductVersion = "2.0";
     }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/SAFTMapping.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/SAFTMapping.cs
@@ -192,7 +192,7 @@ public class SaftExporter
 
         return new AuditFile
         {
-            Header = GetHeader(accountMasterData),
+            Header = GetHeader(accountMasterData, _sandbox),
             MasterFiles = new MasterFiles
             {
                 Customer = [.. actualReceiptRequests.Select(x => GetCustomerData(x.receiptRequest)).DistinctBy(x => x.CustomerID)],
@@ -413,7 +413,7 @@ public class SaftExporter
 
     }
 
-    public static Header GetHeader(AccountMasterData accountMasterData)
+    public static Header GetHeader(AccountMasterData accountMasterData, bool sandbox)
     {
         return new Header
         {
@@ -439,7 +439,7 @@ public class SaftExporter
             DateCreated = DateTime.UtcNow,
             TaxEntity = "GLOBAL",
             ProductCompanyTaxID = PTMappings.CertificationPosSystem.ProductCompanyTaxID,
-            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(_sandbox),
+            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(sandbox),
             ProductID = PTMappings.CertificationPosSystem.ProductID,
             ProductVersion = PTMappings.CertificationPosSystem.ProductVersion,
         };

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/SAFTMapping.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/Exports/SAFTPT/SAFTSchemaPT10401/SAFTMapping.cs
@@ -23,6 +23,7 @@ public class SaftExporter
 {
 
     private readonly DocumentStatusProvider? _documentStatusProvider;
+    private readonly bool _sandbox;
 
     public static bool IsValidPortugueseTaxId(string taxId)
     {
@@ -41,9 +42,10 @@ public class SaftExporter
         }
     }
 
-    public SaftExporter(DocumentStatusProvider? documentStatusProvider = null)
+    public SaftExporter(DocumentStatusProvider? documentStatusProvider = null, bool sandbox = false)
     {
         _documentStatusProvider = documentStatusProvider;
+        _sandbox = sandbox;
     }
 
     private DocumentStatusProvider DocumentStatusProvider => _documentStatusProvider ?? throw new InvalidOperationException("DocumentStatusProvider is required for this operation.");
@@ -437,7 +439,7 @@ public class SaftExporter
             DateCreated = DateTime.UtcNow,
             TaxEntity = "GLOBAL",
             ProductCompanyTaxID = PTMappings.CertificationPosSystem.ProductCompanyTaxID,
-            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.SoftwareCertificateNumber,
+            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(_sandbox),
             ProductID = PTMappings.CertificationPosSystem.ProductID,
             ProductVersion = PTMappings.CertificationPosSystem.ProductVersion,
         };

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/PortugalReceiptCalculations.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Logic/PortugalReceiptCalculations.cs
@@ -24,7 +24,7 @@ public static class PortugalReceiptCalculations
 {
     public static string GetPrintHash(string hash) => new StringBuilder().Append(hash[0]).Append(hash[10]).Append(hash[20]).Append(hash[30]).ToString();
 
-    public static string CreateCreditNoteQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse)
+    public static string CreateCreditNoteQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse, bool sandbox)
     {
         var atcud = numberSeries.ATCUD + "-" + numberSeries.Numerator;
         var taxGroups = request.cbChargeItems.GroupBy(PTMappings.GetIVATAxCode);
@@ -69,12 +69,12 @@ public static class PortugalReceiptCalculations
             TotalTaxes = request.cbChargeItems.Sum(x => Math.Abs(x.VATAmount ?? 0.0m)),
             GrossTotal = request.cbChargeItems.Sum(x => Math.Abs(x.Amount)),
             Hash = qrCodeHash,
-            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.SoftwareCertificateNumber,
+            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(sandbox),
             OtherInformation = "qiid=" + receiptResponse.ftQueueItemID
         }.GenerateQRCode();
     }
 
-    public static string CreateVatFreeQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse)
+    public static string CreateVatFreeQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse, bool sandbox)
     {
         var atcud = numberSeries.ATCUD + "-" + numberSeries.Numerator;
         var taxGroups = request.cbChargeItems.GroupBy(PTMappings.GetIVATAxCode);
@@ -120,12 +120,12 @@ public static class PortugalReceiptCalculations
             TotalTaxes = request.cbChargeItems.Sum(x => x.VATAmount ?? 0.0m),
             GrossTotal = request.cbChargeItems.Sum(x => x.Amount),
             Hash = qrCodeHash,
-            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.SoftwareCertificateNumber,
+            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(sandbox),
             OtherInformation = "qiid=" + receiptResponse.ftQueueItemID
         }.GenerateQRCode();
     }
 
-    public static string CreateQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse)
+    public static string CreateQRCode(string qrCodeHash, string issuerTIN, NumberSeries numberSeries, ReceiptRequest request, ReceiptResponse receiptResponse, bool sandbox)
     {
         var atcud = numberSeries.ATCUD + "-" + numberSeries.Numerator;
         var taxGroups = request.cbChargeItems.GroupBy(PTMappings.GetIVATAxCode);
@@ -168,7 +168,7 @@ public static class PortugalReceiptCalculations
             TotalTaxes = request.cbChargeItems.Sum(x => x.VATAmount ?? 0.0m),
             GrossTotal = request.cbChargeItems.Sum(x => x.Amount),
             Hash = qrCodeHash,
-            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.SoftwareCertificateNumber,
+            SoftwareCertificateNumber = PTMappings.CertificationPosSystem.GetSoftwareCertificateNumber(sandbox),
             OtherInformation = "qiid=" + receiptResponse.ftQueueItemID
         }.GenerateQRCode();
     }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/InvoiceCommandProcessorPT.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/InvoiceCommandProcessorPT.cs
@@ -50,13 +50,13 @@ public class InvoiceCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
         if (request.ReceiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund) || request.ReceiptRequest.IsPartialRefundReceipt())
         {
             var receiptReferences = response.ReceiptResponse.GetRequiredPreviousReceiptReference();
-            var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+            var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
             AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
             response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddReferenceSignature(receiptReferences));
         }
         else
         {
-            var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+            var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
             AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
             if (request.ReceiptRequest.cbPreviousReceiptReference is not null)
             {
@@ -83,7 +83,7 @@ public class InvoiceCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
     private static void AddSignatures(NumberSeries series, ProcessResponse response, string hash, string printHash, bool sandbox, string qrCode)
     {
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddHash(hash));
-        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash));
+        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash, sandbox));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddATCUD(series));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.CreatePTQRCode(response, sandbox, qrCode));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddIvaIncluido());

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/JournalProcessorPT.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/JournalProcessorPT.cs
@@ -14,11 +14,13 @@ namespace fiskaltrust.Middleware.Localization.QueuePT.Processors;
 public class JournalProcessorPT : IJournalProcessor
 {
     private readonly IStorageProvider _storageProvider;
+    private readonly bool _sandbox;
 
-    public JournalProcessorPT(IStorageProvider storageProvider)
+    public JournalProcessorPT(IStorageProvider storageProvider, bool sandbox)
     {
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         _storageProvider = storageProvider;
+        _sandbox = sandbox;
     }
 
     public (ContentType contentType, IAsyncEnumerable<byte[]> result) ProcessAsync(JournalRequest request)
@@ -49,7 +51,7 @@ public class JournalProcessorPT : IJournalProcessor
             queueItems = (await (await _storageProvider.CreateMiddlewareQueueItemRepository()).GetAsync()).ToList();
         }
         var documentStatusProvider = new DocumentStatusProvider(_storageProvider.CreateMiddlewareQueueItemRepository());
-        var data = new SaftExporter(documentStatusProvider).SerializeAuditFile(masterData, queueItems, (int) request.To);
+        var data = new SaftExporter(documentStatusProvider, _sandbox).SerializeAuditFile(masterData, queueItems, (int) request.To);
         yield return data;
     }
 }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/ReceiptCommandProcessorPT.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/Processors/ReceiptCommandProcessorPT.cs
@@ -54,13 +54,13 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
         if (request.ReceiptRequest.ftReceiptCase.IsFlag(ReceiptCaseFlags.Refund) || request.ReceiptRequest.IsPartialRefundReceipt())
         {
             List<Receipt> receiptReferences = response.ReceiptResponse.GetPreviousReceiptReference();
-            var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+            var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
             AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
             response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddReferenceSignature(receiptReferences));
         }
         else
         {
-            var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+            var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
             AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
             if (request.ReceiptRequest.cbPreviousReceiptReference is not null)
             {
@@ -103,7 +103,7 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
         }, series.LastHash);
 
         var printHash = PortugalReceiptCalculations.GetPrintHash(hash);
-        var qrCode = PortugalReceiptCalculations.CreateVatFreeQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+        var qrCode = PortugalReceiptCalculations.CreateVatFreeQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
         AddPaymentTransferSignatures(series, response, hash, printHash, _sandbox, qrCode);
         series.LastHash = hash;
         series.LastCbReceiptMoment = request.ReceiptRequest.cbReceiptMoment;
@@ -169,7 +169,7 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
         }, series.LastHash);
 
         var printHash = PortugalReceiptCalculations.GetPrintHash(hash);
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
         AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
         series.LastHash = hash;
         series.LastCbReceiptMoment = request.ReceiptRequest.cbReceiptMoment;
@@ -229,7 +229,7 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
         }, series.LastHash);
 
         var printHash = PortugalReceiptCalculations.GetPrintHash(hash);
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(printHash, _queuePT.IssuerTIN, series, request.ReceiptRequest, response.ReceiptResponse, _sandbox);
         AddSignatures(series, response, hash, printHash, _sandbox, qrCode);
         series.LastHash = hash;
         series.LastCbReceiptMoment = request.ReceiptRequest.cbReceiptMoment;
@@ -257,7 +257,7 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
     private static void AddSignatures(NumberSeries series, ProcessResponse response, string hash, string printHash, bool sandbox, string qrCode)
     {
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddHash(hash));
-        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash));
+        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash, sandbox));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddATCUD(series));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.CreatePTQRCode(response, sandbox, qrCode));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddIvaIncluido());
@@ -266,7 +266,7 @@ public class ReceiptCommandProcessorPT(IPTSSCD sscd, ftQueuePT queuePT, AsyncLaz
     private static void AddPaymentTransferSignatures(NumberSeries series, ProcessResponse response, string hash, string printHash, bool sandbox, string qrCode)
     {
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddHash(hash));
-        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash));
+        response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddCertificateSignature(printHash, sandbox));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.AddATCUD(series));
         response.ReceiptResponse.AddSignatureItem(SignatureItemFactoryPT.CreatePTQRCode(response, sandbox, qrCode));
     }

--- a/queue/src/fiskaltrust.Middleware.Localization.QueuePT/QueuePTBootstrapper.cs
+++ b/queue/src/fiskaltrust.Middleware.Localization.QueuePT/QueuePTBootstrapper.cs
@@ -107,7 +107,7 @@ public class QueuePTBootstrapper : IV2QueueBootstrapper
         var signProcessorPT = new ReceiptProcessor(loggerFactory.CreateLogger<ReceiptProcessor>(), fvValidator, new LifecycleCommandProcessorPT(queueStorageProvider), receiptProcessor, new DailyOperationsCommandProcessorPT(), invoiceProcessor, protocolProcessor, ValidationConfiguration.FromConfiguration(configuration));
 
         var signProcessor = new SignProcessor(loggerFactory.CreateLogger<SignProcessor>(), queueStorageProvider, signProcessorPT.ProcessAsync, new(() => Task.FromResult(queuePT.CashBoxIdentification)), middlewareConfiguration);
-        var journalProcessor = new JournalProcessor(storageProvider, new JournalProcessorPT(storageProvider), configuration, loggerFactory.CreateLogger<JournalProcessor>());
+        var journalProcessor = new JournalProcessor(storageProvider, new JournalProcessorPT(storageProvider, middlewareConfiguration.IsSandbox), configuration, loggerFactory.CreateLogger<JournalProcessor>());
         _queue = new Queue(signProcessor, journalProcessor, loggerFactory)
         {
             Id = id,

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePT.UnitTest/Factories/PortugalReceiptCalculationsTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePT.UnitTest/Factories/PortugalReceiptCalculationsTests.cs
@@ -440,7 +440,7 @@ public class PortugalReceiptCalculationsTests
         qrCode.Should().Contain("G:NC 20241210001*"); // UniqueIdentificationOfTheDocument - everything after #
         qrCode.Should().Contain("H:0-1*"); // ATCUD
         qrCode.Should().Contain("Q:TESTHASH123*"); // Hash
-        qrCode.Should().Contain("R:9999*"); // SoftwareCertificateNumber
+        qrCode.Should().Contain("R:3535*"); // SoftwareCertificateNumber
         qrCode.Should().Contain($"S:qiid={response.ftQueueItemID}"); // OtherInformation
     }
 

--- a/queue/test/fiskaltrust.Middleware.Localization.QueuePT.UnitTest/Factories/PortugalReceiptCalculationsTests.cs
+++ b/queue/test/fiskaltrust.Middleware.Localization.QueuePT.UnitTest/Factories/PortugalReceiptCalculationsTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using fiskaltrust.ifPOS.v2;
 using fiskaltrust.ifPOS.v2.Cases;
 using fiskaltrust.Middleware.Localization.QueuePT.Models;
+using fiskaltrust.Middleware.Localization.QueuePT.Models.Cases;
 using System.Text.Json;
 using fiskaltrust.Middleware.Localization.v2.Models;
 using fiskaltrust.Middleware.Localization.QueuePT.Logic;
@@ -431,7 +432,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#NC 20241210001");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -445,6 +446,38 @@ public class PortugalReceiptCalculationsTests
     }
 
     [Fact]
+    public void CreateQRCode_InSandbox_ShouldUsePlaceholderCertificateNumber()
+    {
+        // Arrange
+        var qrCodeHash = "TESTHASH123";
+        var issuerTIN = "123456789";
+        var numberSeries = CreateTestNumberSeries("0");
+        var request = CreateTestReceiptRequest();
+        var response = CreateTestReceiptResponse("ft5B1#FS 20241210001");
+
+        // Act
+        var productionQrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
+        var sandboxQrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: true);
+
+        // Assert
+        productionQrCode.Should().Contain("R:3535*");
+        sandboxQrCode.Should().Contain("R:9999*");
+    }
+
+    [Theory]
+    [InlineData(false, "3535")]
+    [InlineData(true, "9999")]
+    public void AddCertificateSignature_ShouldUseCertificateNumberOfEnvironment(bool sandbox, string expectedCertificateNumber)
+    {
+        // Act
+        var signature = SignatureItemFactoryPT.AddCertificateSignature("AxAx", sandbox);
+
+        // Assert
+        signature.Data.Should().Be($"AxAx - Processado por programa certificado  n.º {expectedCertificateNumber}/AT");
+        signature.ftSignatureType.Should().Be(SignatureTypePT.CertificationNo.As<SignatureType>());
+    }
+
+    [Fact]
     public void CreateInvoiceQRCode_ShouldGenerateQRCodeWithCorrectUniqueIdentification()
     {
         // Arrange
@@ -455,7 +488,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft7A2#FT 20241210002/1");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -478,7 +511,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft3X4#PF 20241210003");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -501,7 +534,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft8Y9#RG 20241210004");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateVatFreeQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateVatFreeQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -524,7 +557,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft2B3#FS 20241210005/99");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -547,7 +580,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#queue#system#NC 202412100000001/999");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateCreditNoteQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -566,7 +599,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#FS20241210006");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -585,7 +618,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#FT 20241210007");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -613,7 +646,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#FT 20241210008");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -633,7 +666,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse("ft5B1#FS 20241210009");
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();
@@ -662,7 +695,7 @@ public class PortugalReceiptCalculationsTests
         var response = CreateTestReceiptResponse(ftReceiptIdentification);
 
         // Act
-        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response);
+        var qrCode = PortugalReceiptCalculations.CreateQRCode(qrCodeHash, issuerTIN, numberSeries, request, response, sandbox: false);
 
         // Assert
         qrCode.Should().NotBeNullOrEmpty();


### PR DESCRIPTION
## Summary

The fiskaltrust.CloudCashBox has been certified by the Portuguese Tax and Customs Authority (AT) under **certificate number 3535**. Production documents now carry this number; the **sandbox keeps emitting the `9999` placeholder**, since sandbox documents must not carry the production certificate number.

## Changes

- `PTMappings.CertificationPosSystem`
  - `SoftwareCertificateNumber` = `"3535"` (production)
  - `SandboxSoftwareCertificateNumber` = `"9999"`
  - `GetSoftwareCertificateNumber(bool sandbox)` selects between them.
- The three places that emit the number now take the queue's sandbox flag (`MiddlewareConfiguration.IsSandbox`, already passed to the receipt and invoice processors):
  - `SignatureItemFactoryPT.AddCertificateSignature(printHash, sandbox)` → certificate print line `<hash> - Processado por programa certificado n.º <number>/AT`
  - `PortugalReceiptCalculations.CreateQRCode / CreateCreditNoteQRCode / CreateVatFreeQRCode(..., sandbox)` → QR code field `R`
  - `SaftExporter(documentStatusProvider, sandbox)` and `SaftExporter.GetHeader(accountMasterData, sandbox)` → `SoftwareCertificateNumber` in the SAF-T (PT) header; `JournalProcessorPT` now receives the flag from `QueuePTBootstrapper`.
- Tests
  - Existing QR code tests pass `sandbox: false` and assert `R:3535`.
  - New: `CreateQRCode_InSandbox_ShouldUsePlaceholderCertificateNumber` (production `R:3535`, sandbox `R:9999`).
  - New: `AddCertificateSignature_ShouldUseCertificateNumberOfEnvironment` (theory over both environments).

No expected-output files reference the placeholder; the only remaining `9999` in tests is a commented-out block in `InvoiceCommandProcessorPTTests`.

## Test plan

- [x] `queue-build` workflow (QueuePT unit tests) passes on this PR: 820 tests passed, 0 failed on the current head. The .NET SDK could not be downloaded in the authoring environment, so the tests were not run locally.

Related: documentation of the certificate number in fiskaltrust/docs#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wRTyRWPwtL5iRJGU7bj76