### PR TITLE
fix(scu-it/epson): retry the status query during recovery instead of asking once

### DIFF
--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -5,6 +5,7 @@ using fiskaltrust.Middleware.SCU.IT.Abstraction.Validation;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
 using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
 using Newtonsoft.Json;
+using System.Diagnostics;
 using System.Globalization;
 using fiskaltrust.ifPOS.v1;
 using Microsoft.Extensions.Logging;
@@ -457,10 +458,20 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
     /// command timeout before learning what happened, so the recovery can conclude while whoever asked for the
     /// receipt is still listening.
     /// </para>
+    /// <para>
+    /// <b>What an <see cref="IEpsonFpMateClient"/> has to guarantee for this to hold.</b> "The printer answered,
+    /// so it is not mid-document" is the assumption the resend rests on, and it is only self-evident on a direct
+    /// connection. Any client that queues commands instead of handing them straight to the device must ensure an
+    /// abandoned print command can never be delivered <em>after</em> a later status query was answered: that
+    /// ordering would let a <see cref="PrinterVerdict.NotPrinted"/> verdict be followed by the very document it
+    /// declared absent, and the resend would then duplicate it. Holding at most one command in flight per device
+    /// and discarding it when its wait elapses is sufficient, and is what the relay client does.
+    /// </para>
     /// </summary>
     private async Task<(PrinterVerdict Verdict, LastEmittedDocStatus? Doc)> AwaitPrinterVerdictAsync(string receiptReference, DocPosition baseline)
     {
-        var deadline = DateTime.UtcNow.AddMilliseconds(_configuration.RecoveryVerdictTimeoutMs);
+        // Stopwatch rather than the wall clock: a clock jump must not shorten or extend the window.
+        var elapsed = Stopwatch.StartNew();
         var attempt = 0;
 
         while (true)
@@ -481,7 +492,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                 return (PrinterVerdict.NotPrinted, doc);
             }
 
-            if (DateTime.UtcNow >= deadline)
+            if (elapsed.ElapsedMilliseconds >= _configuration.RecoveryVerdictTimeoutMs)
             {
                 _logger.LogError("({receiptreference}) Printer did not answer within {timeout}ms ({attempts} attempts) — state unknown.",
                     receiptReference, _configuration.RecoveryVerdictTimeoutMs, attempt);

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -431,34 +431,96 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         _lastDoc.Value = null;
     }
 
