### PR TITLE
feat(scu-it): read the codice fiscale from cbCustomer.CustomerTaxId

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Customer.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Customer.cs
@@ -1,8 +1,13 @@
-﻿namespace fiskaltrust.Middleware.SCU.IT.Abstraction;
+namespace fiskaltrust.Middleware.SCU.IT.Abstraction;
 
 public class Customer
 {
     public string? CustomerName { get; set; }
+
+    /// <summary>
+    /// No longer read by the Italian SCUs: the codice fiscale moved to <see cref="CustomerTaxId"/>.
+    /// Kept on the model so that a PoS still sending it does not fail deserialization.
+    /// </summary>
     public string? CustomerId { get; set; }
     public string? CustomerType { get; set; }
     public string? CustomerStreet { get; set; }
@@ -10,6 +15,9 @@ public class Customer
     public string? CustomerCity { get; set; }
     public string? CustomerCountry { get; set; }
     public string? CustomerVATId { get; set; }
+
+    /// <summary>The codice fiscale of the customer.</summary>
+    public string? CustomerTaxId { get; set; }
 }
 
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/CustomerTaxIdValidation.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/CustomerTaxIdValidation.cs
@@ -47,11 +47,11 @@ public static class CustomerTaxIdValidation
             return false;
         }
 
-        return !string.IsNullOrWhiteSpace(customer.CustomerId) || !string.IsNullOrWhiteSpace(customer.CustomerVATId);
+        return !string.IsNullOrWhiteSpace(customer.CustomerTaxId) || !string.IsNullOrWhiteSpace(customer.CustomerVATId);
     }
 
     /// <summary>
-    /// Validates <see cref="Customer.CustomerId"/> (codice fiscale) and <see cref="Customer.CustomerVATId"/>
+    /// Validates <see cref="Customer.CustomerTaxId"/> (codice fiscale) and <see cref="Customer.CustomerVATId"/>
     /// (partita IVA) of the request's cbCustomer. Empty fields are valid - both identifiers are optional.
     /// </summary>
     /// <param name="errorMessage">The failure reason, or null when the request is valid.</param>
@@ -65,15 +65,15 @@ public static class CustomerTaxIdValidation
             return true;
         }
 
-        if (!string.IsNullOrWhiteSpace(customer.CustomerId) && !ItalyValidationHelpers.IsValidCodiceFiscale(customer.CustomerId))
+        if (!string.IsNullOrWhiteSpace(customer.CustomerTaxId) && !ItalyValidationHelpers.IsValidCodiceFiscale(customer.CustomerTaxId))
         {
-            errorMessage = $"The given codice fiscale '{customer.CustomerId}' is not valid. cbCustomer.CustomerId must contain either a 16 character Italian codice fiscale with a valid check character, or an 11 digit partita IVA, or must be left empty.";
+            errorMessage = $"The given codice fiscale '{customer.CustomerTaxId}' is not valid. cbCustomer.CustomerTaxId must contain a 16 character Italian codice fiscale.";
             return false;
         }
 
         if (!string.IsNullOrWhiteSpace(customer.CustomerVATId) && !ItalyValidationHelpers.IsValidPartitaIva(customer.CustomerVATId))
         {
-            errorMessage = $"The given partita IVA '{customer.CustomerVATId}' is not valid. cbCustomer.CustomerVATId must contain 11 digits with a valid check digit, optionally prefixed with 'IT', or must be left empty.";
+            errorMessage = $"The given partita IVA '{customer.CustomerVATId}' is not valid. cbCustomer.CustomerVATId must contain 11 digits with a valid check digit, optionally prefixed with 'IT', or must be left empty. A codice fiscale belongs in cbCustomer.CustomerTaxId.";
             return false;
         }
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/ItalyValidationHelpers.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.Abstraction/Validation/ItalyValidationHelpers.cs
@@ -4,7 +4,7 @@ namespace fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 
 /// <summary>
 /// Validation and normalization of the Italian tax identifiers carried by <see cref="Customer"/>: the
-/// codice fiscale (<see cref="Customer.CustomerId"/>) and the partita IVA (<see cref="Customer.CustomerVATId"/>).
+/// codice fiscale (<see cref="Customer.CustomerTaxId"/>) and the partita IVA (<see cref="Customer.CustomerVATId"/>).
 /// Algorithms: DM 23/12/1976 (codice fiscale and its check character) and DPR 605/1973 art. 4
 /// (partita IVA check digit).
 /// </summary>
@@ -42,31 +42,15 @@ public static class ItalyValidationHelpers
     }
 
     /// <summary>
