### PR TITLE
fix(scu-de/fiskaly): handle new TSE states and log unknown ones

### DIFF
--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/FiskalySCU.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/FiskalySCU.cs
@@ -134,6 +134,17 @@ namespace fiskaltrust.Middleware.SCU.DE.FiskalyCertified
             return transactionState;
         }
 
+        private FiskalyTseState ParseFiskalyTseState(string state)
+        {
+            if (Enum.TryParse<FiskalyTseState>(state, true, out var parsed))
+            {
+                return parsed;
+            }
+
+            _logger.LogError("Received unknown TSE state '{State}' from fiskaly that cannot be mapped; defaulting to {DefaultState}.", state, FiskalyTseState.UNINITIALIZED);
+            return FiskalyTseState.UNINITIALIZED;
+        }
+
         public async Task<TseInfo> GetTseInfoAsync()
         {
             try
@@ -178,7 +189,7 @@ namespace fiskaltrust.Middleware.SCU.DE.FiskalyCertified
                     MaxLogMemorySize = long.MaxValue,
                     MaxNumberOfSignatures = long.MaxValue,
                     CurrentStartedTransactionNumbers = startedTransactions.Select(x => (ulong) x.Number).ToList(),
-                    CurrentState = ((FiskalyTseState) Enum.Parse(typeof(FiskalyTseState), tssResult.State, true)).ToTseStateEnum()
+                    CurrentState = ParseFiskalyTseState(tssResult.State).ToTseStateEnum()
                 };
             }
             catch (Exception ex)
@@ -204,7 +215,7 @@ namespace fiskaltrust.Middleware.SCU.DE.FiskalyCertified
 
                 var response = await _fiskalyApiProvider.PatchTseStateAsync(_configuration.TssId, tseStateDto);
 
-                return ((FiskalyTseState) Enum.Parse(typeof(FiskalyTseState), response.State, true)).ToTseState();
+                return ParseFiskalyTseState(response.State).ToTseState();
             }
             catch (Exception ex)
             {

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/Helpers/Extensions.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/Helpers/Extensions.cs
@@ -12,6 +12,9 @@ namespace fiskaltrust.Middleware.SCU.DE.FiskalyCertified.Helpers
             {
                 FiskalyTseState.INITIALIZED => new TseState { CurrentState = TseStates.Initialized },
                 FiskalyTseState.DISABLED => new TseState { CurrentState = TseStates.Terminated },
+                FiskalyTseState.DELETED => new TseState { CurrentState = TseStates.Terminated },
+                FiskalyTseState.DEFECTIVE => new TseState { CurrentState = TseStates.Terminated },
+                FiskalyTseState.EVICTED => new TseState { CurrentState = TseStates.Terminated },
                 _ => new TseState { CurrentState = TseStates.Uninitialized },
             };
         }
@@ -22,6 +25,9 @@ namespace fiskaltrust.Middleware.SCU.DE.FiskalyCertified.Helpers
             {
                 FiskalyTseState.INITIALIZED => TseStates.Initialized,
                 FiskalyTseState.DISABLED => TseStates.Terminated,
+                FiskalyTseState.DELETED => TseStates.Terminated,
+                FiskalyTseState.DEFECTIVE => TseStates.Terminated,
+                FiskalyTseState.EVICTED => TseStates.Terminated,
                 _ => TseStates.Uninitialized
             };
         }

--- a/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/Helpers/FiskalyTseState.cs
+++ b/scu-de/src/fiskaltrust.Middleware.SCU.DE.FiskalyCertified/Helpers/FiskalyTseState.cs
@@ -5,6 +5,9 @@
         CREATED = -1,
         UNINITIALIZED = 0,
         INITIALIZED = 1,
-        DISABLED = 2        
+        DISABLED = 2,
+        DELETED = 3,
+        DEFECTIVE = 4,
+        EVICTED = 5
     }
 }


### PR DESCRIPTION
Add the DELETED, DEFECTIVE and EVICTED states from sign-de-v2 to FiskalyTseState and map them to TseStates.Terminated (the only terminal value the ifPOS TseStates enum exposes over gRPC).

Parse the fiskaly state via Enum.TryParse in a ParseFiskalyTseState helper: an unrecognized state is now logged as an error and defaulted to UNINITIALIZED instead of throwing a parse exception that aborted the gRPC call.

<!-- Thank you for submitting a pull request to our repo! -->

<!-- If this is your first PR to one of fiskaltrust's repos, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [ ] You've read the [Contributor Guide](https://github.com/fiskaltrust/.github/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/fiskaltrust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [ ] You've included inline docs for your change, where applicable.
- [ ] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

{Summary of the changes}

## Description

{Detail}

Fixes #{issue number}