+    private enum PrinterVerdict
+    {
+        /// <summary>The printer answered and its counter had moved: the document is on paper.</summary>
+        Printed,
+
+        /// <summary>The printer answered and its counter had not moved: nothing was emitted.</summary>
+        NotPrinted,
+
+        /// <summary>The printer never answered within the window. Nothing can be concluded.</summary>
+        Unknown
+    }
+
+    /// <summary>
+    /// Asks the printer what it did, repeatedly, until it answers or the window closes.
+    /// <para>
+    /// The single rule that makes this safe: a verdict is drawn only from an answer, never from silence. A
+    /// printer serves one command at a time, so it cannot reply to a status query while it is emitting a
+    /// document — an answer therefore means the operation is over and its counter is a settled fact. Silence,
+    /// on the other hand, is indistinguishable between "still printing" and "gone", which is why it ends in
+    /// <see cref="PrinterVerdict.Unknown"/> and never in a reprint.
+    /// </para>
+    /// <para>
+    /// This is also what decouples the answer from the wait: the caller no longer has to sit through the full
+    /// command timeout before learning what happened, so the recovery can conclude while whoever asked for the
+    /// receipt is still listening.
+    /// </para>
+    /// </summary>
+    private async Task<(PrinterVerdict Verdict, LastEmittedDocStatus? Doc)> AwaitPrinterVerdictAsync(string receiptReference, DocPosition baseline)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(_configuration.RecoveryVerdictTimeoutMs);
+        var attempt = 0;
+
+        while (true)
+        {
+            attempt++;
+            var doc = await ReadLastEmittedDocStatusAsync(receiptReference);
+            if (IsComparable(doc))
+            {
+                if (IsDocAdvanced(doc, baseline))
+                {
+                    _logger.LogInformation("({receiptreference}) Printer answered on attempt {attempt}: Z#{z} Doc#{doc} — it did emit the document.",
+                        receiptReference, attempt, doc!.ZNumber, doc.DocNumber);
+                    return (PrinterVerdict.Printed, doc);
+                }
+
+                _logger.LogInformation("({receiptreference}) Printer answered on attempt {attempt}: still at Z#{z} Doc#{doc} — nothing was emitted.",
+                    receiptReference, attempt, doc!.ZNumber, doc.DocNumber);
+                return (PrinterVerdict.NotPrinted, doc);
+            }
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                _logger.LogError("({receiptreference}) Printer did not answer within {timeout}ms ({attempts} attempts) — state unknown.",
+                    receiptReference, _configuration.RecoveryVerdictTimeoutMs, attempt);
+                return (PrinterVerdict.Unknown, null);
+            }
+
+            _logger.LogWarning("({receiptreference}) Printer did not answer on attempt {attempt} — asking again.", receiptReference, attempt);
+            await Task.Delay(_configuration.RecoveryVerdictPollIntervalMs);
+        }
+    }
+
     private async Task<ReceiptResponse> TryRecoverFromNetworkErrorAsync(ReceiptRequest receiptRequest, ReceiptResponse receiptResponse, string xmlData)
     {
-        _logger.LogInformation("({receiptreference}) Querying last emitted document from printer...", receiptRequest.cbReceiptReference);
-        var docBeforeRetry = await ReadLastEmittedDocStatusAsync(receiptRequest.cbReceiptReference);
         var baseline = _lastDoc.Value;
-        _logger.LogDebug("({receiptreference}) Last emitted doc: Z#{z} Doc#{doc} amount={amount}cents, baseline: Z#{bz} Doc#{bd}",
-            receiptRequest.cbReceiptReference, docBeforeRetry?.ZNumber, docBeforeRetry?.DocNumber, docBeforeRetry?.TotalDocAmountCents, baseline?.ZNumber, baseline?.DocNumber);
-
-        if (baseline == null || !IsComparable(docBeforeRetry))
+        if (baseline == null)
         {
-            // Either end of the comparison is missing, so the printer state is unknown: the document may or
-            // may not have been printed. Retrying would risk a second fiscal document for the same sale, so
-            // report the error instead. Note that a failed status read is *not* the same as "no progress" —
-            // conflating the two is what would turn a lost answer into a duplicate.
-            _logger.LogError("({receiptreference}) Printer state unknown ({missing}) — refusing to reprint.",
-                receiptRequest.cbReceiptReference, baseline == null ? "no baseline" : "last emitted document unreadable");
+            // Nothing to compare the printer's counter against, so its state cannot be established and
+            // sending the receipt again would be a coin flip on a fiscal document.
+            _logger.LogError("({receiptreference}) No recovery baseline available — refusing to reprint.", receiptRequest.cbReceiptReference);
             receiptResponse.SetReceiptResponseErrored(UnknownDocumentStateError);
             return receiptResponse;
         }
 
-        if (IsDocAdvanced(docBeforeRetry, baseline))
-        {
-            _logger.LogInformation("({receiptreference}) Document found: Z#{zNum} Doc#{docNum} — printer already printed, skipping retry.",
-                receiptRequest.cbReceiptReference, docBeforeRetry!.ZNumber, docBeforeRetry.DocNumber);
-            return ApplyRecoveredDoc(receiptResponse, docBeforeRetry, GetLotteryCode(receiptRequest));
-        }
+        _logger.LogInformation("({receiptreference}) Asking the printer what it did (baseline Z#{z} Doc#{doc})...",
+            receiptRequest.cbReceiptReference, baseline.ZNumber, baseline.DocNumber);
+        var (verdict, doc) = await AwaitPrinterVerdictAsync(receiptRequest.cbReceiptReference, baseline);
 
-        return await RetryReceiptWithRecoveryAsync(receiptRequest, receiptResponse, xmlData, baseline);
+        switch (verdict)
+        {
+            case PrinterVerdict.Printed:
+                return ApplyRecoveredDoc(receiptResponse, doc!, receiptRequest);
+
+            case PrinterVerdict.NotPrinted:
+                return await RetryReceiptWithRecoveryAsync(receiptRequest, receiptResponse, xmlData, baseline);
+
+            default:
+                receiptResponse.SetReceiptResponseErrored(UnknownDocumentStateError);
+                return receiptResponse;
+        }
     }
 
     /// <param name="baseline">
@@ -490,7 +552,7 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
                         RTDocMoment = retryFiscalResponse.ReceiptDateTime,
                         RTDocType = "POSRECEIPT",
                         RTCodiceLotteria = GetLotteryCode(receiptRequest),
-                        RTCustomerID = "",
+                        RTCustomerID = GetCustomerTaxId(receiptRequest),
                     }).ToArray();
                     return receiptResponse;
                 }