-    /// <see cref="Normalize(string?)"/> plus removal of the 'IT' country prefix, but only when what
-    /// remains is an 11 digit partita IVA. A codice fiscale is never stripped, because a surname can
-    /// legitimately start with 'IT' (e.g. ITALIANO) and blind stripping would corrupt the code.
-    /// </summary>
-    public static string NormalizeTaxCode(string? value)
-    {
-        var normalized = Normalize(value);
-        if (!normalized.StartsWith(CountryPrefix, StringComparison.Ordinal))
-        {
-            return normalized;
-        }
-
-        var withoutPrefix = normalized.Substring(CountryPrefix.Length);
-        return ((withoutPrefix.Length == PartitaIvaLength) && IsAllDigits(withoutPrefix)) ? withoutPrefix : normalized;
-    }
-
-    /// <summary>
     /// Picks the tax identifier to hand to a device that offers a single slot for it (the Custom printer
     /// fixed line, the Epson directIO and printRecTaxID): the codice fiscale takes precedence over the
-    /// partita IVA. Both values are normalized, so a whitespace only or empty codice fiscale correctly
-    /// falls through to the partita IVA. Returns an empty string when the customer carries neither.
+    /// partita IVA. Each value is normalized for its own kind - the IT country prefix is stripped from the
+    /// partita IVA only - so a whitespace only or empty codice fiscale correctly falls through to the
+    /// partita IVA. Returns an empty string when the customer carries neither.
     /// </summary>
-    public static string SelectCustomerTaxId(string? customerId, string? customerVatId)
+    public static string SelectCustomerTaxId(string? customerTaxId, string? customerVatId)
     {
-        var taxCode = NormalizeTaxCode(customerId);
+        var taxCode = Normalize(customerTaxId);
         return (taxCode.Length > 0) ? taxCode : NormalizeVatId(customerVatId);
     }
 
@@ -118,11 +102,11 @@ public static class ItalyValidationHelpers
     }
 
     /// <summary>
-    /// Validates an Italian codice fiscale: 16 characters matching
+    /// Validates an Italian codice fiscale: exactly 16 characters matching
     /// ^[A-Z]{6}[0-9LMNPQRSTUV]{2}[ABCDEHLMPRST][0-9LMNPQRSTUV]{2}[A-Z][0-9LMNPQRSTUV]{3}[A-Z]$ with a
     /// plausible day of birth and a valid check character (CIN).
-    /// Legal entities use their 11 digit partita IVA as codice fiscale, so such values are accepted as
-    /// well and validated with <see cref="IsValidPartitaIva(string?)"/>.
+    /// A partita IVA is deliberately NOT accepted here, not even from a legal entity using it as its
+    /// codice fiscale: it belongs in <see cref="Customer.CustomerVATId"/>.
     /// </summary>
     public static bool IsValidCodiceFiscale(string? codiceFiscale)
     {
@@ -134,7 +118,7 @@ public static class ItalyValidationHelpers
         var value = Normalize(codiceFiscale);
         if (value.Length != CodiceFiscaleLength)
         {
-            return IsValidPartitaIva(value);
+            return false;
         }
 
         return HasValidCodiceFiscaleShape(value) && (value[CodiceFiscaleLength - 1] == CalculateCin(value));

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter/CustomRTPrinterSCU.cs
@@ -260,7 +260,7 @@ public sealed class CustomRTPrinterSCU : LegacySCU
             }
 
             // Customer fiscal code / VAT (scontrino parlante) — goes AFTER items/subtotal and BEFORE printRecTotal.
-            var customerCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+            var customerCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerTaxId, customer?.CustomerVATId);
             if (!string.IsNullOrEmpty(customerCfOrVat))
                 records.Add(new FixedLines { Pitch = "B", Description = customerCfOrVat });
 
@@ -635,7 +635,7 @@ public sealed class CustomRTPrinterSCU : LegacySCU
                 records.Add(new PrintRecSubtotal());
             }
 
-            var deliveryCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+            var deliveryCfOrVat = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerTaxId, customer?.CustomerVATId);
             if (!string.IsNullOrEmpty(deliveryCfOrVat))
                 records.Add(new FixedLines { Pitch = "B", Description = deliveryCfOrVat });
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.CustomRTServer/CustomRTServerMapping.cs
@@ -175,7 +175,7 @@ public static class CustomRTServerMapping
 
     /// <summary>
     /// Reads the customer identification from cbCustomer. By convention across the IT SCUs
-    /// (cf. CustomRTPrinterSCU) Customer.CustomerId carries the codice fiscale and
+    /// (cf. CustomRTPrinterSCU) Customer.CustomerTaxId carries the codice fiscale and
     /// Customer.CustomerVATId the partita IVA, so each one maps to its own document field.
     /// Both values are forwarded as-is apart from normalization: their shape is validated upstream in
     /// CustomRTServerSCU.ProcessReceiptAsync.
@@ -183,7 +183,7 @@ public static class CustomRTServerMapping
     public static (string fiscalcode, string vatcode) GetCustomerDataForReceiptRequest(ReceiptRequest receiptRequest)
     {
         var customer = receiptRequest.GetCustomer();
-        return (ItalyValidationHelpers.NormalizeTaxCode(customer?.CustomerId), ItalyValidationHelpers.NormalizeVatId(customer?.CustomerVATId));
+        return (ItalyValidationHelpers.Normalize(customer?.CustomerTaxId), ItalyValidationHelpers.NormalizeVatId(customer?.CustomerVATId));
     }
 
     public static bool InverseAmount(ReceiptRequest receiptRequest, ChargeItem chargeItem) => receiptRequest.IsRefund() || receiptRequest.IsVoid() || chargeItem.IsRefund() || chargeItem.IsVoid();

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -221,7 +221,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
     private static string GetCustomerTaxId(ReceiptRequest receiptRequest)
     {
         var customer = receiptRequest.GetCustomer();
-        return ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+        return ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerTaxId, customer?.CustomerVATId);
     }
 
     public async Task<ReceiptResponse> PerformProtocolReceiptAsync(ReceiptRequest receiptRequest, ReceiptResponse receiptResponse)

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/Utilities/EpsonCommandFactory.cs
@@ -347,9 +347,9 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
 
         /// <summary>
         /// Emits the customer tax identifier for the "scontrino parlante". The codice fiscale takes
-        /// precedence over the partita IVA, as in the Custom SCUs. The two identifiers use different
-        /// commands, which share the same data layout: an 11 digit partita IVA goes to directIO 1060, a
-        /// 16 character alphanumeric codice fiscale to directIO 1061.
+        /// precedence over the partita IVA, as in the Custom SCUs. Each identifier is bound to its own
+        /// command, and the two commands share the same data layout: the 11 digit partita IVA of
+        /// CustomerVATId goes to directIO 1060, the 16 character codice fiscale of CustomerTaxId to 1061.
         /// Shape and checksum are validated upstream in EpsonRTPrinterSCU.ProcessReceiptAsync, so the checks
         /// here are only defence in depth for the receipts the validation gate deliberately skips: a
         /// malformed value must still be dropped rather than sent to the printer, which would answer with a
@@ -358,16 +358,20 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities
         private static void AddCustomerTaxIdDirectIO(FiscalReceipt fiscalReceipt, ReceiptRequest receiptRequest)
         {
             var customer = receiptRequest.GetCustomer();
-            var taxId = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+            var codiceFiscale = ItalyValidationHelpers.Normalize(customer?.CustomerTaxId);
+            var partitaIva = ItalyValidationHelpers.NormalizeVatId(customer?.CustomerVATId);
 
             string command;
-            if ((taxId.Length == PartitaIvaLength) && taxId.All(char.IsDigit))
-            {
-                command = "1060";
-            }
-            else if ((taxId.Length == CodiceFiscaleLength) && taxId.All(IsUpperCaseAlphanumeric))
+            string taxId;
+            if ((codiceFiscale.Length == CodiceFiscaleLength) && codiceFiscale.All(IsUpperCaseAlphanumeric))
             {
                 command = "1061";
+                taxId = codiceFiscale;
+            }
+            else if ((partitaIva.Length == PartitaIvaLength) && partitaIva.All(char.IsDigit))
+            {
+                command = "1060";
+                taxId = partitaIva;
             }
             else
             {

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerMapping.cs
@@ -159,7 +159,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer
                 // partita IVA, as in the Custom SCUs. Normalized so the IT country prefix is not
                 // forwarded to the server as part of the tax id.
                 var customer = receiptRequest.GetCustomer();
-                var customerTaxId = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId);
+                var customerTaxId = ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerTaxId, customer?.CustomerVATId);
                 if (!string.IsNullOrEmpty(customerTaxId))
                 {
                     sb.Append($"<printRecTaxID taxID=\"{Escape(customerTaxId)}\" />");

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTServer/EpsonRTServerSCU.cs
@@ -325,7 +325,7 @@ public sealed class EpsonRTServerSCU : LegacySCU
             // Reports what was actually sent: printRecTaxID is suppressed when a lottery code is present,
             // because the two are mutually exclusive (see EpsonRTServerMapping).
             RTCustomerID = string.IsNullOrEmpty(document.LotteryCode)
-                ? ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerId, customer?.CustomerVATId)
+                ? ItalyValidationHelpers.SelectCustomerTaxId(customer?.CustomerTaxId, customer?.CustomerVATId)
                 : "",
             RTReferenceZNumber = document.ReferenceZNumber,
             RTReferenceDocNumber = document.ReferenceDocNumber,

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.UnitTest/IntegrationTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTPrinter.UnitTest/IntegrationTests.cs
@@ -361,7 +361,7 @@ public class IntegrationTests
             ftReceiptCase = 0x4954_2000_0000_0005, // DeliveryNote0x0005
             cbReceiptMoment = DateTime.UtcNow,
             cbReceiptAmount = 5.00m,