@@ -501,20 +563,18 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             }
             catch (Exception e) when (e is TaskCanceledException || e is HttpRequestException)
             {
-                _logger.LogWarning("({receiptreference}) Network error on retry attempt {attempt}/{max} — checking if printer has printed...", receiptRequest.cbReceiptReference, attempt + 1, _configuration.MaxNetworkRetries);
-                var lastDoc = await ReadLastEmittedDocStatusAsync(receiptRequest.cbReceiptReference);
-                _logger.LogDebug("({receiptreference}) Current: Z#{z} Doc#{doc}, baseline: Z#{bz} Doc#{bd}", receiptRequest.cbReceiptReference, lastDoc?.ZNumber, lastDoc?.DocNumber, baseline.ZNumber, baseline.DocNumber);
+                _logger.LogWarning("({receiptreference}) Network error on retry attempt {attempt}/{max} — asking the printer what it did...", receiptRequest.cbReceiptReference, attempt + 1, _configuration.MaxNetworkRetries);
+                var (verdict, lastDoc) = await AwaitPrinterVerdictAsync(receiptRequest.cbReceiptReference, baseline);
 
-                if (IsDocAdvanced(lastDoc, baseline))
+                if (verdict == PrinterVerdict.Printed)
                 {
-                    _logger.LogInformation("({receiptreference}) Document found: Z#{zNum} Doc#{docNum} — printer already printed, skipping retry.", receiptRequest.cbReceiptReference, lastDoc!.ZNumber, lastDoc.DocNumber);
-                    return ApplyRecoveredDoc(receiptResponse, lastDoc, GetLotteryCode(receiptRequest));
+                    return ApplyRecoveredDoc(receiptResponse, lastDoc!, receiptRequest);
                 }
 
-                if (!IsComparable(lastDoc))
+                if (verdict == PrinterVerdict.Unknown)
                 {
-                    // The attempt we just made may have printed and we can no longer check. Another attempt
-                    // would be a coin flip on a fiscal document, so stop here.
+                    // The attempt we just made may have printed and the printer will not tell us. Another
+                    // attempt would be a coin flip on a fiscal document, so stop here.
                     _logger.LogError("({receiptreference}) Printer state unknown after attempt {attempt}/{max} — refusing to send the receipt again.", receiptRequest.cbReceiptReference, attempt + 1, _configuration.MaxNetworkRetries);
                     receiptResponse.SetReceiptResponseErrored(UnknownDocumentStateError);
                     return receiptResponse;
@@ -546,7 +606,12 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
              (doc.ZNumber == baseline.ZNumber && doc.DocNumber > baseline.DocNumber));
     }
 
-    private ReceiptResponse ApplyRecoveredDoc(ReceiptResponse receiptResponse, LastEmittedDocStatus doc, string lotteryCode)
+    /// <summary>
+    /// Signs the receipt with the document the printer reports, rather than with one we printed ourselves.
+    /// The lottery code and the customer tax identifier come from the request, exactly as on the happy path:
+    /// they describe what was sent to the printer, and the document on paper carries them.
+    /// </summary>
+    private ReceiptResponse ApplyRecoveredDoc(ReceiptResponse receiptResponse, LastEmittedDocStatus doc, ReceiptRequest receiptRequest)
     {
         receiptResponse.ftSignatures = SignatureFactory.CreateDocumentoCommercialeSignatures(new POSReceiptSignatureData
         {
@@ -555,8 +620,8 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
             RTDocNumber = doc.DocNumber,
             RTDocMoment = doc.DocumentDateTime,
             RTDocType = "POSRECEIPT",
-            RTCodiceLotteria = lotteryCode,
-            RTCustomerID = "",
+            RTCodiceLotteria = GetLotteryCode(receiptRequest),
+            RTCustomerID = GetCustomerTaxId(receiptRequest),
         }).ToArray();
         _lastDoc.Value = new DocPosition(doc.ZNumber, doc.DocNumber);
         return receiptResponse;

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCU.cs
@@ -633,7 +633,9 @@ public sealed class EpsonRTPrinterSCU : LegacySCU
         {
             var command = new PrinterCommand() { DirectIO = DirectIO.GetLastEmittedDocStatusCommand() };
             var content = SoapSerializer.Serialize(command);
-            var response = await _httpClient.SendCommandAsync(content);
+            // Deliberately impatient: an unanswered query has to cost a fraction of the recovery window, or
+            // the loop that is supposed to ask several times only ever gets to ask once.
+            var response = await _httpClient.SendCommandAsync(content, TimeSpan.FromMilliseconds(_configuration.RecoveryStatusQueryTimeoutMs));
             using var responseContent = await response.Content.ReadAsStreamAsync();
             var result = SoapSerializer.DeserializeToSoapEnvelope<PrinterCommandResponse>(responseContent);
             var rawData = result?.CommandResponse?.ResponseData;

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
@@ -50,6 +50,16 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter
         /// </summary>
         public int RecoveryVerdictPollIntervalMs { get; set; } = 3000;
 
+        /// <summary>
+        /// How long a single status query inside the recovery waits for the printer.
+        /// <para>
+        /// It has to be a small fraction of <see cref="RecoveryVerdictTimeoutMs"/>: the query is asked
+        /// repeatedly, and one that waited as long as a print command would burn the whole window on the
+        /// first attempt — which is exactly the attempt most likely to find the printer busy and silent.
+        /// </para>
+        /// </summary>
+        public int RecoveryStatusQueryTimeoutMs { get; set; } = 8000;
+
         public string? Password { get; set; }
 
         public string? AdditionalTrailerLines { get; set;}

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
@@ -42,6 +42,18 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter
         /// has to become responsive again in. Raising it makes the recovery more patient; lowering it makes
         /// an unresponsive printer fail faster, always as "state unknown", never as a reprint.
         /// </para>
+        /// <para>
+        /// It bounds when the last query may <em>start</em>, not when it ends, so the recovery can overrun it
+        /// by up to one <see cref="RecoveryStatusQueryTimeoutMs"/>. Budget for the sum when comparing against
+        /// the caller's own deadline.
+        /// </para>
+        /// <para>
+        /// This is the budget of a single pass. A <c>NotPrinted</c> verdict resends the receipt, and a further
+        /// network error starts another pass, so the worst case is roughly
+        /// <see cref="MaxNetworkRetries"/> times the whole wait-plus-window. Only the first pass is guaranteed
+        /// to land while the caller is still listening; lower <see cref="MaxNetworkRetries"/> where that
+        /// matters more than the extra attempts.
+        /// </para>
         /// </summary>
         public int RecoveryVerdictTimeoutMs { get; set; } = 40000;
 

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/EpsonRTPrinterSCUConfiguration.cs
@@ -24,6 +24,32 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter
         /// </summary>
         public int MaxNetworkRetries { get; set; } = 3;
 
+        /// <summary>
+        /// How long a command waits for the device when it is reached through a relay instead of a direct
+        /// connection. Ignored by the direct client, which uses <see cref="ClientTimeoutMs"/>.
+        /// <para>
+        /// It has to leave room, inside the timeout of whoever called the SCU, for this wait plus
+        /// <see cref="RecoveryVerdictTimeoutMs"/>: past that point the recovery still reaches the right
+        /// answer, but there is nobody left to hand it to.
+        /// </para>
+        /// </summary>
+        public int RelayCommandTimeoutMs { get; set; } = 45000;
+
+        /// <summary>
+        /// How long the network-error recovery keeps asking the printer what it did before giving up.
+        /// <para>
+        /// The recovery concludes only from an answer, never from silence, so this is the window the printer
+        /// has to become responsive again in. Raising it makes the recovery more patient; lowering it makes
+        /// an unresponsive printer fail faster, always as "state unknown", never as a reprint.
+        /// </para>
+        /// </summary>
+        public int RecoveryVerdictTimeoutMs { get; set; } = 40000;
+
+        /// <summary>
+        /// Pause between two status queries while waiting for the printer to become responsive again.
+        /// </summary>
+        public int RecoveryVerdictPollIntervalMs { get; set; } = 3000;
+
         public string? Password { get; set; }
 
         public string? AdditionalTrailerLines { get; set;}

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/IEpsonFpMateClient.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/IEpsonFpMateClient.cs
@@ -1,9 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Net.Http;
 
 namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter;
 
 public interface IEpsonFpMateClient
 {
-    Task<HttpResponseMessage> SendCommandAsync(string payload);
+    /// <param name="timeout">
+    /// How long to wait for this particular command, when it differs from the client's own. The recovery uses
+    /// it to keep its status queries short: it asks the printer the same question several times, so a query
+    /// that waited as long as a print command would spend the whole recovery window on a single attempt.
+    /// </param>
+    Task<HttpResponseMessage> SendCommandAsync(string payload, TimeSpan? timeout = null);
 }

--- a/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/LocalEpsonFpMateClient.cs
+++ b/scu-it/src/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter/LocalEpsonFpMateClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using System.Net.Http;
 using System;
 using System.Text;
@@ -24,9 +25,14 @@ public class LocalEpsonFpMateClient : IEpsonFpMateClient
         _commandUrl = $"cgi-bin/fpmate.cgi?timeout={configuration.ServerTimeoutMs}";
     }
 
-    public async Task<HttpResponseMessage> SendCommandAsync(string content)
+    public async Task<HttpResponseMessage> SendCommandAsync(string content, TimeSpan? timeout = null)
     {
-        var response = await _httpClient.PostAsync(_commandUrl, new StringContent(content, Encoding.UTF8, "application/xml"));
+        // A shorter deadline for this one command; the client's own still applies as the upper bound. Cancelling
+        // the token surfaces as TaskCanceledException, the same shape HttpClient raises when its timeout
+        // elapses, so callers cannot tell the two apart and do not need to.
+        using var cancellation = timeout.HasValue ? new CancellationTokenSource(timeout.Value) : null;
+        var response = await _httpClient.PostAsync(_commandUrl, new StringContent(content, Encoding.UTF8, "application/xml"),
+            cancellation?.Token ?? CancellationToken.None);
         if (!response.IsSuccessStatusCode)
         {
             throw new HttpRequestException($"An error occured while sending a request to the Epson device (StatusCode: {response.StatusCode}, Content: {await response.Content.ReadAsStringAsync()})");

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/DailyClosingRebootTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using fiskaltrust.ifPOS.v1;
@@ -23,7 +24,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
         {
             var xml = SoapSerializer.Serialize(zReportResult);
             var client = new Mock<IEpsonFpMateClient>();
-            client.Setup(c => c.SendCommandAsync(It.IsAny<string>()))
+            client.Setup(c => c.SendCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>()))
                   .ReturnsAsync(() => new HttpResponseMessage { Content = new StringContent(xml) });
             return client;
         }
@@ -36,7 +37,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 
-            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Once);
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p)), It.IsAny<TimeSpan?>()), Times.Once);
         }
 
         [Fact]