-            cbCustomer = """{"CustomerId":"RSSMRA80A01H501U","CustomerName":"Mario Rossi","CustomerStreet":"Via Roma 1","CustomerZip":"00100","CustomerCity":"Roma"}""",
+            cbCustomer = """{"CustomerTaxId":"RSSMRA80A01H501U","CustomerName":"Mario Rossi","CustomerStreet":"Via Roma 1","CustomerZip":"00100","CustomerCity":"Roma"}""",
             cbChargeItems = new[]
             {
                 new ChargeItem { Description = "Prodotto A", Amount = 3.00m, Quantity = 1, ftChargeItemCase = 0x4954_2000_0000_0011 },

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.CustomRTServer.UnitTest/CustomRTServerSCUTests.cs
@@ -167,7 +167,7 @@ public class CustomRTServerSCUTests : IDisposable
 
     [Theory]
     [InlineData("""{"CustomerVATId":"12345"}""")]
-    [InlineData("""{"CustomerId":"RSSMRA80A01H501Z"}""")]
+    [InlineData("""{"CustomerTaxId":"RSSMRA80A01H501Z"}""")]
     public async Task ProcessReceiptAsync_WithAnInvalidCustomerTaxId_FailsBeforeContactingTheServer(string cbCustomer)
     {
         var sut = CreateSut();
@@ -309,9 +309,9 @@ public class CustomRTServerSCUTests : IDisposable
     }
 
     [Fact]
-    public void GenerateFiscalDocument_WithCustomerId_MapsCodiceFiscaleToFiscalCode()
+    public void GenerateFiscalDocument_WithCustomerTaxId_MapsCodiceFiscaleToFiscalCode()
     {
-        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U"}""");
+        var receiptRequest = CreateReceiptRequest("""{"CustomerTaxId":"RSSMRA80A01H501U"}""");
 
         (var commercialDocument, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
 
@@ -321,9 +321,9 @@ public class CustomRTServerSCUTests : IDisposable
     }
 
     [Fact]
-    public void GenerateFiscalDocument_WithBothCustomerIdAndVATId_MapsBothFields()
+    public void GenerateFiscalDocument_WithBothCustomerTaxIdAndVATId_MapsBothFields()
     {
-        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+        var receiptRequest = CreateReceiptRequest("""{"CustomerTaxId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
 
         (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
 
@@ -368,9 +368,9 @@ public class CustomRTServerSCUTests : IDisposable
     [InlineData("RSSMRA80A01H501", "RSSMRA80A01H501")]        // too short
     [InlineData("RSSMRA80A01H501UU", "RSSMRA80A01H501UU")]    // too long
     [InlineData("  rssmra80a01h501u  ", "RSSMRA80A01H501U")]  // trimmed and upper-cased, not validated
-    public void GenerateFiscalDocument_ForwardsCustomerIdWithoutRevalidating(string customerId, string expected)
+    public void GenerateFiscalDocument_ForwardsCustomerTaxIdWithoutRevalidating(string customerId, string expected)
     {
-        var receiptRequest = CreateReceiptRequest($$"""{"CustomerId":"{{customerId}}"}""");
+        var receiptRequest = CreateReceiptRequest($$"""{"CustomerTaxId":"{{customerId}}"}""");
 
         (_, var fiscalDocument) = CustomRTServerMapping.GenerateFiscalDocument(receiptRequest, CreateQueueIdentification());
 
@@ -411,7 +411,7 @@ public class CustomRTServerSCUTests : IDisposable
     [Fact]
     public void CreateResoDocument_WithCustomer_MapsCustomerFields()
     {
-        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+        var receiptRequest = CreateReceiptRequest("""{"CustomerTaxId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
 
         (_, var fiscalDocument) = CustomRTServerMapping.CreateResoDocument(receiptRequest, CreateQueueIdentification(), CreateReceiptResponse());
 
@@ -423,7 +423,7 @@ public class CustomRTServerSCUTests : IDisposable
     [Fact]
     public void CreateAnnuloDocument_WithCustomer_MapsCustomerFields()
     {
-        var receiptRequest = CreateReceiptRequest("""{"CustomerId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
+        var receiptRequest = CreateReceiptRequest("""{"CustomerTaxId":"RSSMRA80A01H501U","CustomerVATId":"01606720215"}""");
 
         (_, var fiscalDocument) = CustomRTServerMapping.CreateAnnuloDocument(receiptRequest, CreateQueueIdentification(), CreateReceiptResponse());
 

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/CustomerTaxIdDirectIOTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/CustomerTaxIdDirectIOTests.cs
@@ -85,14 +85,14 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         [MemberData(nameof(RequestBuilders))]
         public void AllBuilders_WithACodiceFiscale_EmitDirectIO1061(string builder)
         {
-            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"" + CodiceFiscale + "\"}"), "1061", CodiceFiscale);
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerTaxId\":\"" + CodiceFiscale + "\"}"), "1061", CodiceFiscale);
         }
 
         [Theory]
         [MemberData(nameof(RequestBuilders))]
         public void AllBuilders_WithAnUntrimmedLowerCaseCodiceFiscale_StillEmitDirectIO1061(string builder)
         {
-            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"  rssmra80a01h501u \"}"), "1061", CodiceFiscale);
+            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerTaxId\":\"  rssmra80a01h501u \"}"), "1061", CodiceFiscale);
         }
 
         /// <summary>Same precedence rule as the Custom SCUs: the codice fiscale wins.</summary>
@@ -100,25 +100,30 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         [MemberData(nameof(RequestBuilders))]
         public void AllBuilders_WithBothIdentifiers_PreferTheCodiceFiscale(string builder)
         {
-            var cbCustomer = "{\"CustomerId\":\"" + CodiceFiscale + "\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
+            var cbCustomer = "{\"CustomerTaxId\":\"" + CodiceFiscale + "\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
 
             AssertSingleCommand(BuildDirectIOCommands(builder, cbCustomer), "1061", CodiceFiscale);
         }
 
-        /// <summary>An Italian legal entity uses its partita IVA as codice fiscale, so it belongs on 1060.</summary>
+        /// <summary>
+        /// CustomerTaxId carries a codice fiscale only. A legal entity using its partita IVA as codice
+        /// fiscale has to send it as CustomerVATId; put on CustomerTaxId it reaches neither command.
+        /// </summary>
         [Theory]
         [MemberData(nameof(RequestBuilders))]
-        public void AllBuilders_WithAPartitaIvaInCustomerId_EmitDirectIO1060(string builder)
+        public void AllBuilders_WithAPartitaIvaInCustomerTaxId_EmitNoDirectIO(string builder)
         {
-            AssertSingleCommand(BuildDirectIOCommands(builder, "{\"CustomerId\":\"IT" + PartitaIva + "\"}"), "1060", PartitaIva);
+            var commands = BuildDirectIOCommands(builder, "{\"CustomerTaxId\":\"" + PartitaIva + "\"}");
+
+            Assert.Empty(commands.Where(x => x.Command == "1060" || x.Command == "1061"));
         }
 
-        /// <summary>An empty CustomerId must not suppress a usable partita IVA.</summary>
+        /// <summary>An empty CustomerTaxId must not suppress a usable partita IVA.</summary>
         [Theory]
         [MemberData(nameof(RequestBuilders))]
-        public void AllBuilders_WithAnEmptyCustomerId_FallBackToThePartitaIva(string builder)
+        public void AllBuilders_WithAnEmptyCustomerTaxId_FallBackToThePartitaIva(string builder)
         {
-            var cbCustomer = "{\"CustomerId\":\"\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
+            var cbCustomer = "{\"CustomerTaxId\":\"\",\"CustomerVATId\":\"" + PartitaIva + "\"}";
 
             AssertSingleCommand(BuildDirectIOCommands(builder, cbCustomer), "1060", PartitaIva);
         }
@@ -126,8 +131,10 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         [Theory]
         [InlineData("{\"CustomerVATId\":\"12345\"}")]              // too short
         [InlineData("{\"CustomerVATId\":\"0160672021A\"}")]        // right length, not all digits
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501\"}")]       // 15 characters
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U!\"}")]     // 16 characters, not alphanumeric
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501\"}")]       // 15 characters
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U!\"}")]     // 16 characters, not alphanumeric
+        [InlineData("{\"CustomerTaxId\":\"IT01606720215\"}")]         // a partita IVA does not belong here
+        [InlineData("{\"CustomerVATId\":\"RSSMRA80A01H501U\"}")]      // ... and neither does a codice fiscale there
         [InlineData("{\"CustomerVATId\":\"\"}")]
         [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
         [InlineData("")]

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest/EpsonRTServerSCUTests.cs
@@ -430,7 +430,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         [Theory]
         [InlineData("{\"CustomerVATId\":\"12345\"}")]
         [InlineData("{\"CustomerVATId\":\"DE123456789\"}")]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501Z\"}")]
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501Z\"}")]
         public async Task ProcessReceiptAsync_WithAnInvalidCustomerTaxId_FailsWithoutSendingAnyDocument(string cbCustomer)
         {
             var client = CreateClientMock();
@@ -455,7 +455,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         }
 
         [Theory]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"IT01606720215\"}")]
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"IT01606720215\"}")]
         [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
         [InlineData("")]
         public async Task ProcessReceiptAsync_WithAValidOrAbsentCustomerTaxId_SendsTheDocument(string cbCustomer)
@@ -507,15 +507,16 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTServer.UnitTest
         }
 
         /// <summary>
-        /// printRecTaxID has a single slot, so CustomerId (codice fiscale) takes precedence over
-        /// CustomerVATId, matching the Custom SCUs. An empty CustomerId must fall through to the partita IVA.
+        /// printRecTaxID has a single slot, so CustomerTaxId (codice fiscale) takes precedence over
+        /// CustomerVATId, matching the Custom SCUs. An empty CustomerTaxId must fall through to the partita
+        /// IVA, whose IT country prefix is stripped before it is sent.
         /// </summary>
         [Theory]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\"}", "RSSMRA80A01H501U")]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}", "RSSMRA80A01H501U")]
-        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"01606720215\"}", "01606720215")]
-        [InlineData("{\"CustomerId\":\"IT01606720215\"}", "01606720215")]
-        public async Task ProcessReceiptAsync_WithACustomerId_SendsItAsTheTaxId(string cbCustomer, string expectedTaxId)
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U\"}", "RSSMRA80A01H501U")]
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}", "RSSMRA80A01H501U")]
+        [InlineData("{\"CustomerTaxId\":\"\",\"CustomerVATId\":\"01606720215\"}", "01606720215")]
+        [InlineData("{\"CustomerVATId\":\"IT01606720215\"}", "01606720215")]
+        public async Task ProcessReceiptAsync_WithACustomerTaxId_SendsItAsTheTaxId(string cbCustomer, string expectedTaxId)
         {
             var sentDocuments = new List<string>();
             var client = CreateClientMock();

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/CustomerTaxIdValidationTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/CustomerTaxIdValidationTests.cs
@@ -44,8 +44,8 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         [InlineData("")]
         [InlineData("not json at all")]
         [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
-        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"\"}")]
-        [InlineData("{\"CustomerId\":\"   \"}")]
+        [InlineData("{\"CustomerTaxId\":\"\",\"CustomerVATId\":\"\"}")]
+        [InlineData("{\"CustomerTaxId\":\"   \"}")]
         public void CarriesCustomerTaxIds_WithoutAnIdentifier_ReturnsFalse(string cbCustomer)
         {
             var receiptRequest = CreateReceiptRequest(cbCustomer);
@@ -54,7 +54,7 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         }
 
         [Theory]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\"}")]
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U\"}")]
         [InlineData("{\"CustomerVATId\":\"01606720215\"}")]
         [InlineData(InvalidCustomer)]
         public void CarriesCustomerTaxIds_ForASaleReceiptWithAnIdentifier_ReturnsTrue(string cbCustomer)
@@ -69,10 +69,9 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         [InlineData("")]
         [InlineData("not json at all")]
         [InlineData("{\"CustomerName\":\"Mario Rossi\"}")]
-        [InlineData("{\"CustomerId\":\"\",\"CustomerVATId\":\"\"}")]
-        [InlineData("{\"CustomerId\":\"   \",\"CustomerVATId\":\"   \"}")]
-        [InlineData("{\"CustomerId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}")]
-        [InlineData("{\"CustomerId\":\"01606720215\"}")]
+        [InlineData("{\"CustomerTaxId\":\"\",\"CustomerVATId\":\"\"}")]
+        [InlineData("{\"CustomerTaxId\":\"   \",\"CustomerVATId\":\"   \"}")]
+        [InlineData("{\"CustomerTaxId\":\"RSSMRA80A01H501U\",\"CustomerVATId\":\"01606720215\"}")]
         [InlineData("{\"CustomerVATId\":\"IT01606720215\"}")]
         public void TryValidateCustomerTaxIds_WithAbsentOrValidIdentifiers_ReturnsTrue(string cbCustomer)
         {
@@ -88,13 +87,44 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         [Fact]
         public void TryValidateCustomerTaxIds_WithAnInvalidCodiceFiscale_ReturnsFalseAndNamesTheField()
         {
-            var receiptRequest = CreateReceiptRequest("{\"CustomerId\":\"RSSMRA80A01H501Z\"}");
+            var receiptRequest = CreateReceiptRequest("{\"CustomerTaxId\":\"RSSMRA80A01H501Z\"}");
 
             var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
 
             using var scope = new AssertionScope();
             isValid.Should().BeFalse();
-            errorMessage.Should().Contain("RSSMRA80A01H501Z").And.Contain("cbCustomer.CustomerId");
+            errorMessage.Should().Contain("RSSMRA80A01H501Z").And.Contain("cbCustomer.CustomerTaxId");
+        }
+
+        /// <summary>
+        /// Each field takes one kind of identifier only: a partita IVA on CustomerTaxId is rejected, even
+        /// though a legal entity legitimately uses it as its codice fiscale - it belongs on CustomerVATId.
+        /// </summary>
+        [Theory]
+        [InlineData("01606720215")]
+        [InlineData("IT01606720215")]
+        public void TryValidateCustomerTaxIds_WithAPartitaIvaAsCodiceFiscale_ReturnsFalse(string customerTaxId)
+        {
+            var receiptRequest = CreateReceiptRequest("{\"CustomerTaxId\":\"" + customerTaxId + "\"}");
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeFalse();
+            errorMessage.Should().Contain(customerTaxId).And.Contain("cbCustomer.CustomerTaxId");
+        }
+
+        /// <summary>A codice fiscale on CustomerVATId is rejected the same way, in the other direction.</summary>
+        [Fact]
+        public void TryValidateCustomerTaxIds_WithACodiceFiscaleAsPartitaIva_ReturnsFalse()
+        {
+            var receiptRequest = CreateReceiptRequest("{\"CustomerVATId\":\"RSSMRA80A01H501U\"}");
+
+            var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
+
+            using var scope = new AssertionScope();
+            isValid.Should().BeFalse();
+            errorMessage.Should().Contain("RSSMRA80A01H501U").And.Contain("cbCustomer.CustomerVATId");
         }
 
         [Fact]
@@ -112,13 +142,13 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         [Fact]
         public void TryValidateCustomerTaxIds_WithBothIdentifiersInvalid_ReportsTheCodiceFiscaleFirst()
         {
-            var receiptRequest = CreateReceiptRequest("{\"CustomerId\":\"RSSMRA80A01H501Z\",\"CustomerVATId\":\"12345\"}");
+            var receiptRequest = CreateReceiptRequest("{\"CustomerTaxId\":\"RSSMRA80A01H501Z\",\"CustomerVATId\":\"12345\"}");
 
             var isValid = receiptRequest.TryValidateCustomerTaxIds(out var errorMessage);
 
             using var scope = new AssertionScope();
             isValid.Should().BeFalse();
-            errorMessage.Should().Contain("cbCustomer.CustomerId").And.NotContain("cbCustomer.CustomerVATId");
+            errorMessage.Should().Contain("codice fiscale 'RSSMRA80A01H501Z'").And.NotContain("12345");
         }
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/ItalyValidationHelpersTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.UnitTest/ItalyValidationHelpersTests.cs
@@ -49,9 +49,6 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         // substituted code.
         [InlineData("MRTMTT25D09F20RU")]
         [InlineData("RSSMRA80A01H5LMX")]
-        // Legal entities use their partita IVA as codice fiscale.
-        [InlineData("01606720215")]
-        [InlineData("IT01606720215")]
         public void IsValidCodiceFiscale_WithValidValue_ReturnsTrue(string codiceFiscale)
         {
             ItalyValidationHelpers.IsValidCodiceFiscale(codiceFiscale).Should().BeTrue();
@@ -68,6 +65,10 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         [InlineData("RSSMRA80A00H501U")]        // day 00 is out of range
         [InlineData("DE123456789")]
         [InlineData("01606720216")]             // 11 digits, wrong check digit
+        // A partita IVA is not a codice fiscale, not even a valid one from a legal entity: it belongs
+        // in cbCustomer.CustomerVATId.
+        [InlineData("01606720215")]
+        [InlineData("IT01606720215")]
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
@@ -111,26 +112,16 @@ namespace fiskaltrust.Middleware.SCU.IT.UnitTest
         }
 
         [Theory]
-        [InlineData(null, "")]
-        [InlineData("  it01606720215 ", "01606720215")]           // an IT prefixed partita IVA is stripped
-        [InlineData("IT12345678901", "12345678901")]              // 11 digits remain, so it is a partita IVA
-        [InlineData("RSSMRA80A01H501U", "RSSMRA80A01H501U")]
-        [InlineData("ITLMRA80A01H501U", "ITLMRA80A01H501U")]      // a surname starting with IT is left alone
-        [InlineData("IT12345", "IT12345")]                        // not 11 digits, so nothing is stripped
-        public void NormalizeTaxCode_StripsTheCountryPrefixOnlyForAPartitaIva(string value, string expected)
-        {
-            ItalyValidationHelpers.NormalizeTaxCode(value).Should().Be(expected);
-        }
-
-        [Theory]
         [InlineData(null, null, "")]
         [InlineData("RSSMRA80A01H501U", null, "RSSMRA80A01H501U")]
         [InlineData(null, "01606720215", "01606720215")]
         [InlineData(null, "IT01606720215", "01606720215")]
         [InlineData("RSSMRA80A01H501U", "01606720215", "RSSMRA80A01H501U")]   // the codice fiscale wins
-        [InlineData("", "01606720215", "01606720215")]                        // an empty CustomerId falls through
+        [InlineData("", "01606720215", "01606720215")]                        // an empty CustomerTaxId falls through
         [InlineData("   ", "01606720215", "01606720215")]                     // ... and so does a blank one
-        [InlineData("IT01606720215", null, "01606720215")]                    // CustomerId carrying a partita IVA
+        // CustomerTaxId is a codice fiscale slot, so it is only normalized: the IT country prefix is
+        // stripped from the partita IVA alone.
+        [InlineData("IT01606720215", null, "IT01606720215")]
         [InlineData("ITLMRA80A01H501U", null, "ITLMRA80A01H501U")]            // a surname starting with IT survives
         public void SelectCustomerTaxId_PrefersTheCodiceFiscaleAndNormalizesBoth(string customerId, string customerVatId, string expected)
         {


### PR DESCRIPTION
Closes #774.

## What changes

The Italian SCUs read the customer codice fiscale from `cbCustomer.CustomerId`, a generic field with no fiscal meaning in any other market. Spain already models this properly (`SCU.ES.Common.Models.MiddlewareCustomer`): `CustomerTaxId` holds the tax identifier and `CustomerId` is never read. The IT SCUs now do the same.

`CustomerTaxId` replaces `CustomerId` as the codice fiscale slot in all seven read sites - Epson printer (directIO 1060/1061 and `RTCustomerID`), Epson server (`printRecTaxID`), Custom printer (fixed line), Custom server (`fiscalcode`) - and in the request validation. `CustomerId` stays on the model so a PoS still sending it does not fail deserialization, but nothing reads it any more.

Each field now takes one kind of identifier only:

- `CustomerTaxId`: a 16 character codice fiscale. `IsValidCodiceFiscale` no longer falls back to `IsValidPartitaIva`, so a legal entity using its partita IVA as codice fiscale has to send it as `CustomerVATId`.
- `CustomerVATId`: an 11 digit partita IVA, optionally `IT` prefixed - unchanged.

`NormalizeTaxCode` is gone: the `IT` country prefix is only ever stripped from a partita IVA, so the codice fiscale slot just needs `Normalize`. The Epson directIO follows the same split - `CustomerTaxId` reaches command 1061 only and `CustomerVATId` 1060 only, instead of picking the command from the shape of whatever value won. Validation messages name the field they are about.

## Breaking change

A PoS sending the codice fiscale on `cbCustomer.CustomerId` loses it silently: it is no longer printed and no longer validated. A PoS sending a partita IVA on the codice fiscale field now gets the receipt rejected with `it-customer-taxid-invalid`. This is the clean cut the issue describes; whether a transitional fallback to `CustomerId` is wanted is still open.

## Testing

`dotnet build` on the IT solution: 0 errors. Unit tests: 279 passed - `SCU.IT.UnitTest` 96, `EpsonRTPrinter.UnitTest` 50, `EpsonRTServer.UnitTest` 96, `CustomRTServer.UnitTest` 37. `CustomRTPrinter.UnitTest` is skipped as before (needs hardware), and the SCUs were not exercised against a real RT device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