@@ -47,7 +48,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 
-            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Never);
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p)), It.IsAny<TimeSpan?>()), Times.Never);
         }
 
         [Fact]
@@ -58,7 +59,7 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
 
             await sut.ProcessReceiptAsync(new ProcessRequest { ReceiptRequest = DailyClosing(), ReceiptResponse = new ReceiptResponse() });
 
-            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p))), Times.Never);
+            client.Verify(c => c.SendCommandAsync(It.Is<string>(p => IsRebootCommand(p)), It.IsAny<TimeSpan?>()), Times.Never);
         }
     }
 }

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/RecoveryVerdictTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/RecoveryVerdictTests.cs
@@ -1,0 +1,264 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using fiskaltrust.ifPOS.v1;
+using fiskaltrust.ifPOS.v1.it;
+using fiskaltrust.Middleware.SCU.IT.Abstraction;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Models;
+using fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.Utilities;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
+{
+    /// <summary>
+    /// When a receipt command fails at transport level the printer may or may not have emitted the document,
+    /// and the SCU has to find out which before it decides whether sending the receipt again is safe. These
+    /// cover the three answers it can reach, and the rule that ties them together: a verdict is drawn from an
+    /// answer, never from silence.
+    /// </summary>
+    public class RecoveryVerdictTests
+    {
+        private const string LastEmittedDocCommand = "1387";
+
+        private static EpsonRTPrinterSCUConfiguration Configuration() => new()
+        {
+            // Production waits tens of seconds for the printer to speak again; the shape of the loop is what
+            // is under test, not its patience.
+            RecoveryVerdictTimeoutMs = 200,
+            RecoveryVerdictPollIntervalMs = 10,
+            RecoveryStatusQueryTimeoutMs = 10,
+            MaxNetworkRetries = 1
+        };
+
+        [Fact]
+        public async Task WhenTheCounterAdvanced_TheDocumentIsRecoveredWithoutReprinting()
+        {
+            var printer = Printer(
+                status: n => n == 1 ? LastEmittedDoc(zNumber: 320, docNumber: 3) : LastEmittedDoc(zNumber: 320, docNumber: 4),
+                receipt: _ => throw new TaskCanceledException());
+
+            var response = await ProcessAsync(printer);
+
+            response.HasFailed().Should().BeFalse();
+            SignatureData(response, SignatureTypesIT.RTZNumber).Should().Be("0320");
+            SignatureData(response, SignatureTypesIT.RTDocumentNumber).Should().Be("0004");
+            printer.ReceiptCommands.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WhenTheCounterDidNotMove_TheReceiptIsSentAgain()
+        {
+            // The printer answered, and a printer that answers is not in the middle of a document, so "still
+            // at 3" is settled: nothing was emitted and the resend cannot duplicate anything.
+            var printer = Printer(
+                status: _ => LastEmittedDoc(zNumber: 320, docNumber: 3),
+                receipt: n => n == 1 ? throw new TaskCanceledException() : PrintedReceipt(zNumber: 320, docNumber: 4));
+
+            var response = await ProcessAsync(printer);
+
+            response.HasFailed().Should().BeFalse();
+            SignatureData(response, SignatureTypesIT.RTDocumentNumber).Should().Be("0004");
+            printer.ReceiptCommands.Should().Be(2);
+        }
+
+        [Fact]
+        public async Task WhenThePrinterNeverAnswers_TheStateIsUnknownAndNothingIsReprinted()
+        {
+            var printer = Printer(
+                status: n => n == 1 ? LastEmittedDoc(zNumber: 320, docNumber: 3) : throw new TaskCanceledException(),
+                receipt: _ => throw new TaskCanceledException());
+
+            var response = await ProcessAsync(printer);
+
+            response.HasFailed().Should().BeTrue();
+            FailureData(response).Should().Be(EpsonRTPrinterSCU.UnknownDocumentStateError);
+            printer.ReceiptCommands.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WhenThePrinterIsSilentAtFirst_TheQuestionIsAskedAgain()
+        {
+            // A printer busy emitting the document cannot reply at all, so the first answers are silence.
+            // Concluding from the first one would report an unknown state for a document that is on paper.
+            var printer = Printer(
+                status: n => n switch
+                {
+                    1 => LastEmittedDoc(zNumber: 320, docNumber: 3),
+                    2 or 3 => throw new TaskCanceledException(),
+                    _ => LastEmittedDoc(zNumber: 320, docNumber: 4)
+                },
+                receipt: _ => throw new TaskCanceledException());
+
+            var response = await ProcessAsync(printer);
+
+            response.HasFailed().Should().BeFalse();
+            SignatureData(response, SignatureTypesIT.RTDocumentNumber).Should().Be("0004");
+            printer.StatusCommands.Should().BeGreaterThan(3);
+            printer.ReceiptCommands.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task WhenTheLastEmittedDocumentIsNotFiscal_TheStateIsUnknown()
+        {
+            // A non-fiscal document numbers on another counter, so it cannot be compared with the baseline.
+            var printer = Printer(
+                status: n => n == 1
+                    ? LastEmittedDoc(zNumber: 320, docNumber: 3)
+                    : LastEmittedDoc(zNumber: 320, docNumber: 1, fiscal: false),
+                receipt: _ => throw new TaskCanceledException());
+
+            var response = await ProcessAsync(printer);
+
+            response.HasFailed().Should().BeTrue();
+            FailureData(response).Should().Be(EpsonRTPrinterSCU.UnknownDocumentStateError);
+            printer.ReceiptCommands.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task ARecoveredDocumentKeepsTheCustomerTaxId()
+        {
+            // The document on paper carries it, because it was in the command that printed it.
+            var printer = Printer(
+                status: n => n == 1 ? LastEmittedDoc(zNumber: 320, docNumber: 3) : LastEmittedDoc(zNumber: 320, docNumber: 4),
+                receipt: _ => throw new TaskCanceledException());
+
+            var response = await ProcessAsync(printer, ReceiptExamples.GetTakeAway_Delivery_Card_WithCustomerIva());
+
+            SignatureData(response, SignatureTypesIT.RTCustomerID).Should().Be("01606720215");
+        }
+
+        [Fact]
+        public async Task TheStatusQueryCarriesItsOwnShortDeadline()
+        {
+            // The loop can only ask several times if an unanswered question is cheap. Inheriting the client's
+            // own wait would spend the whole window on the first attempt — the attempt most likely to find the
+            // printer busy. A mock answers instantly, so only the deadline itself can show this.
+            var configuration = Configuration();
+            var printer = Printer(
+                status: _ => LastEmittedDoc(zNumber: 320, docNumber: 3),
+                receipt: n => n == 1 ? throw new TaskCanceledException() : PrintedReceipt(zNumber: 320, docNumber: 4));
+
+            await ProcessAsync(printer, configuration: configuration);
+
+            var expected = TimeSpan.FromMilliseconds(configuration.RecoveryStatusQueryTimeoutMs);
+            printer.StatusTimeouts.Should().OnlyContain(t => t == expected);
+            printer.ReceiptTimeouts.Should().OnlyContain(t => t == null);
+        }
+
+        private static async Task<ReceiptResponse> ProcessAsync(
+            FakePrinter printer,
+            ReceiptRequest request = null,
+            EpsonRTPrinterSCUConfiguration configuration = null)
+        {
+            var sut = new EpsonRTPrinterSCU(NullLogger<EpsonRTPrinterSCU>.Instance, configuration ?? Configuration(), printer.Client);
+            var response = await sut.ProcessReceiptAsync(new ProcessRequest
+            {
+                ReceiptRequest = request ?? ReceiptExamples.GetTakeAway_Delivery_Cash(),
+                ReceiptResponse = new ReceiptResponse { ftSignatures = Array.Empty<SignaturItem>() }
+            });
+            return response.ReceiptResponse;
+        }
+
+        private static string SignatureData(ReceiptResponse response, SignatureTypesIT type) =>
+            response.ftSignatures.FirstOrDefault(x => x.ftSignatureType == (ITConstants.BASE_STATE | (long) type))?.Data;
+
+        private static string FailureData(ReceiptResponse response) => response.ftSignatures.Single().Data;
+
+        /// <summary>
+        /// Answers by the kind of command it is asked rather than by call order: the recovery asks for the
+        /// status as many times as it needs to, so a script keyed on a global index would break whenever the
+        /// loop changes its mind. Each callback receives its own 1-based attempt number.
+        /// </summary>
+        private static FakePrinter Printer(
+            Func<int, Task<HttpResponseMessage>> status,
+            Func<int, Task<HttpResponseMessage>> receipt) => new(status, receipt);
+
+        private sealed class FakePrinter
+        {
+            private readonly List<TimeSpan?> _statusTimeouts = new();
+            private readonly List<TimeSpan?> _receiptTimeouts = new();
+
+            public FakePrinter(Func<int, Task<HttpResponseMessage>> status, Func<int, Task<HttpResponseMessage>> receipt)
+            {
+                var mock = new Mock<IEpsonFpMateClient>();
+                mock.Setup(c => c.SendCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>()))
+                    .Returns((string payload, TimeSpan? timeout) =>
+                    {
+                        if (payload.Contains(LastEmittedDocCommand))
+                        {
+                            _statusTimeouts.Add(timeout);
+                            return status(_statusTimeouts.Count);
+                        }
+
+                        _receiptTimeouts.Add(timeout);
+                        return receipt(_receiptTimeouts.Count);
+                    });
+                Client = mock.Object;
+            }
+
+            public IEpsonFpMateClient Client { get; }
+
+            public int StatusCommands => _statusTimeouts.Count;
+
+            public int ReceiptCommands => _receiptTimeouts.Count;
+
+            public IEnumerable<TimeSpan?> StatusTimeouts => _statusTimeouts;
+
+            public IEnumerable<TimeSpan?> ReceiptTimeouts => _receiptTimeouts;
+        }
+
+        /// <summary>
+        /// Answer of the "last emitted document" DirectIO command, laid out as the device returns it: fixed
+        /// width fields, see <see cref="LastEmittedDocStatus"/>.
+        /// </summary>
+        private static Task<HttpResponseMessage> LastEmittedDoc(long zNumber, long docNumber, bool fiscal = true)
+        {
+            var responseData = new StringBuilder()
+                .Append("01")                                            // OP
+                .Append(7800.ToString("D9", CultureInfo.InvariantCulture)) // total doc amount
+                .Append("000000000")                                     // total vat amount
+                .Append("220826")                                        // date DDMMYY
+                .Append("132600")                                        // time HHMMSS
+                .Append(zNumber.ToString("D4", CultureInfo.InvariantCulture))
+                .Append(docNumber.ToString("D4", CultureInfo.InvariantCulture))
+                .Append("99MEY123456")                                   // printer serial number
+                .Append("0")                                             // lottery installed
+                .Append("        ")                                      // lottery code
+                .Append(fiscal ? "1" : "0")
+                .ToString();
+
+            return Soap(new PrinterCommandResponse
+            {
+                Success = true,
+                CommandResponse = new CommandResponse { PrinterStatus = "00000000", ResponseData = responseData }
+            });
+        }
+
+        private static Task<HttpResponseMessage> PrintedReceipt(long zNumber, long docNumber) =>
+            Soap(new PrinterReceiptResponse
+            {
+                Success = true,
+                Receipt = new PrinterReceiptReceiptInfo
+                {
+                    PrinterStatus = "00000000",
+                    FiscalReceiptNumber = docNumber.ToString(CultureInfo.InvariantCulture),
+                    ZRepNumber = zNumber.ToString(CultureInfo.InvariantCulture),
+                    FiscalReceiptDate = "22/8/2026",
+                    FiscalReceiptTime = "13:26:00",
+                    SerialNumber = "99MEY123456"
+                }
+            });
+
+        private static Task<HttpResponseMessage> Soap<T>(T body) where T : class =>
+            Task.FromResult(new HttpResponseMessage
+            {
+                Content = new StringContent(SoapSerializer.Serialize(body), Encoding.UTF8, "application/xml")
+            });
+    }
+}

--- a/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ReprintSerialNumberTests.cs
+++ b/scu-it/test/fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest/ReprintSerialNumberTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -63,8 +64,8 @@ namespace fiskaltrust.Middleware.SCU.IT.EpsonRTPrinter.UnitTest
             var generic = SoapSerializer.Serialize(new PrinterResponse { Success = true });
 
             var client = new Mock<IEpsonFpMateClient>();
-            client.Setup(c => c.SendCommandAsync(It.IsAny<string>()))
-                  .ReturnsAsync((string payload) =>
+            client.Setup(c => c.SendCommandAsync(It.IsAny<string>(), It.IsAny<TimeSpan?>()))
+                  .ReturnsAsync((string payload, TimeSpan? _) =>
                   {
                       sentPayloads.Add(payload);
                       var body = generic;


### PR DESCRIPTION
Follow-up to #763. That change made the network-error recovery reachable; this one makes its
answer arrive in time, and stops it concluding from silence.

## Why

The recovery asked the printer what it did exactly once, right after the command wait had elapsed,
and treated "no answer" the same as "the counter did not move". Two consequences.

**The answer arrived too late to be useful.** Its cost is the full command wait plus one status
round trip, because the status query only goes out once the wait is over. Whoever calls the SCU has
a deadline of its own, and when that deadline is shorter the recovery still reaches the right
conclusion — with nobody left to hand it to. A relayed deployment measured it end to end: the
caller gave up at 100s, the recovery concluded correctly at 124s, and the document it had found was
discarded. With those two numbers the recovery could never be observed, in any run.

**And a single unanswered query ended the matter.** A printer serves one command at a time, so
while it is emitting a document it cannot reply at all. The first status query is exactly when
silence is most likely, and silence does not mean the document was not printed.

## What changes

`AwaitPrinterVerdictAsync` replaces the one-shot check with a loop that concludes only from an
answer:

| reading | conclusion | action |
|---|---|---|
| answered, counter moved | the document is on paper | recover it, no reprint |
| answered, counter unmoved | answering means the printer is not mid-document, so this is settled | nothing was emitted; sending the receipt again is safe |
| never answered in the window | unknown | `epson-printer-network-error-unknown-document-state`, never a reprint |

That middle row is what makes a short wait safe rather than dangerous: without it, shortening the
wait would only raise the chance of misreading a busy printer.

**A status query now carries its own deadline.** The loop was meant to ask several times but could
only ever ask once: `ReadLastEmittedDocStatusAsync` goes through the same client as a print command
and inherited its wait, so a silent printer — the case the loop exists for — consumed the whole
window on the first attempt. With relayed defaults the arithmetic was plain: a 45s wait per query
against a 40s window is one attempt, never two. `SendCommandAsync` takes an optional per-command
timeout and the status query passes `RecoveryStatusQueryTimeoutMs` (8s), so four attempts fit in the
window instead of none. `LocalEpsonFpMateClient` applies it as a cancellation on that one request,
surfacing as `TaskCanceledException` exactly like its own timeout, so callers cannot tell the two
apart.

New configuration, all with defaults, all per device:

- `RecoveryVerdictTimeoutMs` (40s) — how long the recovery keeps asking
- `RecoveryVerdictPollIntervalMs` (3s) — pause between questions
- `RecoveryStatusQueryTimeoutMs` (8s) — deadline of one question
- `RelayCommandTimeoutMs` (45s) — how long a command waits when the device is reached through a
  relay rather than a direct connection; ignored by `LocalEpsonFpMateClient`, which keeps using
  `ClientTimeoutMs`

## Also here

Both recovery paths signed `RTCustomerID` as empty while the happy path uses `GetCustomerTaxId`. A
receipt for a customer who gave a codice fiscale or partita IVA lost it precisely when the document
had to be reconstructed — the document on paper carries the value, because it was in the command
that printed it.

## Note for review

The optional parameter on `SendCommandAsync` breaks Moq expression trees, so five existing setups in
`DailyClosingRebootTests` and `ReprintSerialNumberTests` needed updating. Mechanical, but they are
not otherwise part of this change.

## Testing

`dotnet build scu-it/fiskaltrust.Middleware.SCU.IT.sln` — 0 errors, all three TFMs
(`netstandard2.0`, `net461`, `net6.0`).

- `EpsonRTPrinter.UnitTest` 58 passed
- `SCU.IT.UnitTest` 100 passed

The consumer-side tests live with the downstream repository that builds this SCU from source and
drives the recovery through a simulated relay. They cover the loop waiting out a printer that is
silent while it prints, the three verdicts, and — asserting the deadline rather than the behaviour,
since a fake answers instantly and hides the cost of silence — that a status query is issued with
its own short timeout.
